### PR TITLE
ci: fix 403 on forked PR coverage comments

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,64 @@
+name: 📝 Coverage Comment
+
+on:
+  workflow_run:
+    workflows: ['📊 API Coverage Report']
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Download coverage context
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-context
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 💬 Post or update coverage comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const prNumber = parseInt(fs.readFileSync('pr-number.txt', 'utf-8').trim(), 10);
+            const body = fs.readFileSync('report.md', 'utf-8');
+
+            if (!Number.isFinite(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid PR number in artifact: "${prNumber}"`);
+              return;
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existing = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes('API Coverage Report')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches: [ main ]
 
-permissions:
-  pull-requests: write
-
 jobs:
   coverage:
     runs-on: ubuntu-latest
@@ -27,52 +24,37 @@ jobs:
       - name: 🛠️ Build package
         run: npm run build
 
-      - name: 📊 Generate & Post Table Report
+      - name: 📊 Run API coverage
+        id: coverage
+        run: |
+          if npx test-coverage --format=github-plain; then
+            echo "failed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "failed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 📦 Package coverage context for comment workflow
         if: always()
-        uses: actions/github-script@v7
-        env:
-          REPORT_FORMAT: 'plain'
+        run: |
+          mkdir -p coverage-context
+          echo "${{ github.event.pull_request.number }}" > coverage-context/pr-number.txt
+          echo "${{ steps.coverage.outputs.failed }}" > coverage-context/coverage-failed.txt
+          if [ -f test-coverage-report.md ]; then
+            cp test-coverage-report.md coverage-context/report.md
+          else
+            echo "⚠️ Coverage report was not generated." > coverage-context/report.md
+          fi
+
+      - name: 📤 Upload coverage context
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const fs = require('fs');
-            const cp = require('child_process');
-            
-            const config = {
-              table: { flag: 'github-table', header: 'Table report'},
-              plain: { flag: 'github-plain', header: 'Plain report' }
-            }[process.env.REPORT_FORMAT];
+          name: coverage-context
+          path: coverage-context/
+          retention-days: 1
 
-            let coverageFailed = false;
-            try {
-              cp.execSync(`npx test-coverage --format=${config.flag}`, { stdio: 'inherit' });
-            } catch {
-              coverageFailed = true;
-            }
-            const body = fs.readFileSync('test-coverage-report.md', 'utf-8');
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            
-            const existing = comments.find(c => 
-              c.user.login === 'github-actions[bot]' && 
-              c.body.includes(config.header)
-            );
-
-            const commentPayload = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            };
-
-            if (existing) {
-              await github.rest.issues.updateComment({ ...commentPayload, comment_id: existing.id });
-            } else {
-              await github.rest.issues.createComment({ ...commentPayload, issue_number: context.issue.number });
-            }
-
-            if (coverageFailed) {
-              core.setFailed('API coverage is below the required threshold. See the PR comment for details.');
-            }
+      - name: ❌ Fail job if coverage below threshold
+        if: steps.coverage.outputs.failed == 'true'
+        run: |
+          echo "API coverage is below the required threshold. See the PR comment for details."
+          exit 1


### PR DESCRIPTION
## Summary

- Split the coverage workflow in two so PRs from forks can get coverage comments without the 403 failure seen on #71.
- `coverage.yml` now runs on `pull_request` (untrusted context): builds, runs coverage, uploads PR number + report as an artifact, fails the job if below threshold.
- New `coverage-comment.yml` runs on `workflow_run` (trusted, base-repo context) with `pull-requests: write`: downloads the artifact and posts/updates the comment.

## Why

`pull_request` workflows triggered by forked PRs receive a read-only `GITHUB_TOKEN` regardless of the `permissions:` block — GitHub caps forked-PR token capabilities as a security measure. The existing `coverage.yml` tried to POST a comment and got `HttpError: Resource not accessible by integration` (403). Every external contributor PR has been hitting this; #71 is the current example.

This follows GitHub's documented pattern for "commenting on forked PRs" — fork code never executes in the trusted job, and the trusted job is gated to `pull-requests: write` only.

## Effect

- First-time contributors still see the coverage comment (after the one-click maintainer approval GitHub already requires).
- The red/green coverage status check continues to land on the PR in real time.
- This PR itself won't post a comment (workflow_run triggers only fire for workflows on the default branch) — that's expected; once merged, every subsequent PR (including Maryna's after a rebase) gets the comment posted by the new workflow.

## Test plan

- [ ] CI on this PR passes (coverage job should succeed on main-branch code)
- [ ] After merge, trigger a rerun on #71; verify the coverage comment posts without 403
- [ ] Verify first-time contributor PR shows the coverage comment after workflow approval

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>