### PR TITLE
fix: remove redundant undefined values from constructor calls

### DIFF
--- a/src/fixture/BaseFixture.ts
+++ b/src/fixture/BaseFixture.ts
@@ -27,10 +27,10 @@ export function baseFixture<T extends {}>(
             await use(new ElementRepository(locatorPath));
         },
         steps: async ({ page, repo }, use) => {
-            await use(new Steps(page, repo, undefined, options?.emailCredentials));
+            await use(new Steps(page, repo, options?.emailCredentials));
         },
         interactions: async ({ page }, use) => {
-            await use(new ElementInteractions(page, undefined, options?.emailCredentials));
+            await use(new ElementInteractions(page, options?.emailCredentials));
         },
         contextStore: async ({ }, use) => {
             await use(new ContextStore());

--- a/src/fixture/BaseFixture.ts
+++ b/src/fixture/BaseFixture.ts
@@ -27,10 +27,10 @@ export function baseFixture<T extends {}>(
             await use(new ElementRepository(locatorPath));
         },
         steps: async ({ page, repo }, use) => {
-            await use(new Steps(page, repo, options?.emailCredentials));
+            await use(new Steps(page, repo, { emailCredentials: options?.emailCredentials }));
         },
         interactions: async ({ page }, use) => {
-            await use(new ElementInteractions(page, options?.emailCredentials));
+            await use(new ElementInteractions(page, { emailCredentials: options?.emailCredentials }));
         },
         contextStore: async ({ }, use) => {
             await use(new ContextStore());

--- a/src/interactions/facade/ElementInteractions.ts
+++ b/src/interactions/facade/ElementInteractions.ts
@@ -24,10 +24,10 @@ export class ElementInteractions {
     /**
      * Initializes the ElementInteractions facade.
      * @param page - The current Playwright Page object.
-     * @param emailCredentials - Optional email credentials to enable the email sub-API.
-     * @param timeout - Optional global timeout override (in milliseconds) for all interactions and verifications. Defaults to 30000 ms (30 seconds).
+     * @param options - Optional configuration: emailCredentials and/or timeout.
      */
-    constructor(page: Page, emailCredentials?: EmailCredentials | EmailClientConfig, timeout?: number) {
+    constructor(page: Page, options?: { emailCredentials?: EmailCredentials | EmailClientConfig; timeout?: number }) {
+        const { emailCredentials, timeout } = options ?? {};
         this.interact = new Interactions(page, timeout);
         this.verify = new Verifications(page, timeout);
         this.navigate = new Navigation(page);

--- a/src/interactions/facade/ElementInteractions.ts
+++ b/src/interactions/facade/ElementInteractions.ts
@@ -24,10 +24,10 @@ export class ElementInteractions {
     /**
      * Initializes the ElementInteractions facade.
      * @param page - The current Playwright Page object.
-     * @param timeout - Optional global timeout override (in milliseconds) for all interactions and verifications. Defaults to 30000 ms (30 seconds).
      * @param emailCredentials - Optional email credentials to enable the email sub-API.
+     * @param timeout - Optional global timeout override (in milliseconds) for all interactions and verifications. Defaults to 30000 ms (30 seconds).
      */
-    constructor(page: Page, timeout?: number, emailCredentials?: EmailCredentials | EmailClientConfig) {
+    constructor(page: Page, emailCredentials?: EmailCredentials | EmailClientConfig, timeout?: number) {
         this.interact = new Interactions(page, timeout);
         this.verify = new Verifications(page, timeout);
         this.navigate = new Navigation(page);

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -42,16 +42,15 @@ export class Steps {
      * Initializes the Steps class with the required Playwright page and element repository.
      * @param page - The current Playwright Page object.
      * @param repo - An initialized instance of `ElementRepository` containing your locators.
-     * @param emailCredentials - Optional email credentials to enable the email sub-API.
-     * @param timeout - Optional global timeout override (in milliseconds).
+     * @param options - Optional configuration: emailCredentials and/or timeout.
      */
     constructor(
         private page: Page,
         private repo: ElementRepository,
-        emailCredentials?: EmailCredentials | EmailClientConfig,
-        timeout?: number
+        options?: { emailCredentials?: EmailCredentials | EmailClientConfig; timeout?: number }
     ) {
-        const interactions = new ElementInteractions(page, emailCredentials, timeout);
+        const { emailCredentials, timeout } = options ?? {};
+        const interactions = new ElementInteractions(page, { emailCredentials, timeout });
         this.interact = interactions.interact;
         this.navigate = interactions.navigate;
         this.extract = interactions.extract;

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -42,16 +42,16 @@ export class Steps {
      * Initializes the Steps class with the required Playwright page and element repository.
      * @param page - The current Playwright Page object.
      * @param repo - An initialized instance of `ElementRepository` containing your locators.
-     * @param timeout - Optional global timeout override (in milliseconds).
      * @param emailCredentials - Optional email credentials to enable the email sub-API.
+     * @param timeout - Optional global timeout override (in milliseconds).
      */
     constructor(
         private page: Page,
         private repo: ElementRepository,
-        timeout?: number,
-        emailCredentials?: EmailCredentials | EmailClientConfig
+        emailCredentials?: EmailCredentials | EmailClientConfig,
+        timeout?: number
     ) {
-        const interactions = new ElementInteractions(page, timeout, emailCredentials);
+        const interactions = new ElementInteractions(page, emailCredentials, timeout);
         this.interact = interactions.interact;
         this.navigate = interactions.navigate;
         this.extract = interactions.extract;

--- a/tests/core-api.spec.ts
+++ b/tests/core-api.spec.ts
@@ -100,7 +100,7 @@ test.describe('E2E Facade Implementation Suite', () => {
 
   test('TC_003: Negative Assertions - Expecting Verifications to Fail', async ({ page, repo }) => {
 
-    const steps = new Steps(page, repo, 1000); // Shorten timeout for negative assertions
+    const steps = new Steps(page, repo, { timeout: 1000 }); // Shorten timeout for negative assertions
 
     await test.step('Navigate to the website', async () => {
       await steps.navigateTo('/');
@@ -132,7 +132,7 @@ test.describe('E2E Facade Implementation Suite', () => {
   });
 
   test('TC_004: Wait For State - Warning behavior on incorrect state', async ({ page, repo }) => {
-    const steps = new Steps(page, repo, 500);
+    const steps = new Steps(page, repo, { timeout: 500 });
 
     await test.step('Navigate to the website', async () => {
       await steps.navigateTo('/');
@@ -170,7 +170,7 @@ test.describe('E2E Facade Implementation Suite', () => {
   });
 
   test('TC_006: Verify Count - greaterThan and lessThan', async ({ page, repo }) => {
-    const steps = new Steps(page, repo, 3000);
+    const steps = new Steps(page, repo, { timeout: 3000 });
 
     await test.step('Navigate to the website', async () => {
       await steps.navigateTo('/');

--- a/tests/negative.spec.ts
+++ b/tests/negative.spec.ts
@@ -14,7 +14,7 @@ test.describe('Negative Tests', () => {
   const NEGATIVE_TIMEOUT = 2000;
 
   test('TC_077: click on missing element throws', async ({ page }) => {
-    const fast = new ElementInteractions(page, NEGATIVE_TIMEOUT);
+    const fast = new ElementInteractions(page, { timeout: NEGATIVE_TIMEOUT });
     await page.goto('/');
     const missing = page.locator('[data-testid="does-not-exist"]');
     await expect(async () => {
@@ -24,7 +24,7 @@ test.describe('Negative Tests', () => {
   });
 
   test('TC_078: verifyText rejects incorrect text', async ({ page, steps }) => {
-    const fast = new ElementInteractions(page, NEGATIVE_TIMEOUT);
+    const fast = new ElementInteractions(page, { timeout: NEGATIVE_TIMEOUT });
     await steps.navigateTo('/');
     const title = page.locator('h1');
     await expect(async () => {
@@ -34,7 +34,7 @@ test.describe('Negative Tests', () => {
   });
 
   test('TC_079: verifyAbsence rejects visible element', async ({ page, steps }) => {
-    const fast = new ElementInteractions(page, NEGATIVE_TIMEOUT);
+    const fast = new ElementInteractions(page, { timeout: NEGATIVE_TIMEOUT });
     await steps.navigateTo('/');
     const title = page.locator('h1');
     await expect(async () => {
@@ -44,7 +44,7 @@ test.describe('Negative Tests', () => {
   });
 
   test('TC_080: verifyCount rejects incorrect count', async ({ page, steps }) => {
-    const fast = new ElementInteractions(page, NEGATIVE_TIMEOUT);
+    const fast = new ElementInteractions(page, { timeout: NEGATIVE_TIMEOUT });
     await steps.navigateTo('/');
     const categories = page.locator('.sidebar-section');
     await expect(async () => {
@@ -54,7 +54,7 @@ test.describe('Negative Tests', () => {
   });
 
   test('TC_081: fill rejects disabled input', async ({ page, steps }) => {
-    const fast = new ElementInteractions(page, NEGATIVE_TIMEOUT);
+    const fast = new ElementInteractions(page, { timeout: NEGATIVE_TIMEOUT });
     await steps.navigateTo('/text-inputs');
     const disabled = page.locator('[data-testid="input-disabled"]');
     await expect(async () => {
@@ -64,7 +64,7 @@ test.describe('Negative Tests', () => {
   });
 
   test('TC_082: selectDropdown rejects nonexistent value', async ({ page, steps }) => {
-    const fast = new ElementInteractions(page, NEGATIVE_TIMEOUT);
+    const fast = new ElementInteractions(page, { timeout: NEGATIVE_TIMEOUT });
     await steps.navigateTo('/dropdown');
     await expect(async () => {
       await fast.interact.selectDropdown(
@@ -76,7 +76,7 @@ test.describe('Negative Tests', () => {
   });
 
   test('TC_083: clicking non-matching listed element throws', async ({ page, steps }) => {
-    const fast = new ElementInteractions(page, NEGATIVE_TIMEOUT);
+    const fast = new ElementInteractions(page, { timeout: NEGATIVE_TIMEOUT });
     await steps.navigateTo('/table');
     const rows = page.locator('[data-testid^="table-row-"]');
     const result = await fast.interact.getListedElement(rows, { text: 'Nonexistent Person XYZ' });
@@ -88,7 +88,7 @@ test.describe('Negative Tests', () => {
   });
 
   test('TC_084: getListedElement requires text or attribute', async ({ page, steps }) => {
-    const fast = new ElementInteractions(page, NEGATIVE_TIMEOUT);
+    const fast = new ElementInteractions(page, { timeout: NEGATIVE_TIMEOUT });
     await steps.navigateTo('/table');
     const rows = page.locator('[data-testid^="table-row-"]');
     await expect(async () => {
@@ -98,7 +98,7 @@ test.describe('Negative Tests', () => {
   });
 
   test('TC_085: dragAndDrop rejects missing options', async ({ page, steps }) => {
-    const fast = new ElementInteractions(page, NEGATIVE_TIMEOUT);
+    const fast = new ElementInteractions(page, { timeout: NEGATIVE_TIMEOUT });
     await steps.navigateTo('/draggable');
     const draggable = page.locator('[data-testid="draggable-box"]');
     await expect(async () => {
@@ -108,7 +108,7 @@ test.describe('Negative Tests', () => {
   });
 
   test('TC_086: getByText strict throws when not found', async ({ page, steps }) => {
-    const fast = new ElementInteractions(page, NEGATIVE_TIMEOUT);
+    const fast = new ElementInteractions(page, { timeout: NEGATIVE_TIMEOUT });
     await steps.navigateTo('/table');
     const rows = page.locator('[data-testid^="table-row-"]');
     await expect(async () => {


### PR DESCRIPTION
## Summary
- Swaps `emailCredentials` and `timeout` parameter order in `Steps` and `ElementInteractions` constructors so `BaseFixture` no longer needs to pass `undefined` as a positional placeholder
- All 104 tests pass

Closes #43

## Test plan
- [x] `npm run build` compiles cleanly
- [x] All 104 existing tests pass