### PR TITLE
feat: add expectEqual and expectNotEqual for value comparison assertions      

### DIFF
--- a/src/interactions/Verification.ts
+++ b/src/interactions/Verification.ts
@@ -207,6 +207,28 @@ export class Verifications {
         ).toBe(expectedCount);
     }
 
+    /**                                                                                     
+       * Asserts that two extracted values are strictly equal.                                
+       * Use to compare two values already captured from the page (e.g. via getText).         
+       * @param actual - The actual value captured from the page.
+       * @param expected - The expected value to compare against.                             
+       */         
+      expectEqual(actual: string | null, expected: string): void {                            
+          expect(actual, `Expected values to be equal.\n  Actual:   "${actual}"\n  Expected:
+  "${expected}"`).toBe(expected);                                                             
+      }                                   
+                                                                                              
+      /**                                                                                     
+       * Asserts that two extracted values are not equal.                                     
+       * Use to confirm two captured page values differ from each other.                      
+       * @param actual - The actual value captured from the page.
+       * @param notExpected - The value that actual must differ from.
+       */                                                                                     
+      expectNotEqual(actual: string | null, notExpected: string): void {                      
+          expect(actual, `Expected values to differ, but both were:                           
+  "${actual}"`).not.toBe(notExpected);                                                        
+      }
+
     /**
     * Asserts the number of elements matching the locator based on the provided conditions.
     * @param target - A Playwright Locator or Element pointing to the target elements.

--- a/src/interactions/Verification.ts
+++ b/src/interactions/Verification.ts
@@ -207,42 +207,24 @@ export class Verifications {
         ).toBe(expectedCount);
     }
 
-    /**                                                                                     
-       * Asserts that two extracted values are strictly equal.                                
-       * Use to compare two values already captured from the page (e.g. via getText).         
-       * @param actual - The actual value captured from the page.
-       * @param expected - The expected value to compare against.                             
-       */         
-      expectEqual(actual: string | null, expected: string): void {                            
-          expect(actual, `Expected values to be equal.\n  Actual:   "${actual}"\n  Expected:
-  "${expected}"`).toBe(expected);                                                             
-      }                                   
-                                                                                              
-      /**                                                                                     
-       * Asserts that two extracted values are not equal.                                     
-       * Use to confirm two captured page values differ from each other.                      
-       * @param actual - The actual value captured from the page.
-       * @param notExpected - The value that actual must differ from.
-       */                                                                                     
-      expectNotEqual(actual: string | null, notExpected: string): void {                      
-          expect(actual, `Expected values to differ, but both were:                           
-  "${actual}"`).not.toBe(notExpected);                                                        
-      }
-
     /**
-     * Asserts that two extracted values are strictly equal.
-     * Use to compare two values already captured from the page (e.g. via getText).
-     * @param actual - The actual value captured from the page.
-     * @param expected - The expected value to compare against.
+     * Asserts that two values are strictly equal.
+     * Typically used to compare two values captured from the page via getText() or getInputValue().
+     * Both parameters accept null to support values that may not be present in the DOM.
+     *
+     * @param actual - The value captured from the page.
+     * @param expected - The value to compare against. Can be another captured value or a literal string.
      */
     expectEqual(actual: string | null, expected: string | null): void {
         expect(actual, `Expected values to be equal.\n  Actual:   "${actual}"\n  Expected: "${expected}"`).toBe(expected);
     }
 
     /**
-     * Asserts that two extracted values are not equal.
-     * Use to confirm two captured page values differ from each other.
-     * @param actual - The actual value captured from the page.
+     * Asserts that two values are not equal.
+     * Typically used to confirm that two values captured from the page differ from each other.
+     * Both parameters accept null to support values that may not be present in the DOM.
+     *
+     * @param actual - The value captured from the page.
      * @param notExpected - The value that actual must differ from.
      */
     expectNotEqual(actual: string | null, notExpected: string | null): void {

--- a/src/interactions/Verification.ts
+++ b/src/interactions/Verification.ts
@@ -235,7 +235,7 @@ export class Verifications {
      * @param actual - The actual value captured from the page.
      * @param expected - The expected value to compare against.
      */
-    expectEqual(actual: string | null, expected: string): void {
+    expectEqual(actual: string | null, expected: string | null): void {
         expect(actual, `Expected values to be equal.\n  Actual:   "${actual}"\n  Expected: "${expected}"`).toBe(expected);
     }
 
@@ -245,7 +245,7 @@ export class Verifications {
      * @param actual - The actual value captured from the page.
      * @param notExpected - The value that actual must differ from.
      */
-    expectNotEqual(actual: string | null, notExpected: string): void {
+    expectNotEqual(actual: string | null, notExpected: string | null): void {
         expect(actual, `Expected values to differ, but both were: "${actual}"`).not.toBe(notExpected);
     }
 

--- a/src/interactions/Verification.ts
+++ b/src/interactions/Verification.ts
@@ -230,6 +230,26 @@ export class Verifications {
       }
 
     /**
+     * Asserts that two extracted values are strictly equal.
+     * Use to compare two values already captured from the page (e.g. via getText).
+     * @param actual - The actual value captured from the page.
+     * @param expected - The expected value to compare against.
+     */
+    expectEqual(actual: string | null, expected: string): void {
+        expect(actual, `Expected values to be equal.\n  Actual:   "${actual}"\n  Expected: "${expected}"`).toBe(expected);
+    }
+
+    /**
+     * Asserts that two extracted values are not equal.
+     * Use to confirm two captured page values differ from each other.
+     * @param actual - The actual value captured from the page.
+     * @param notExpected - The value that actual must differ from.
+     */
+    expectNotEqual(actual: string | null, notExpected: string): void {
+        expect(actual, `Expected values to differ, but both were: "${actual}"`).not.toBe(notExpected);
+    }
+
+    /**
     * Asserts the number of elements matching the locator based on the provided conditions.
     * @param target - A Playwright Locator or Element pointing to the target elements.
     * @param options - Configuration specifying 'exact', 'greaterThan', or 'lessThan' logic.

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -793,7 +793,7 @@ export class Steps {
      * @param actual - The actual value captured from the page.
      * @param expected - The expected value.
      */
-    expectEqual(actual: string | null, expected: string): void {
+    expectEqual(actual: string | null, expected: string | null): void {
         log.verify('Expecting values to be equal: "%s" === "%s"', actual, expected);
         this.verify.expectEqual(actual, expected);
     }
@@ -804,7 +804,7 @@ export class Steps {
      * @param actual - The actual value captured from the page.
      * @param notExpected - The value that actual must differ from.
      */
-    expectNotEqual(actual: string | null, notExpected: string): void {
+    expectNotEqual(actual: string | null, notExpected: string | null): void {
         log.verify('Expecting values to differ: "%s" !== "%s"', actual, notExpected);
         this.verify.expectNotEqual(actual, notExpected);
     }

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -765,48 +765,21 @@ export class Steps {
         await this.verify.tabCount(expectedCount);
     }
 
-    /**                                                     
-       * Asserts that two extracted values are strictly equal.                                
-       * Use after getText() or getInputValue() to compare two captured values.               
-       * @param actual - The actual value captured from the page.
-       * @param expected - The expected value.                                                
-       */                                                         
-      expectEqual(actual: string | null, expected: string): void {                            
-          log.verify('Expecting values to be equal: "%s" === "%s"', actual, expected);
-          this.verify.expectEqual(actual, expected);                                          
-      }                                   
-                                                                                              
-      /**                                                                                     
-       * Asserts that two extracted values are not equal.                                     
-       * Use after getText() or getInputValue() to compare two captured values.               
-       * @param actual - The actual value captured from the page.    
-       * @param notExpected - The value that actual must differ from.
-       */                                                                                     
-      expectNotEqual(actual: string | null, notExpected: string): void {               
-          log.verify('Expecting values to differ: "%s" !== "%s"', actual, notExpected);       
-          this.verify.expectNotEqual(actual, notExpected);
-      }
-
     /**
-     * Asserts that two extracted values are strictly equal.
+     * Asserts that two extracted values are equal or not equal.
      * Use after getText() or getInputValue() to compare two captured values.
      * @param actual - The actual value captured from the page.
-     * @param expected - The expected value.
+     * @param expected - The value to compare against.
+     * @param options - Optional. Pass `{ not: true }` to assert the values differ instead.
      */
-    expectEqual(actual: string | null, expected: string | null): void {
-        log.verify('Expecting values to be equal: "%s" === "%s"', actual, expected);
-        this.verify.expectEqual(actual, expected);
-    }
-
-    /**
-     * Asserts that two extracted values are not equal.
-     * Use after getText() or getInputValue() to compare two captured values.
-     * @param actual - The actual value captured from the page.
-     * @param notExpected - The value that actual must differ from.
-     */
-    expectNotEqual(actual: string | null, notExpected: string | null): void {
-        log.verify('Expecting values to differ: "%s" !== "%s"', actual, notExpected);
-        this.verify.expectNotEqual(actual, notExpected);
+    expectValue(actual: string | null, expected: string | null, options?: { not?: boolean }): void {
+        if (options?.not) {
+            log.verify('Expecting values to differ: "%s" !== "%s"', actual, expected);
+            this.verify.expectNotEqual(actual, expected);
+        } else {
+            log.verify('Expecting values to be equal: "%s" === "%s"', actual, expected);
+            this.verify.expectEqual(actual, expected);
+        }
     }
 
     /**

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -772,7 +772,7 @@ export class Steps {
      * @param expected - The value to compare against.
      * @param options - Optional. Pass `{ not: true }` to assert the values differ instead.
      */
-    expectValue(actual: string | null, expected: string | null, options?: { not?: boolean }): void {
+    expect(actual: string | null, expected: string | null, options?: { not?: boolean }): void {
         if (options?.not) {
             log.verify('Expecting values to differ: "%s" !== "%s"', actual, expected);
             this.verify.expectNotEqual(actual, expected);

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -765,6 +765,28 @@ export class Steps {
         await this.verify.tabCount(expectedCount);
     }
 
+    /**                                                     
+       * Asserts that two extracted values are strictly equal.                                
+       * Use after getText() or getInputValue() to compare two captured values.               
+       * @param actual - The actual value captured from the page.
+       * @param expected - The expected value.                                                
+       */                                                         
+      expectEqual(actual: string | null, expected: string): void {                            
+          log.verify('Expecting values to be equal: "%s" === "%s"', actual, expected);
+          this.verify.expectEqual(actual, expected);                                          
+      }                                   
+                                                                                              
+      /**                                                                                     
+       * Asserts that two extracted values are not equal.                                     
+       * Use after getText() or getInputValue() to compare two captured values.               
+       * @param actual - The actual value captured from the page.    
+       * @param notExpected - The value that actual must differ from.
+       */                                                                                     
+      expectNotEqual(actual: string | null, notExpected: string): void {               
+          log.verify('Expecting values to differ: "%s" !== "%s"', actual, notExpected);       
+          this.verify.expectNotEqual(actual, notExpected);
+      }
+
     /**
      * Asserts that the text contents of all elements matching the locator appear
      * in the exact order specified.     * @param elementName - The element name as defined under the given page.

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -788,6 +788,28 @@ export class Steps {
       }
 
     /**
+     * Asserts that two extracted values are strictly equal.
+     * Use after getText() or getInputValue() to compare two captured values.
+     * @param actual - The actual value captured from the page.
+     * @param expected - The expected value.
+     */
+    expectEqual(actual: string | null, expected: string): void {
+        log.verify('Expecting values to be equal: "%s" === "%s"', actual, expected);
+        this.verify.expectEqual(actual, expected);
+    }
+
+    /**
+     * Asserts that two extracted values are not equal.
+     * Use after getText() or getInputValue() to compare two captured values.
+     * @param actual - The actual value captured from the page.
+     * @param notExpected - The value that actual must differ from.
+     */
+    expectNotEqual(actual: string | null, notExpected: string): void {
+        log.verify('Expecting values to differ: "%s" !== "%s"', actual, notExpected);
+        this.verify.expectNotEqual(actual, notExpected);
+    }
+
+    /**
      * Asserts that the text contents of all elements matching the locator appear
      * in the exact order specified.     * @param elementName - The element name as defined under the given page.
 

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -373,6 +373,17 @@ export class ElementAction {
         return await this.interactions.extract.screenshot(locator, options);
     }
 
+    /** Assert the element's text equals (or differs from) the expected value. Pass `{ not: true }` to assert inequality. */
+    async expectValue(expected: string | null, options?: { not?: boolean }): Promise<void> {
+        const element = await this.resolve();
+        const actual = await element.action(this.timeout).getText();
+        if (options?.not) {
+            this.interactions.verify.expectNotEqual(actual, expected);
+        } else {
+            this.interactions.verify.expectEqual(actual, expected);
+        }
+    }
+
     // -- Terminal actions: waiting --
 
     /** Wait for the element to reach the specified state. */

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -373,10 +373,42 @@ export class ElementAction {
         return await this.interactions.extract.screenshot(locator, options);
     }
 
-    /** Assert the element's text equals (or differs from) the expected value. Pass `{ not: true }` to assert inequality. */
-    async expectValue(expected: string | null, options?: { not?: boolean }): Promise<void> {
-        const element = await this.resolve();
-        const actual = await element.action(this.timeout).getText();
+    /**
+     * Extracts a value from the element and asserts it matches the expected value.
+     *
+     * By default, compares against the element's text content. Use options to extract
+     * a specific attribute, input value, or CSS property instead.
+     *
+     * @param expected - The value to compare against.
+     * @param options.not - When true, asserts the extracted value does NOT equal the expected value.
+     * @param options.attribute - Extract the given HTML attribute (e.g. `'href'`, `'data-id'`).
+     * @param options.inputValue - Extract the input field's value instead of its text content.
+     * @param options.cssProperty - Extract the computed CSS property (e.g. `'color'`, `'font-size'`).
+     *
+     * @example
+     * await steps.on('title', 'Page').expect('Welcome');
+     * await steps.on('link', 'Page').expect('/dashboard', { attribute: 'href' });
+     * await steps.on('input', 'Page').expect('hello@example.com', { inputValue: true });
+     * await steps.on('banner', 'Page').expect('rgb(255, 0, 0)', { cssProperty: 'color' });
+     * await steps.on('price', 'Page').expect('$0.00', { not: true });
+     */
+    async expect(
+        expected: string | null,
+        options?: { not?: boolean; attribute?: string; inputValue?: boolean; cssProperty?: string }
+    ): Promise<void> {
+        const locator = await this.resolveLocator();
+        let actual: string | null;
+
+        if (options?.attribute) {
+            actual = await this.interactions.extract.getAttribute(locator, options.attribute);
+        } else if (options?.inputValue) {
+            actual = await this.interactions.extract.getInputValue(locator);
+        } else if (options?.cssProperty) {
+            actual = await this.interactions.extract.getCssProperty(locator, options.cssProperty);
+        } else {
+            actual = await this.interactions.extract.getText(locator);
+        }
+
         if (options?.not) {
             this.interactions.verify.expectNotEqual(actual, expected);
         } else {

--- a/tests/negative.spec.ts
+++ b/tests/negative.spec.ts
@@ -116,4 +116,17 @@ test.describe('Negative Tests', () => {
     }).rejects.toThrow('not found');
     log('TC_086 Negative getByText strict — passed');
   });
+
+  test('TC_088: expectEqual throws on mismatch, expectNotEqual throws on match', async ({ steps }) => {
+
+    expect(() => {
+      steps.expectEqual('hello', 'world');
+    }).toThrow();
+
+    expect(() => {
+      steps.expectNotEqual('hello', 'hello');
+    }).toThrow();
+
+    log('TC_088 Negative expectEqual/expectNotEqual — passed');
+  });
 });

--- a/tests/negative.spec.ts
+++ b/tests/negative.spec.ts
@@ -117,16 +117,25 @@ test.describe('Negative Tests', () => {
     log('TC_086 Negative getByText strict — passed');
   });
 
-  test('TC_088: expectEqual throws on mismatch, expectNotEqual throws on match', async ({ steps }) => {
+  test('TC_088: expectValue throws on mismatch and throws on match when { not: true }', async ({ page, steps }) => {
+    const fast = new ElementInteractions(page, { timeout: NEGATIVE_TIMEOUT });
 
     expect(() => {
-      steps.expectEqual('hello', 'world');
+      steps.expectValue('hello', 'world');
     }).toThrow();
 
     expect(() => {
-      steps.expectNotEqual('hello', 'hello');
+      steps.expectValue('hello', 'hello', { not: true });
     }).toThrow();
 
-    log('TC_088 Negative expectEqual/expectNotEqual — passed');
+    expect(() => {
+      fast.verify.expectEqual('hello', 'world');
+    }).toThrow();
+
+    expect(() => {
+      fast.verify.expectNotEqual('hello', 'hello');
+    }).toThrow();
+
+    log('TC_088 Negative expectValue — passed');
   });
 });

--- a/tests/negative.spec.ts
+++ b/tests/negative.spec.ts
@@ -121,11 +121,11 @@ test.describe('Negative Tests', () => {
     const fast = new ElementInteractions(page, { timeout: NEGATIVE_TIMEOUT });
 
     expect(() => {
-      steps.expectValue('hello', 'world');
+      steps.expect('hello', 'world');
     }).toThrow();
 
     expect(() => {
-      steps.expectValue('hello', 'hello', { not: true });
+      steps.expect('hello', 'hello', { not: true });
     }).toThrow();
 
     expect(() => {

--- a/tests/steps-api.spec.ts
+++ b/tests/steps-api.spec.ts
@@ -252,27 +252,27 @@ test.describe('TC_047: Steps - isPresent boolean visibility check', () => {
   });
 });
 
-test.describe('TC_087: Steps - expectEqual and expectNotEqual', () => {
+test.describe('TC_087: Steps - expectValue', () => {
 
-  test('expectEqual passes for matching values, expectNotEqual passes for differing values', async ({ steps }) => {
+  test('expectValue passes for equal values and for differing values with { not: true }', async ({ steps }) => {
 
-    await test.step('expectEqual passes when values are identical', () => {
-      steps.expectEqual('$5.99', '$5.99');
+    await test.step('expectValue passes when values are identical', () => {
+      steps.expectValue('$5.99', '$5.99');
     });
 
-    await test.step('expectEqual passes when both values are null', () => {
-      steps.expectEqual(null, null);
+    await test.step('expectValue passes when both values are null', () => {
+      steps.expectValue(null, null);
     });
 
-    await test.step('expectNotEqual passes when values differ', () => {
-      steps.expectNotEqual('$5.99', '$9.99');
+    await test.step('expectValue with { not: true } passes when values differ', () => {
+      steps.expectValue('$5.99', '$9.99', { not: true });
     });
 
-    await test.step('expectNotEqual passes when actual is null and expected is a string', () => {
-      steps.expectNotEqual(null, 'some value');
+    await test.step('expectValue with { not: true } passes when actual is null and expected is a string', () => {
+      steps.expectValue(null, 'some value', { not: true });
     });
 
-    log('TC_087 expectEqual and expectNotEqual — passed');
+    log('TC_087 expectValue — passed');
   });
 });
 

--- a/tests/steps-api.spec.ts
+++ b/tests/steps-api.spec.ts
@@ -252,6 +252,30 @@ test.describe('TC_047: Steps - isPresent boolean visibility check', () => {
   });
 });
 
+test.describe('TC_087: Steps - expectEqual and expectNotEqual', () => {
+
+  test('expectEqual passes for matching values, expectNotEqual passes for differing values', async ({ steps }) => {
+
+    await test.step('expectEqual passes when values are identical', () => {
+      steps.expectEqual('$5.99', '$5.99');
+    });
+
+    await test.step('expectEqual passes when both values are null', () => {
+      steps.expectEqual(null, null);
+    });
+
+    await test.step('expectNotEqual passes when values differ', () => {
+      steps.expectNotEqual('$5.99', '$9.99');
+    });
+
+    await test.step('expectNotEqual passes when actual is null and expected is a string', () => {
+      steps.expectNotEqual(null, 'some value');
+    });
+
+    log('TC_087 expectEqual and expectNotEqual — passed');
+  });
+});
+
 test.describe('TC_048: Steps - navigateTo with query params', () => {
   test.use({ baseURL: 'https://civitas-cerebrum.github.io/vue-test-app/' });
 

--- a/tests/steps-api.spec.ts
+++ b/tests/steps-api.spec.ts
@@ -257,19 +257,19 @@ test.describe('TC_087: Steps - expectValue', () => {
   test('expectValue passes for equal values and for differing values with { not: true }', async ({ steps }) => {
 
     await test.step('expectValue passes when values are identical', () => {
-      steps.expectValue('$5.99', '$5.99');
+      steps.expect('$5.99', '$5.99');
     });
 
     await test.step('expectValue passes when both values are null', () => {
-      steps.expectValue(null, null);
+      steps.expect(null, null);
     });
 
     await test.step('expectValue with { not: true } passes when values differ', () => {
-      steps.expectValue('$5.99', '$9.99', { not: true });
+      steps.expect('$5.99', '$9.99', { not: true });
     });
 
     await test.step('expectValue with { not: true } passes when actual is null and expected is a string', () => {
-      steps.expectValue(null, 'some value', { not: true });
+      steps.expect(null, 'some value', { not: true });
     });
 
     log('TC_087 expectValue — passed');


### PR DESCRIPTION
## What                                 
  Adds two new synchronous assertion methods to `Steps` and `Verifications`:
  - `expectEqual(actual, expected)` — asserts two extracted values are strictly equal         
  - `expectNotEqual(actual, notExpected)` — asserts two extracted values differ      
                                                                                              
  ## Why                                      
  There is currently no built-in way to compare two values captured from the page             
  against each other (e.g. verifying that shipping costs differ between two countries).
  The only option was raw Playwright `expect()` in test files, which breaks the               
  abstraction the Steps API provides.                                          
                                                                                              
  ## Usage                                    
  ```ts                                                                                       
  const deShippingCost = await steps.getText('CheckoutPage', 'shippingCost');                 
  // ... change country ...                                                                   
  const caShippingCost = await steps.getText('CheckoutPage', 'shippingCost');                 
                                                                                              
  steps.expectNotEqual(deShippingCost, caShippingCost); // values must differ
  steps.expectEqual(deShippingCost, '$5.99');            // exact match                       
                                                                       
  Note: these are synchronous — no await needed. 