### PR TITLE
chore: bump email-client to 0.0.7 (security fixes)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civitas-cerebrum/element-interactions",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@civitas-cerebrum/context-store": "^0.0.2",
         "@civitas-cerebrum/element-repository": "^0.1.2",
-        "@civitas-cerebrum/email-client": "^0.0.6",
+        "@civitas-cerebrum/email-client": "^0.0.7",
         "debug": "^4.4.3",
         "dotenv": "^17.3.1"
       },
@@ -53,15 +53,15 @@
       }
     },
     "node_modules/@civitas-cerebrum/email-client": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/email-client/-/email-client-0.0.6.tgz",
-      "integrity": "sha512-2CbX6BbvBY3uAAn39n92NELZnNNELDu/m+jpVrciQhtIPJZnAJ4fKU0KLgy1Jcy6qjLsrZf9FxvzEvjxNwtPnw==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/email-client/-/email-client-0.0.7.tgz",
+      "integrity": "sha512-iKG41mLngqCehrQkME1iXDyVZiL8GP3e0H6bJEaIPAP3RdXpUiSdixXBxrtayy3E8cF9D/rVeFjjeLcySLF/mQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
-        "imapflow": "^1.2.16",
-        "mailparser": "^3.9.5",
-        "nodemailer": "^8.0.3"
+        "imapflow": "^1.3.1",
+        "mailparser": "^3.9.8",
+        "nodemailer": "^8.0.5"
       }
     },
     "node_modules/@civitas-cerebrum/test-coverage": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A robust, readable interaction and assertion Facade for Playwright. Abstract away boilerplate into semantic, English-like methods, making your test automation framework cleaner, easier to maintain, and accessible to non-developers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@civitas-cerebrum/context-store": "^0.0.2",
     "@civitas-cerebrum/element-repository": "^0.1.2",
-    "@civitas-cerebrum/email-client": "^0.0.6",
+    "@civitas-cerebrum/email-client": "^0.0.7",
     "debug": "^4.4.3",
     "dotenv": "^17.3.1"
   }


### PR DESCRIPTION
## Summary
- Bumps `@civitas-cerebrum/email-client` from `^0.0.6` to `^0.0.7`
- 0.0.7 resolves moderate severity vulnerabilities: nodemailer SMTP command injection (GHSA-vvjj-xcjg-gr5g, GHSA-c7w3-x93f-qmm8), imapflow, and mailparser

## Test plan
- [ ] `npm audit` returns 0 vulnerabilities