### PR TITLE
feat: chain-style expect matcher tree for Steps and fluent API

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Once loaded, Claude Code will:
 * **Force click with auto-retry** — Clicks automatically retry with a native DOM event when pointer interception is detected. No configuration needed.
 * **Non-throwing visibility probes** — `isVisible()` returns a boolean with configurable timeout and text filtering, never throws.
 * **Conditional chaining** — `steps.on('banner', 'Page').ifVisible().click()` silently skips when the element isn't visible.
+* **Chain-style expect matchers** — `steps.expect('price', 'Page').text.toMatch(/^\$/).count.toBe(1).attributes.get('data-status').toBe('ready')` chains as many verifications as you need on a single element; awaiting flushes the queue and short-circuits on the first failure. `.not` is one-shot, `.throws('msg')` overrides messages, `.timeout(ms)` scopes wait time per call.
+* **Predicate escape hatch** — `steps.expect('price', 'Page').toBe(el => parseFloat(el.text.slice(1)) > 10).throws('price must be above $10')` for assertions the matcher tree doesn't cover. Predicates run against a snapshot of plain element data — no async access required inside the lambda.
 * **Role + accessible name selectors** — `{ "role": "button", "name": "Log in" }` resolves via `page.getByRole()` with regex support.
 * **Regex text selectors** — `{ "text": { "regex": "pattern", "flags": "i" } }` for matching dynamic content.
 * **Iframe-scoped pages** — Elements inside iframes are resolved transparently via `frame` property on page definitions.
@@ -217,6 +219,43 @@ test('Fluent checkout flow', async ({ steps }) => {
   const hasDiscount = await steps.on('discountBadge', 'ProductDetailsPage').isVisible();
 });
 ```
+
+### Expect Matcher Tree
+
+A chain-style assertion API for the common case where you want to verify multiple things about a single element. Available at both `steps.expect(el, page)` (top-level) and as field getters on `steps.on(el, page)` (fluent). Each matcher call queues an assertion; awaiting flushes the queue and short-circuits on the first failure.
+
+```ts
+test('Submit button readiness', async ({ steps }) => {
+  // Chain multiple verifications in one expression
+  await steps.on('submit-button', 'CheckoutPage')
+    .text.toBe('Place Order')
+    .visible.toBeTrue()
+    .enabled.toBeTrue()
+    .attributes.get('data-variant').toBe('primary')
+    .not.attributes.toHaveKey('disabled')
+    .css('cursor').toMatch(/pointer|default|auto/);
+});
+
+test('Top-level matcher tree', async ({ steps }) => {
+  await steps.expect('price', 'ProductPage').text.toBe('$19.99');
+  await steps.expect('price', 'ProductPage').text.toMatch(/^\$\d+\.\d{2}$/);
+  await steps.expect('items', 'ListPage').count.toBeGreaterThan(3);
+  await steps.expect('error', 'Page').not.text.toContain('Crash');
+});
+
+test('Predicate escape hatch + custom message', async ({ steps }) => {
+  await steps.expect('price', 'ProductPage')
+    .toBe(el => parseFloat(el.text.slice(1)) > 10)
+    .throws('price must be above $10');
+});
+
+test('Per-call timeout override', async ({ steps }) => {
+  await steps.on('slow-widget', 'Page').timeout(5000).text.toBe('Ready');
+  await steps.on('items', 'Page').count.timeout(500).toBeGreaterThan(0);
+});
+```
+
+**Field matchers:** `text`, `value`, `count`, `visible`, `enabled`, `attributes`, `css(prop)`. Each carries `.not` for negation. Snapshot fields available in predicates: `text`, `value`, `attributes`, `visible`, `enabled`, `count`. See the [API reference](skills/element-interactions/references/api-reference.md#expect-matcher-tree) for the full surface.
 
 ### StepOptions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civitas-cerebrum/element-interactions",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civitas-cerebrum/element-interactions",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.7",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civitas-cerebrum/element-interactions",
-      "version": "0.2.7",
+      "version": "0.2.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,18 +27,19 @@
         "@playwright/test": ">=1.0.0"
       }
     },
-    "../element-repository": {
-      "name": "@civitas-cerebrum/element-repository",
+    "node_modules/@civitas-cerebrum/context-store": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/context-store/-/context-store-0.0.2.tgz",
+      "integrity": "sha512-v5j/L1+ngS1hge5mmNtsIqby9c6+LPivlGn/VqDAzg06wAtNQ1uEy4bSTI4zyNovEh03MeNEzSNcz6Ob+2N40A==",
+      "license": "MIT"
+    },
+    "node_modules/@civitas-cerebrum/element-repository": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/element-repository/-/element-repository-0.1.4.tgz",
+      "integrity": "sha512-iBZhE0iqGk1Yvdq0754a+2Hd3kADz0GYJPOKBa7BQ5oWLZNXdzIyOtIfgGMC2hizoOxkAHkDmvX8qp70aCSbXg==",
       "license": "MIT",
       "dependencies": {
         "@civitas-cerebrum/test-coverage": "^0.1.0"
-      },
-      "devDependencies": {
-        "@playwright/test": "^1.59.1",
-        "@types/node": "^20.0.0",
-        "typescript": "^5.0.0",
-        "webdriverio": "^9.27.0"
       },
       "peerDependencies": {
         "@playwright/test": "^1.58.2",
@@ -52,14 +53,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@civitas-cerebrum/context-store": {
-      "version": "0.0.2",
-      "license": "MIT"
-    },
-    "node_modules/@civitas-cerebrum/element-repository": {
-      "resolved": "../element-repository",
-      "link": true
     },
     "node_modules/@civitas-cerebrum/email-client": {
       "version": "0.0.7",
@@ -77,7 +70,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@civitas-cerebrum/test-coverage/-/test-coverage-0.1.0.tgz",
       "integrity": "sha512-6qPGRRFuF3JkGH2UMgnRNV5lh8F77+bSJgROAqYzFmq1Gq97DzlpjCt6ExUNzq8JUXh9uxA8w28rdQVGyq0K2w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "glob": "^10.4.5",
@@ -91,7 +83,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -115,7 +106,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -126,8 +116,9 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -153,6 +144,8 @@
     },
     "node_modules/@types/debug": {
       "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -161,11 +154,15 @@
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -173,13 +170,13 @@
       }
     },
     "node_modules/@zone-eu/mailsplit": {
-      "version": "5.4.8",
-      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz",
-      "integrity": "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA==",
+      "version": "5.4.9",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.9.tgz",
+      "integrity": "sha512-Qq7k6FzA5SmGf5HFPcr17gE7M+O1gttlmWn7tlGUlhGsbbjUaBL/4cEWIwExeCzqu5+kyZJ91mcBZbQ9zEwwYA==",
       "license": "(MIT OR EUPL-1.1+)",
       "dependencies": {
         "libbase64": "1.3.0",
-        "libmime": "5.3.7",
+        "libmime": "5.3.8",
         "libqp": "2.1.1"
       }
     },
@@ -187,7 +184,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -200,7 +196,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -222,14 +217,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -239,7 +232,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -252,14 +244,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -272,6 +262,8 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -350,9 +342,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -365,14 +357,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encoding-japanese": {
@@ -400,7 +390,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -433,7 +422,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -511,12 +499,12 @@
       }
     },
     "node_modules/imapflow": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.3.1.tgz",
-      "integrity": "sha512-DKwpMDR1EWXpV5T7adqQAccN7n684AX3poEZ5F3YoPlm2MyGeKavpRgNr3qptdEQaK+x5SlZ9jigT+cMs4geBA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.3.2.tgz",
+      "integrity": "sha512-lIhVpjAf+o/1SELeR34vqeoEjAyBOMd6xq2Vdx2E4XIRwDi5sfqfBqqr5YkTwp7G/Q3f5ACpU7/zuGklJeCj9Q==",
       "license": "MIT",
       "dependencies": {
-        "@zone-eu/mailsplit": "5.4.8",
+        "@zone-eu/mailsplit": "5.4.9",
         "encoding-japanese": "2.2.0",
         "iconv-lite": "0.7.2",
         "libbase64": "1.3.0",
@@ -525,18 +513,6 @@
         "nodemailer": "8.0.5",
         "pino": "10.3.1",
         "socks": "2.8.7"
-      }
-    },
-    "node_modules/imapflow/node_modules/libmime": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.8.tgz",
-      "integrity": "sha512-ZrCY+Q66mPvasAfjsQ/IgahzoBvfE1VdtGRpo1hwRB1oK3wJKxhKA3GOcd2a6j7AH5eMFccxK9fBoCpRZTf8ng==",
-      "license": "MIT",
-      "dependencies": {
-        "encoding-japanese": "2.2.0",
-        "iconv-lite": "0.7.2",
-        "libbase64": "1.3.0",
-        "libqp": "2.1.1"
       }
     },
     "node_modules/ip-address": {
@@ -552,7 +528,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -562,14 +537,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -597,27 +570,15 @@
       "license": "MIT"
     },
     "node_modules/libmime": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.7.tgz",
-      "integrity": "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.8.tgz",
+      "integrity": "sha512-ZrCY+Q66mPvasAfjsQ/IgahzoBvfE1VdtGRpo1hwRB1oK3wJKxhKA3GOcd2a6j7AH5eMFccxK9fBoCpRZTf8ng==",
       "license": "MIT",
       "dependencies": {
         "encoding-japanese": "2.2.0",
-        "iconv-lite": "0.6.3",
+        "iconv-lite": "0.7.2",
         "libbase64": "1.3.0",
         "libqp": "2.1.1"
-      }
-    },
-    "node_modules/libmime/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/libqp": {
@@ -639,7 +600,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/mailparser": {
@@ -660,14 +620,37 @@
         "tlds": "1.261.0"
       }
     },
-    "node_modules/mailparser/node_modules/libmime": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.8.tgz",
-      "integrity": "sha512-ZrCY+Q66mPvasAfjsQ/IgahzoBvfE1VdtGRpo1hwRB1oK3wJKxhKA3GOcd2a6j7AH5eMFccxK9fBoCpRZTf8ng==",
+    "node_modules/mailparser/node_modules/@zone-eu/mailsplit": {
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz",
+      "integrity": "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA==",
+      "license": "(MIT OR EUPL-1.1+)",
+      "dependencies": {
+        "libbase64": "1.3.0",
+        "libmime": "5.3.7",
+        "libqp": "2.1.1"
+      }
+    },
+    "node_modules/mailparser/node_modules/@zone-eu/mailsplit/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mailparser/node_modules/@zone-eu/mailsplit/node_modules/libmime": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.7.tgz",
+      "integrity": "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw==",
       "license": "MIT",
       "dependencies": {
         "encoding-japanese": "2.2.0",
-        "iconv-lite": "0.7.2",
+        "iconv-lite": "0.6.3",
         "libbase64": "1.3.0",
         "libqp": "2.1.1"
       }
@@ -676,7 +659,6 @@
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -692,7 +674,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -700,6 +681,8 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/nodemailer": {
@@ -724,7 +707,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parseley": {
@@ -744,7 +726,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -754,7 +735,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -817,7 +797,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -836,7 +816,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -916,7 +896,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -929,7 +908,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -939,7 +917,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -994,7 +971,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -1013,7 +989,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -1028,7 +1003,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1038,14 +1012,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -1058,7 +1030,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -1075,7 +1046,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -1088,7 +1058,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1117,7 +1086,8 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -1135,6 +1105,8 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1142,7 +1114,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -1158,7 +1129,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -1177,7 +1147,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -1195,7 +1164,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1205,7 +1173,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1221,14 +1188,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -1243,7 +1208,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@civitas-cerebrum/context-store": "^0.0.2",
-        "@civitas-cerebrum/element-repository": "file:../element-repository",
+        "@civitas-cerebrum/element-repository": "^0.1.4",
         "@civitas-cerebrum/email-client": "^0.0.7",
         "debug": "^4.4.3",
         "dotenv": "^17.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@civitas-cerebrum/context-store": "^0.0.2",
-        "@civitas-cerebrum/element-repository": "^0.1.3",
+        "@civitas-cerebrum/element-repository": "file:../element-repository",
         "@civitas-cerebrum/email-client": "^0.0.7",
         "debug": "^4.4.3",
         "dotenv": "^17.3.1"
@@ -27,17 +27,18 @@
         "@playwright/test": ">=1.0.0"
       }
     },
-    "node_modules/@civitas-cerebrum/context-store": {
-      "version": "0.0.2",
-      "license": "MIT"
-    },
-    "node_modules/@civitas-cerebrum/element-repository": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/element-repository/-/element-repository-0.1.3.tgz",
-      "integrity": "sha512-JX3m8BK+5mvoqbEA/YEX5dFr88fj3dVaR6pk741k8xRCTRbdt79aE6Fo1Y1A+siSCAbZLkN5hNgmH2HmSGHMDg==",
+    "../element-repository": {
+      "name": "@civitas-cerebrum/element-repository",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@civitas-cerebrum/test-coverage": "^0.0.9"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.59.1",
+        "@types/node": "^20.0.0",
+        "typescript": "^5.0.0",
+        "webdriverio": "^9.27.0"
       },
       "peerDependencies": {
         "@playwright/test": "^1.58.2",
@@ -51,6 +52,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@civitas-cerebrum/context-store": {
+      "version": "0.0.2",
+      "license": "MIT"
+    },
+    "node_modules/@civitas-cerebrum/element-repository": {
+      "resolved": "../element-repository",
+      "link": true
     },
     "node_modules/@civitas-cerebrum/email-client": {
       "version": "0.0.7",
@@ -68,6 +77,7 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@civitas-cerebrum/test-coverage/-/test-coverage-0.0.9.tgz",
       "integrity": "sha512-+fnvV+dD2SnxbYAjlN9sI3oyh/VIzgW/T8Y6i7Y+Vttyw9DdJ3wesN+bWkxVGF8F1GAf4LKg1BRGlw5vjy5agQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "glob": "^10.4.5",
@@ -81,6 +91,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -104,6 +115,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -114,9 +126,8 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -176,6 +187,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -188,6 +200,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -209,12 +222,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
       "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -224,6 +239,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -236,12 +252,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -347,12 +365,14 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encoding-japanese": {
@@ -380,6 +400,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -412,6 +433,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -530,6 +552,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -539,12 +562,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -614,6 +639,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/mailparser": {
@@ -650,6 +676,7 @@
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -665,6 +692,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -696,6 +724,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parseley": {
@@ -715,6 +744,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -724,6 +754,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -786,7 +817,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -805,7 +836,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -885,6 +916,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -897,6 +929,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -906,6 +939,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -960,6 +994,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -978,6 +1013,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -992,6 +1028,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1001,12 +1038,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -1019,6 +1058,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -1035,6 +1075,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -1047,6 +1088,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1075,6 +1117,7 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -1099,6 +1142,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -1114,6 +1158,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -1132,6 +1177,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -1149,6 +1195,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1158,6 +1205,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1173,12 +1221,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -1193,6 +1243,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "dotenv": "^17.3.1"
       },
       "devDependencies": {
-        "@civitas-cerebrum/test-coverage": "^0.0.9",
+        "@civitas-cerebrum/test-coverage": "^0.1.0",
         "@playwright/test": "^1.59.1",
         "@types/debug": "^4.1.13",
         "@types/node": "^20.0.0",
@@ -32,7 +32,7 @@
       "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
-        "@civitas-cerebrum/test-coverage": "^0.0.9"
+        "@civitas-cerebrum/test-coverage": "^0.1.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@civitas-cerebrum/test-coverage": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/test-coverage/-/test-coverage-0.0.9.tgz",
-      "integrity": "sha512-+fnvV+dD2SnxbYAjlN9sI3oyh/VIzgW/T8Y6i7Y+Vttyw9DdJ3wesN+bWkxVGF8F1GAf4LKg1BRGlw5vjy5agQ==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/test-coverage/-/test-coverage-0.1.0.tgz",
+      "integrity": "sha512-6qPGRRFuF3JkGH2UMgnRNV5lh8F77+bSJgROAqYzFmq1Gq97DzlpjCt6ExUNzq8JUXh9uxA8w28rdQVGyq0K2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civitas-cerebrum/element-interactions",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "license": "MIT",
   "dependencies": {
     "@civitas-cerebrum/context-store": "^0.0.2",
-    "@civitas-cerebrum/element-repository": "^0.1.3",
+    "@civitas-cerebrum/element-repository": "file:../element-repository",
     "@civitas-cerebrum/email-client": "^0.0.7",
     "debug": "^4.4.3",
     "dotenv": "^17.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "A robust, readable interaction and assertion Facade for Playwright. Abstract away boilerplate into semantic, English-like methods, making your test automation framework cleaner, easier to maintain, and accessible to non-developers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@playwright/test": ">=1.0.0"
   },
   "devDependencies": {
-    "@civitas-cerebrum/test-coverage": "^0.0.9",
+    "@civitas-cerebrum/test-coverage": "^0.1.0",
     "@playwright/test": "^1.59.1",
     "@types/debug": "^4.1.13",
     "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "license": "MIT",
   "dependencies": {
     "@civitas-cerebrum/context-store": "^0.0.2",
-    "@civitas-cerebrum/element-repository": "file:../element-repository",
+    "@civitas-cerebrum/element-repository": "^0.1.4",
     "@civitas-cerebrum/email-client": "^0.0.7",
     "debug": "^4.4.3",
     "dotenv": "^17.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.7",
+  "version": "0.2.5",
   "description": "A robust, readable interaction and assertion Facade for Playwright. Abstract away boilerplate into semantic, English-like methods, making your test automation framework cleaner, easier to maintain, and accessible to non-developers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "A robust, readable interaction and assertion Facade for Playwright. Abstract away boilerplate into semantic, English-like methods, making your test automation framework cleaner, easier to maintain, and accessible to non-developers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A robust, readable interaction and assertion Facade for Playwright. Abstract away boilerplate into semantic, English-like methods, making your test automation framework cleaner, easier to maintain, and accessible to non-developers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/skills/element-interactions/contributing.md
+++ b/skills/element-interactions/contributing.md
@@ -1,0 +1,311 @@
+---
+name: contributing-to-element-interactions
+description: >
+  Use this skill when contributing to the @civitas-cerebrum/element-interactions
+  package itself (adding/modifying source in src/, opening a PR, reviewing
+  contributions, debugging the package's own tests), or when a user of the
+  package runs into an API gap — they need a method/option that doesn't exist
+  yet, or they're tempted to drop down to raw Playwright Locator calls because
+  the framework doesn't expose what they need. This skill explains the
+  separation of concerns between element-repository and element-interactions,
+  the test coverage rules, the design principles that must be respected when
+  scaling the package, and the exact workflow for adding new APIs cleanly.
+  Triggers on phrases like: "contribute to element-interactions", "extend the
+  Steps API", "add a new method to ElementAction", "no equivalent in the
+  framework", "the package doesn't have", "missing API in element-interactions",
+  "how do I add to this framework", "drop down to raw Playwright", or any
+  request to modify files under /Users/Ay/GitHub/element-interactions/src/.
+---
+
+# Contributing to @civitas-cerebrum/element-interactions
+
+This package is a Playwright-on-top facade. Every API decision should preserve the framework's two non-negotiable promises:
+
+1. **No raw selectors in user test files.** Tests refer to elements by name (`'submitButton'`, `'CheckoutPage'`), never by CSS/XPath/locator strings.
+2. **No raw Playwright `Locator.*` calls in user test files.** Every interaction, verification, and extraction goes through `Steps`, `ElementAction`, or the matcher tree — never `await page.locator('x').click()` directly.
+
+If a contribution undermines either promise, it doesn't ship.
+
+---
+
+## 🏛️ Architecture: separation of concerns
+
+The framework is split across **two packages** for a reason. Understand the split before adding anything.
+
+### `@civitas-cerebrum/element-repository`
+
+Owns **element acquisition** and the platform-agnostic `Element` interface.
+
+- `Element` interface — cross-platform contract: `click`, `fill`, `getAttribute`, `getCssProperty`, `boundingBox`, `screenshot`, `dragTo`, `getTagName`, `exists`, `waitFor`, `count`, `first`, `nth`, `filter`, etc.
+- `WebElement` — Playwright-backed implementation. Also exposes web-only methods that have no platform equivalent: `getAllAttributes`, `selectOption`, `rightClick`.
+- `PlatformElement` — WebDriverIO/Appium-backed implementation. Implements every `Element` method.
+- `ElementRepository` — resolves names → `Element` instances using `page-repository.json`.
+- `ElementChain` — fluent action builder returned by `element.action()`.
+
+**Where things go in element-repository:**
+- A method on the **Element interface** if it has a meaningful implementation on both web and Appium.
+- A method on **WebElement only** if it's a pure DOM/HTML/mouse concept with no cross-platform equivalent (HTML `<select>`, mouse right-click, DOM attribute enumeration).
+- The `Element.click/fill/...` etc. include a presence-detection preamble (`ensureAttached(timeout)`) before the underlying driver call. New action methods MUST do the same.
+
+### `@civitas-cerebrum/element-interactions`
+
+Owns **interaction patterns, assertions, and the test-author-facing facade**.
+
+- `Steps` — top-level API used in tests (`steps.click('el', 'page')`, `steps.expect('el', 'page').text.toBe('x')`).
+- `ElementAction` — the fluent builder returned by `steps.on('el', 'page')`.
+- `Interactions`, `Verifications`, `Extractions` — internal helpers Steps delegates to.
+- `ExpectMatchers` — the chain-style matcher tree (`text.toBe`, `count.toBeGreaterThan`, `.not`, `.throws`, `.timeout`).
+- `BaseFixture` — Playwright fixture that wires everything up.
+
+**Where things go in element-interactions:**
+- New verification matchers belong on `ExpectMatchers.ts` — extending the chain tree.
+- New action helpers (e.g. composite workflows) belong on `Steps` and possibly `ElementAction`.
+- Anything that touches a Playwright `Locator` directly is a smell — the underlying capability probably belongs in `element-repository`'s `Element` interface first.
+
+---
+
+## 🚦 Decision tree: where does my new API go?
+
+When you want to add something, walk this in order:
+
+1. **Is it a raw element capability** (e.g. "read CSS variable", "drag with custom timing")?
+   → Add to `Element` interface in element-repository (and/or `WebElement` if web-only). Bump element-repository version. Then expose it through element-interactions.
+
+2. **Is it a verification/assertion** (e.g. "assert element has class X", "assert N items in this list")?
+   → Add a matcher to `ExpectMatchers.ts`. Either extend an existing matcher class (`TextMatcher`, `CountMatcher`, etc.) or add a new field matcher under `ExpectBuilder`.
+
+3. **Is it a composite workflow** (e.g. "fill an entire form from an object", "retry an action until verification passes")?
+   → Add a method to `Steps` in `CommonSteps.ts`. Use existing primitives (`steps.fill`, `steps.verifyText`, `steps.on(...)`) — never call `page.locator()` from inside the new method.
+
+4. **Is it a strategy selector or filter** (e.g. "select first matching by aria-label")?
+   → Add to `ElementAction` as a chainable strategy method. It should mutate `resolutionOptions` and return `this`.
+
+5. **Is it a fixture-level concern** (e.g. "auto-clean cookies between tests")?
+   → Extend `BaseFixture` or compose via `test.extend<T>()` — don't pollute Steps with global cross-cutting setup.
+
+If none of the above fit, **stop and discuss** before writing code. There's probably a deeper design issue.
+
+---
+
+## 🚨 Hard rules — don't violate
+
+### No raw `locator.*()` in element-interactions src/
+
+Every `locator.click()`, `locator.fill()`, `locator.evaluate()`, etc. that creeps into `src/` is a regression. If you need a primitive Playwright doesn't expose through `Element`, **add it to the Element interface in element-repository first**.
+
+The one exception: the `WebElement` constructor itself (`new WebElement(locator)`) is the boundary where a raw Locator legitimately enters. Everywhere else uses `Element`.
+
+To audit:
+
+```bash
+grep -rn "locator\.\(click\|fill\|textContent\|inputValue\|getAttribute\|count\|evaluate\|isVisible\|isEnabled\|waitFor\|scrollIntoView\|hover\|check\|uncheck\|selectOption\|dispatchEvent\|boundingBox\|press\|setInputFiles\|screenshot\|dragTo\|clear\)" src/ --include="*.ts" | grep -v "dist/"
+```
+
+Should return **zero results** in user-facing call sites. The only allowed calls are in `Element` implementations themselves (which live in element-repository).
+
+### Action methods presence-detect
+
+Every action on `Element` (`click`, `fill`, `dragTo`, ...) calls `ensureAttached(timeout)` first. When you add a new action to element-repository, follow the same pattern:
+
+```ts
+async myNewAction(options?: ElementActionOptions): Promise<Element> {
+    await this.ensureAttached(options?.timeout);  // <-- mandatory
+    await this.locator.myUnderlyingCall({ timeout: options?.timeout });
+    return this;
+}
+```
+
+This is what gives the framework predictable failure modes ("element never attached" instead of opaque driver errors) and makes Appium actions stable without depending on auto-wait.
+
+### Web-only methods only get cast at the call site, not aliased
+
+If element-interactions needs `selectOption` (which is `WebElement`-only), the call site does the narrowing:
+
+```ts
+const element = toElement(target) as WebElement;
+await element.selectOption(...);
+```
+
+Don't smuggle web-only methods onto `Element` with throw-stubs on `PlatformElement`. The cast makes the web-only intent explicit and keeps the cross-platform contract honest.
+
+### Maintain 100% API coverage
+
+The CI gate requires **100% API coverage** — every public method on `Steps`, `ElementAction`, `Verifications`, `Interactions`, `Extractions`, and the matcher classes must have at least one test that exercises it. The coverage tool (`@civitas-cerebrum/test-coverage`) introspects the public surface and fails the build if anything is uncovered.
+
+When you add a new method:
+1. Add a passing test for it (even a one-liner against the Vue test app).
+2. Run `npx test-coverage --format=github-plain` locally to confirm 100%.
+3. The CI coverage job will fail otherwise.
+
+### No mocked unit tests
+
+Every test in this repo runs against the **real Vue test app** at `https://civitas-cerebrum.github.io/vue-test-app/` via Playwright. We do **not** use mocked locators / mock Steps / spy fixtures.
+
+Reason: the framework is a Playwright facade. Mocked tests would only verify that we wire up Playwright "correctly" — but Playwright's actual behavior is what users care about. End-to-end tests catch real regressions; mocks don't.
+
+When adding tests, place them in `tests/` and use the existing `StepFixture` import pattern:
+
+```ts
+import { test, expect } from './fixture/StepFixture';
+
+test('new feature', async ({ steps }) => {
+    await steps.navigateTo('/');
+    // ... real interactions against the live app
+});
+```
+
+---
+
+## 📐 Design principles — respect when scaling
+
+### 1. Chain-style API for assertions
+
+The matcher tree (`steps.expect('price', 'Page').text.toBe('$10').count.toBe(1)`) is the canonical shape for verifications. New verifications should extend this tree, not add flat `verifyX` methods. The `verify*` family on `Steps` is legacy compatibility — keep it, don't grow it.
+
+### 2. One-shot semantics for `.not`
+
+`.not` flips the **next matcher only**, then resets. Don't introduce sticky-negation modes or multi-matcher negation scopes; it confuses reading.
+
+### 3. Builder-mutates, matcher-clones
+
+- Strategy selectors on `ElementAction` (`.first()`, `.nth()`, `.byText()`, `.timeout()`) **mutate** the builder and return `this`. Consistent with Playwright's locator semantics.
+- Matcher classes are immutable — `.timeout(ms)` and `.not` return new instances. Each matcher call is independent.
+
+### 4. Snapshot-based predicates
+
+The predicate escape hatch (`steps.expect(el, page).toBe(predicate)`) takes a function that receives an `ElementSnapshot` — plain data, no async access. This keeps custom assertions readable and predictable. **Do not** change the predicate to receive an `Element` directly — users should never need to `await` inside a predicate.
+
+### 5. Backwards compatibility on user-facing API
+
+`steps.click`, `steps.verifyText`, `steps.on(...).fill`, etc. — all the entry points users have written tests against — stay stable across versions. Internal refactors are fine; signature changes on user-facing methods need a major bump and a clear migration note.
+
+The current public `Target` type (`Locator | Element`) accepting raw Locators is held for backwards compatibility (see issue #74). Don't tighten this without coordination.
+
+### 6. Patch-version one-PR-one-bump rule
+
+Run `npm version patch` once per PR (at the first commit). Do not bump on every follow-up commit on the same branch — the `publish.yml` workflow publishes whatever version is in `package.json` at merge time.
+
+---
+
+## 🧰 Workflow: adding a new API
+
+### A. Adding to element-repository (the underlying capability)
+
+```bash
+cd /path/to/element-repository
+git checkout main && git pull
+git checkout -b feat/your-feature
+
+# 1. Update src/types/Element.ts (interface)
+# 2. Implement in src/types/WebElement.ts
+# 3. Implement in src/types/PlatformElement.ts (or stub if web-only — but prefer cross-platform)
+# 4. Add live test in tests/live-element-location.spec.ts using the Vue test app
+# 5. Verify
+npm run build
+npx playwright test tests/live-element-location.spec.ts
+npx test-coverage --format=github-plain     # must show 100%
+
+# 6. Bump version
+npm version patch --no-git-tag-version
+
+# 7. Commit + push + open PR
+git add -A
+git commit -m "feat: add Element.<method> for <use case>"
+git push -u origin feat/your-feature
+gh pr create --base main --title "feat: ..." --body "..."
+```
+
+After this PR merges, element-repository auto-publishes to npm. Then update element-interactions to use the new version.
+
+### B. Adding to element-interactions (the user-facing API)
+
+```bash
+cd /path/to/element-interactions
+git checkout main && git pull
+git checkout -b feat/your-feature
+
+# 1. Add the API to the right layer:
+#    - New matcher → src/steps/ExpectMatchers.ts
+#    - New step / composite → src/steps/CommonSteps.ts
+#    - New strategy → src/steps/ElementAction.ts
+#    - Internal helper → src/interactions/{Interaction,Verification,Extraction}.ts
+
+# 2. Add tests in tests/ — must hit the real Vue test app
+# 3. Run full suite + coverage
+npm run build
+npm run test                                 # all tests must pass
+npx test-coverage --format=github-plain     # must show 100%
+
+# 4. Update docs (in this order):
+#    - skills/element-interactions/references/api-reference.md (the canonical source)
+#    - skills/element-interactions/SKILL.md (only if the change affects the workflow stages)
+#    - README.md (only for headline-worthy features)
+
+# 5. Bump version once
+npm version patch --no-git-tag-version
+
+# 6. Commit + push + open PR
+git add -A
+git commit -m "feat: add steps.<method> for <use case>"
+git push -u origin feat/your-feature
+gh pr create --base main --title "feat: ..." --body "..."
+```
+
+### C. Cross-package change (new Element capability + matching Steps API)
+
+Open both PRs in parallel. Element-repository PR ships first; element-interactions PR depends on it:
+
+1. Push element-repository PR.
+2. Locally, point element-interactions at `file:../element-repository` so you can develop both sides simultaneously.
+3. Once element-repository PR merges and the new version publishes, flip element-interactions back to `^X.Y.Z`.
+4. Push the version-flip commit; CI goes green; merge.
+
+---
+
+## 🧯 When a user runs into an API gap
+
+If you're using the package and want to write something like:
+
+```ts
+// ❌ Don't do this — drops out of the framework
+const locator = page.locator('button.submit');
+const cssVar = await locator.evaluate(el => getComputedStyle(el).getPropertyValue('--brand-color'));
+```
+
+Stop. The right path:
+
+1. **Check if the framework already supports it.** Read `skills/element-interactions/references/api-reference.md` end-to-end. The matcher tree, predicate form, `.css(prop)`, and `interactions` raw escape hatch cover most needs.
+
+2. **If it's truly missing:**
+   - Open an issue on `civitas-cerebrum/element-interactions` describing the use case.
+   - If it's a generic element capability (CSS variable, custom property, drag with timing), it belongs in element-repository's `Element` interface first.
+   - If it's an assertion shape, it belongs on the matcher tree.
+
+3. **If you need to ship NOW**, the documented escape hatch is `interactions.interact.*`, `interactions.verify.*`, `interactions.extract.*` — they accept either `Locator` or `Element`. Use these for the one-off, but file the issue so the proper API can land.
+
+4. **Never** check raw `locator.*()` calls into a test file or into the element-interactions src/. The audit grep above will catch it in code review.
+
+---
+
+## 📋 PR checklist
+
+Before opening a PR on element-interactions:
+
+- [ ] Tests pass: `npm run test` shows all tests passing
+- [ ] Coverage 100%: `npx test-coverage --format=github-plain` shows ✅
+- [ ] No raw Playwright leak: `grep -rn "locator\.\(click\|fill\|...\)" src/ --include="*.ts"` returns zero matches in non-`Element`-impl code
+- [ ] Version bumped exactly once (`npm version patch` at first commit, not at every commit)
+- [ ] API reference updated (`skills/element-interactions/references/api-reference.md`) for any new public surface
+- [ ] README updated only if the change is headline-worthy (new entry point, new feature category)
+- [ ] If adding a new method, it has a JSDoc block on the public-facing class
+
+If you're adding to element-repository first:
+
+- [ ] New method on `Element` interface (cross-platform) OR `WebElement` only (with rationale comment)
+- [ ] `WebElement` implementation included
+- [ ] `PlatformElement` implementation included if cross-platform
+- [ ] Action methods include the `ensureAttached(timeout)` preamble
+- [ ] Live test added in `tests/live-element-location.spec.ts`
+- [ ] Coverage 100% (`npx test-coverage`)
+- [ ] Patch version bumped
+- [ ] README updated if adding to the public surface

--- a/skills/element-interactions/references/api-reference.md
+++ b/skills/element-interactions/references/api-reference.md
@@ -275,6 +275,33 @@ await steps.on('cards', 'ListPage').random().text.toMatch(/\$\d+/);
 await steps.on('banner', 'HomePage').ifVisible().text.toContain('Promo');
 ```
 
+**Per-call timeout override — `.timeout(ms)`:**
+
+Composes anywhere in the chain. Useful for slow widgets or fast-failing assertions without changing the fixture-level default.
+
+```ts
+// On ElementAction (fluent)
+await steps.on('slowWidget', 'Page').timeout(5000).text.toBe('Ready');
+
+// On ExpectBuilder (top-level)
+await steps.expect('slowWidget', 'Page').timeout(5000).text.toBe('Ready');
+
+// On a specific field matcher
+await steps.expect('el', 'Page').text.timeout(5000).toBe('x');
+await steps.expect('el', 'Page').count.timeout(2000).toBeGreaterThan(3);
+await steps.expect('el', 'Page').attributes.get('href').timeout(1000).toBe('/x');
+
+// On the predicate chain — order independent with .throws()
+await steps.expect('price', 'Page')
+  .toBe(el => parseFloat(el.text.slice(1)) > 10)
+  .timeout(2000)
+  .throws('price must be above $10');
+
+// Composes with .not and strategy selectors
+await steps.on('item', 'Page').nth(2).timeout(500).text.toBe('x');
+await steps.expect('error', 'Page').not.timeout(1000).visible.toBeTrue();
+```
+
 **Negation with `.not`:**
 
 ```ts

--- a/skills/element-interactions/references/api-reference.md
+++ b/skills/element-interactions/references/api-reference.md
@@ -286,24 +286,23 @@ await steps.on('link', 'Page').attributes.not.toHaveKey('disabled');
 await steps.on('link', 'Page').attributes.get('href').not.toBe('/wrong');
 ```
 
-**Predicate escape hatch** — for assertions the matcher tree doesn't cover (multi-field combinations, parsed numeric thresholds, JSON in `data-*`):
+**Predicate escape hatch** — for assertions the matcher tree doesn't cover (multi-field combinations, parsed numeric thresholds, JSON in `data-*`). Use `.toBe(predicate)` — returns a chainable, awaitable assertion. Add `.throws(message)` for a custom failure message.
 
 ```ts
-// Top-level — pass predicate as third argument
-await steps.expect(
-  'price', 'ProductPage',
-  el => parseFloat(el.text.slice(1)) > 10,
-  'price must be above $10',
-);
+// Top-level
+await steps.expect('price', 'ProductPage').toBe(el => parseFloat(el.text.slice(1)) > 10);
+await steps.expect('price', 'ProductPage')
+  .toBe(el => parseFloat(el.text.slice(1)) > 10)
+  .throws('price must be above $10');
 
-// Fluent — .expect(predicate, message?) on ElementAction
-await steps.on('price', 'ProductPage').expect(
-  el => parseFloat(el.text.slice(1)) > 10,
-);
-
-await steps.on('card', 'DashboardPage').expect(
+// Fluent
+await steps.on('price', 'ProductPage').toBe(el => parseFloat(el.text.slice(1)) > 10);
+await steps.on('card', 'DashboardPage').toBe(
   el => el.visible && el.attributes['data-status'] === 'ready' && el.count > 0,
 );
+
+// Negated — predicate's expected outcome is flipped
+await steps.on('error', 'Page').not.toBe(el => el.visible);
 ```
 
 Predicates receive an `ElementSnapshot` — plain data, no async methods:
@@ -322,7 +321,7 @@ interface ElementSnapshot {
 On predicate timeout, the error message includes the full snapshot pretty-printed so you can see exactly why the assertion failed:
 
 ```
-expect() predicate failed on ProductPage.price after 30000ms
+expect().toBe(predicate) failed on ProductPage.price after 30000ms
   snapshot at timeout:
     {
       "text": "12.99 USD",
@@ -333,6 +332,8 @@ expect() predicate failed on ProductPage.price after 30000ms
       "count": 1
     }
 ```
+
+When `.throws(message)` is chained, that message replaces the default header while the snapshot is still appended — so you get both the domain-specific explanation and the raw state.
 
 ### Visibility Probe
 

--- a/skills/element-interactions/references/api-reference.md
+++ b/skills/element-interactions/references/api-reference.md
@@ -275,6 +275,40 @@ await steps.on('cards', 'ListPage').random().text.toMatch(/\$\d+/);
 await steps.on('banner', 'HomePage').ifVisible().text.toContain('Promo');
 ```
 
+**Chained multi-verification on `steps.on()`:**
+
+Every matcher call enqueues an assertion onto the builder and returns it, so multiple verifications on a single element compose in one expression. `await` executes the queue sequentially; the first failure short-circuits the rest.
+
+```ts
+// Chain 8+ verifications on one element in a single expression
+await steps.on('primaryButton', 'ButtonsPage')
+  .text.toBe('Primary')
+  .visible.toBeTrue()
+  .enabled.toBeTrue()
+  .count.toBe(1)
+  .attributes.get('data-testid').toBe('btn-primary')
+  .attributes.toHaveKey('data-testid')
+  .not.attributes.toHaveKey('disabled')
+  .css('cursor').toMatch(/pointer|default|auto/)
+  .toBe(el => el.visible && el.enabled && el.text === 'Primary');
+
+// .not is one-shot — applies to the next matcher only
+await steps.on('btn', 'Page')
+  .not.text.toBe('Wrong')    // negated
+  .count.toBe(1);            // NOT negated
+
+// .throws(msg) attaches to the most recently queued assertion
+await steps.on('btn', 'Page')
+  .text.toBe('Primary').throws('primary button must have correct label')
+  .visible.toBeTrue();
+
+// .timeout(ms) mixes long and short per-matcher in one chain
+await steps.on('slowThenFast', 'Page')
+  .text.timeout(5000).toBe('Ready')      // this one may take up to 5s
+  .visible.timeout(100).toBeTrue()       // this one must be visible within 100ms
+  .count.timeout(500).toBe(1);
+```
+
 **Per-call timeout override — `.timeout(ms)`:**
 
 Composes anywhere in the chain. Useful for slow widgets or fast-failing assertions without changing the fixture-level default.

--- a/skills/element-interactions/references/api-reference.md
+++ b/skills/element-interactions/references/api-reference.md
@@ -5,7 +5,7 @@ The following sections document the full API available for writing tests in Stag
 ## Table of Contents
 - [Setup — Fixtures](#setup--fixtures)
 - [Locator Format](#locator-format) (css, xpath, id, text, role+name, regex, iframe)
-- [Steps API](#steps-api) (navigation, interaction, extraction, verification, visibility, listed elements, waiting, composite, screenshot)
+- [Steps API](#steps-api) (navigation, interaction, extraction, verification, expect matcher tree, visibility, listed elements, waiting, composite, screenshot)
 - [Fluent API — steps.on()](#fluent-api--stepson) (strategy selectors, ifVisible, terminal actions, chaining)
 - [Accessing the Repository Directly](#accessing-the-repository-directly)
 - [Raw Interactions API](#raw-interactions-api)
@@ -230,6 +230,108 @@ await steps.verifyTabCount(2);
 await steps.verifyOrder('listItems', 'PageName', ['First', 'Second', 'Third']);
 await steps.verifyListOrder('listItems', 'PageName', 'asc');               // or 'desc'
 await steps.verifyCssProperty('elementName', 'PageName', 'color', 'rgb(255, 0, 0)');
+```
+
+### Expect Matcher Tree
+
+A chain-style assertion API available at both the top level (`steps.expect(el, page)`) and the fluent builder (`steps.on(el, page)`). Each matcher retries against a fresh snapshot until the element timeout expires, then throws with the final snapshot in the error message. `verify*` still works and remains the shortest form for the basic cases it covers — use the matcher tree when you need regex, contains, negation, multi-field conditions, or custom predicates.
+
+**Field matchers — available on both entry points:**
+
+```ts
+// Top-level entry — steps.expect(elementName, pageName)
+await steps.expect('price', 'ProductPage').text.toBe('$19.99');
+await steps.expect('price', 'ProductPage').text.toContain('Premium');
+await steps.expect('price', 'ProductPage').text.toMatch(/^\$\d+\.\d{2}$/);
+await steps.expect('price', 'ProductPage').text.toStartWith('$');
+await steps.expect('price', 'ProductPage').text.toEndWith('USD');
+
+await steps.expect('emailInput', 'LoginPage').value.toBe('user@test.com');
+await steps.expect('emailInput', 'LoginPage').value.toMatch(/@/);
+
+await steps.expect('link', 'NavPage').attributes.get('href').toBe('/dashboard');
+await steps.expect('link', 'NavPage').attributes.get('class').toContain('active');
+await steps.expect('link', 'NavPage').attributes.get('href').toMatch(/\/products\/\d+/);
+await steps.expect('btn', 'Page').attributes.toHaveKey('disabled');
+
+await steps.expect('items', 'ListPage').count.toBe(3);
+await steps.expect('items', 'ListPage').count.toBeGreaterThan(3);
+await steps.expect('items', 'ListPage').count.toBeLessThan(20);
+await steps.expect('items', 'ListPage').count.toBeGreaterThanOrEqual(5);
+await steps.expect('items', 'ListPage').count.toBeLessThanOrEqual(10);
+
+await steps.expect('banner', 'Page').visible.toBeTrue();
+await steps.expect('banner', 'Page').visible.toBe(true);
+await steps.expect('spinner', 'Page').visible.toBeFalse();
+await steps.expect('submitBtn', 'Page').enabled.toBeTrue();
+
+await steps.expect('banner', 'Page').css('color').toBe('rgb(255, 0, 0)');
+await steps.expect('banner', 'Page').css('cursor').toMatch(/pointer|default/);
+
+// Fluent entry — same matchers directly on steps.on()
+await steps.on('price', 'ProductPage').text.toBe('$19.99');
+await steps.on('row', 'TablePage').nth(2).attributes.get('data-id').toBe('42');
+await steps.on('cards', 'ListPage').random().text.toMatch(/\$\d+/);
+await steps.on('banner', 'HomePage').ifVisible().text.toContain('Promo');
+```
+
+**Negation with `.not`:**
+
+```ts
+// Flip any matcher via .not — composes on either side of the field accessor
+await steps.expect('error', 'Page').not.text.toContain('Crash');
+await steps.expect('error', 'Page').text.not.toContain('Crash');
+await steps.on('submitBtn', 'Page').enabled.not.toBe(false);
+await steps.on('link', 'Page').attributes.not.toHaveKey('disabled');
+await steps.on('link', 'Page').attributes.get('href').not.toBe('/wrong');
+```
+
+**Predicate escape hatch** — for assertions the matcher tree doesn't cover (multi-field combinations, parsed numeric thresholds, JSON in `data-*`):
+
+```ts
+// Top-level — pass predicate as third argument
+await steps.expect(
+  'price', 'ProductPage',
+  el => parseFloat(el.text.slice(1)) > 10,
+  'price must be above $10',
+);
+
+// Fluent — .expect(predicate, message?) on ElementAction
+await steps.on('price', 'ProductPage').expect(
+  el => parseFloat(el.text.slice(1)) > 10,
+);
+
+await steps.on('card', 'DashboardPage').expect(
+  el => el.visible && el.attributes['data-status'] === 'ready' && el.count > 0,
+);
+```
+
+Predicates receive an `ElementSnapshot` — plain data, no async methods:
+
+```ts
+interface ElementSnapshot {
+    readonly text: string;
+    readonly value: string;                         // input value, '' for non-inputs
+    readonly attributes: Readonly<Record<string, string>>;
+    readonly visible: boolean;
+    readonly enabled: boolean;
+    readonly count: number;                         // total matches post-strategy
+}
+```
+
+On predicate timeout, the error message includes the full snapshot pretty-printed so you can see exactly why the assertion failed:
+
+```
+expect() predicate failed on ProductPage.price after 30000ms
+  snapshot at timeout:
+    {
+      "text": "12.99 USD",
+      "value": "",
+      "attributes": { ... },
+      "visible": true,
+      "enabled": true,
+      "count": 1
+    }
 ```
 
 ### Visibility Probe

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export { ElementAction } from './steps/ElementAction';
 // Expect Matcher Tree
 export {
     ExpectBuilder,
+    PredicateAssertion,
     TextMatcher,
     ValueMatcher,
     CountMatcher,

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,19 @@ export { ElementType, WebElement, PlatformElement, ElementChain, ElementAssertio
 export { Steps } from './steps/CommonSteps';
 export { ElementAction } from './steps/ElementAction';
 
+// Expect Matcher Tree
+export {
+    ExpectBuilder,
+    TextMatcher,
+    ValueMatcher,
+    CountMatcher,
+    BooleanMatcher,
+    AttributeMatcher,
+    AttributesMatcher,
+    CssMatcher,
+} from './steps/ExpectMatchers';
+export type { ElementSnapshot, ExpectContext } from './steps/ExpectMatchers';
+
 // Test Fixture
 export { baseFixture, BaseFixtureOptions } from './fixture/BaseFixture';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,6 @@ export { ElementAction } from './steps/ElementAction';
 // Expect Matcher Tree
 export {
     ExpectBuilder,
-    PredicateAssertion,
     TextMatcher,
     ValueMatcher,
     CountMatcher,

--- a/src/interactions/Extraction.ts
+++ b/src/interactions/Extraction.ts
@@ -5,109 +5,68 @@ import { Element, WebElement } from '@civitas-cerebrum/element-repository';
 
 type Target = Locator | Element;
 
-function resolveLocator(target: Target): Locator {
-    if ('_type' in target) {
-        return (target as unknown as WebElement).locator;
-    }
-    return target as Locator;
+function toElement(target: Target): Element {
+    if ('_type' in target) return target as Element;
+    return new WebElement(target as Locator);
 }
 
 export class Extractions {
-    private ELEMENT_TIMEOUT : number;
+    private ELEMENT_TIMEOUT: number;
     private utils: Utils;
 
-    /**
-     * Initializes the Extractions class.
-     * @param page - The current Playwright Page object.
-     * @param timeout - Optional override for the default element timeout.
-     */
     constructor(private page: Page, timeout: number = 30000) {
         this.ELEMENT_TIMEOUT = timeout;
         this.utils = new Utils(this.ELEMENT_TIMEOUT);
     }
 
-    /**
-     * Safely retrieves and trims the text content of an element.
-     * @param target - A Playwright Locator or Element pointing to the target element.
-     * @returns The trimmed string, or an empty string if null.
-     */
+    /** Safely retrieves and trims the text content of an element. */
     async getText(target: Target): Promise<string | null> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'attached');
-        const text = await locator.textContent({ timeout: this.ELEMENT_TIMEOUT });
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'attached');
+        const text = await element.textContent();
         return text?.trim() ?? null;
     }
 
-    /**
-     * Retrieves the value of a specified attribute (e.g., 'href', 'aria-pressed').
-     * @param target - A Playwright Locator or Element pointing to the target element.
-     * @param attributeName - The name of the attribute to retrieve.
-     * @returns The attribute value as a string, or null if it doesn't exist.
-     */
+    /** Retrieves the value of a specified attribute. */
     async getAttribute(target: Target, attributeName: string): Promise<string | null> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'attached');
-        return await locator.getAttribute(attributeName, { timeout: this.ELEMENT_TIMEOUT });
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'attached');
+        return element.getAttribute(attributeName);
     }
 
-    /**
-     * Retrieves the trimmed text content of every element matching the locator.
-     * @param target - A Playwright Locator or Element pointing to the target elements.
-     * @returns An array of trimmed text strings, one per matching element.
-     */
+    /** Retrieves the trimmed text content of every element matching the locator. */
     async getAllTexts(target: Target): Promise<string[]> {
-        const locator = resolveLocator(target);
-        const rawTexts = await locator.allTextContents();
-        return rawTexts.map(t => t.trim());
+        const element = toElement(target);
+        const all = await element.all();
+        const texts = await Promise.all(all.map(e => e.textContent()));
+        return texts.map(t => (t ?? '').trim());
     }
 
-    /**
-     * Retrieves the current value of an input, textarea, or select element.
-     * Unlike `getText` which reads `textContent`, this reads the `value` property.
-     * @param target - A Playwright Locator or Element pointing to the input element.
-     * @returns The current value of the input.
-     */
+    /** Retrieves the current value of an input, textarea, or select element. */
     async getInputValue(target: Target): Promise<string> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'attached');
-        return await locator.inputValue({ timeout: this.ELEMENT_TIMEOUT });
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'attached');
+        return element.inputValue();
     }
 
-    /**
-     * Returns the number of DOM elements matching the locator.
-     * @param target - A Playwright Locator or Element pointing to the target elements.
-     * @returns The count of matching elements.
-     */
+    /** Returns the number of DOM elements matching the target. */
     async getCount(target: Target): Promise<number> {
-        const locator = resolveLocator(target);
-        return await locator.count();
+        const element = toElement(target);
+        return element.count();
     }
 
-    /**
-     * Retrieves a computed CSS property value from an element via `getComputedStyle`.
-     * @param target - A Playwright Locator or Element pointing to the target element.
-     * @param property - The CSS property name (e.g. `'color'`, `'font-size'`, `'display'`).
-     * @returns The computed value of the CSS property as a string.
-     */
+    /** Retrieves a computed CSS property value from an element. */
     async getCssProperty(target: Target, property: string): Promise<string> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'attached');
-        return await locator.evaluate(
-            (el, prop) => window.getComputedStyle(el).getPropertyValue(prop),
-            property
-        );
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'attached');
+        return element.getCssProperty(property);
     }
 
-    /**
-     * Captures a screenshot of the full page or a specific element.
-     * @param target - If provided, screenshots only this element. If omitted, screenshots the full page.
-     * @param options - Optional configuration: `fullPage` for scrollable capture, `path` to save to disk.
-     * @returns The screenshot image as a Buffer.
-     */
+    /** Captures a screenshot of the full page or a specific element. */
     async screenshot(target?: Target, options?: ScreenshotOptions): Promise<Buffer> {
         if (target) {
-            const locator = resolveLocator(target);
-            return await locator.screenshot({ path: options?.path }) as Buffer;
+            const element = toElement(target);
+            return element.screenshot({ path: options?.path });
         }
         return await this.page.screenshot({
             fullPage: options?.fullPage,

--- a/src/interactions/Extraction.ts
+++ b/src/interactions/Extraction.ts
@@ -55,9 +55,9 @@ export class Extractions {
         return element.count();
     }
 
-    /** Retrieves a computed CSS property value from an element. Web-only. */
+    /** Retrieves a computed CSS property value from an element. */
     async getCssProperty(target: Target, property: string): Promise<string> {
-        const element = toElement(target) as WebElement;
+        const element = toElement(target);
         await this.utils.waitForState(element, 'attached');
         return element.getCssProperty(property);
     }

--- a/src/interactions/Extraction.ts
+++ b/src/interactions/Extraction.ts
@@ -55,9 +55,9 @@ export class Extractions {
         return element.count();
     }
 
-    /** Retrieves a computed CSS property value from an element. */
+    /** Retrieves a computed CSS property value from an element. Web-only. */
     async getCssProperty(target: Target, property: string): Promise<string> {
-        const element = toElement(target);
+        const element = toElement(target) as WebElement;
         await this.utils.waitForState(element, 'attached');
         return element.getCssProperty(property);
     }

--- a/src/interactions/Interaction.ts
+++ b/src/interactions/Interaction.ts
@@ -6,49 +6,40 @@ import { Element, WebElement } from '@civitas-cerebrum/element-repository';
 /** A Playwright Locator or an Element wrapper from the repository. */
 export type Target = Locator | Element;
 
-/** Resolves a Target to a Playwright Locator. */
-function resolveLocator(target: Target): Locator {
-    if ('_type' in target) {
-        return (target as unknown as WebElement).locator;
-    }
-    return target as Locator;
+/** Normalizes a `Target` into an `Element`. All internal interactions route through element-repository. */
+function toElement(target: Target): Element {
+    if ('_type' in target) return target as Element;
+    return new WebElement(target as Locator);
 }
 
 /**
  * The `Interactions` class provides a robust set of methods for interacting
- * with DOM elements via Playwright Locators. It abstracts away common boilerplate
- * and handles edge cases like overlapping elements or optional UI components.
+ * with DOM elements. All operations route through element-repository's
+ * `Element` interface, keeping this class framework-agnostic.
  */
 export class Interactions {
-    private ELEMENT_TIMEOUT : number;
+    private ELEMENT_TIMEOUT: number;
     private utils: Utils;
 
-    /**
-     * Initializes the Interactions class.
-     * @param page - The current Playwright Page object.
-     * @param timeout - Optional override for the default element timeout.
-     */
     constructor(private page: Page, timeout: number = 30000) {
         this.ELEMENT_TIMEOUT = timeout;
         this.utils = new Utils(this.ELEMENT_TIMEOUT);
     }
 
     /**
-     * Performs a standard Playwright click on the given target.
+     * Performs a standard click on the given target.
      * Automatically waits for the element to be attached, visible, stable, and actionable.
-     * @param target - A Playwright Locator or Element pointing to the target element.
-     * @param options - Optional click modifiers.
      */
     async click(target: Target, options?: ClickOptions): Promise<boolean | void> {
-        const locator = resolveLocator(target);
+        const element = toElement(target);
         const useDispatch = options?.force || options?.withoutScrolling;
 
         if (options?.ifPresent) {
-            if (await locator.isVisible()) {
+            if (await element.isVisible()) {
                 if (useDispatch) {
-                    await this.dispatchClick(locator);
+                    await this.dispatchClick(element);
                 } else {
-                    await this.clickWithInterceptionRetry(locator);
+                    await this.clickWithInterceptionRetry(element);
                 }
                 return true;
             }
@@ -56,113 +47,79 @@ export class Interactions {
         }
 
         if (useDispatch) {
-            await this.dispatchClick(locator);
+            await this.dispatchClick(element);
             return;
         }
 
-        await this.utils.waitForState(locator, 'visible');
-        await this.clickWithInterceptionRetry(locator);
+        await this.utils.waitForState(element, 'visible');
+        await this.clickWithInterceptionRetry(element);
     }
 
     /**
      * Dispatches a native 'click' event directly on the element, bypassing
-     * Playwright's actionability checks and pointer-interception guards.
-     * Used by both `force` and `withoutScrolling` options.
+     * actionability checks. Used for both `force` and `withoutScrolling`.
      */
-    private async dispatchClick(locator: Locator): Promise<void> {
-        await this.utils.waitForState(locator, 'attached');
-        await locator.dispatchEvent('click');
+    private async dispatchClick(element: Element): Promise<void> {
+        await this.utils.waitForState(element, 'attached');
+        await element.dispatchEvent('click');
     }
 
     /**
-     * Attempts a standard click. If the click fails because another element
-     * intercepts pointer events, automatically retries by dispatching a native
-     * click event directly on the element (bypassing the overlay).
-     *
-     * Uses a short initial timeout (5s) for the first attempt so that
-     * interception retries don't add 30s+ of dead wait time.
+     * Attempts a standard click. If interception is reported, retries by
+     * dispatching a native click event on the element instead.
      */
-    private async clickWithInterceptionRetry(locator: Locator): Promise<void> {
+    private async clickWithInterceptionRetry(element: Element): Promise<void> {
         try {
-            await locator.click({ timeout: Math.min(this.ELEMENT_TIMEOUT, 5000) });
+            await element.click({ timeout: Math.min(this.ELEMENT_TIMEOUT, 5000) });
         } catch (error: unknown) {
             const message = error instanceof Error ? error.message : String(error);
             if (message.includes('intercepts pointer events')) {
-                await locator.dispatchEvent('click');
+                await element.dispatchEvent('click');
             } else {
-                // Retry with full timeout in case the short attempt failed for
-                // a timing reason (element wasn't ready yet)
-                await locator.click({ timeout: this.ELEMENT_TIMEOUT });
+                await element.click({ timeout: this.ELEMENT_TIMEOUT });
             }
         }
     }
 
-    /**
-     * Dispatches a native 'click' event directly to the element.
-     * This bypasses Playwright's default scrolling and intersection observer checks.
-     * Highly useful for clicking elements that might be artificially obscured by sticky headers or transparent overlays.
-     * @param target - A Playwright Locator or Element pointing to the target element.
-     * @deprecated Use `click(target, { withoutScrolling: true })` instead.
-     */
+    /** @deprecated Use `click(target, { withoutScrolling: true })` instead. */
     async clickWithoutScrolling(target: Target): Promise<void> {
         await this.click(target, { withoutScrolling: true });
     }
 
-    /**
-     * Checks if an element is visible before attempting to click it.
-     * If the element is hidden or not in the DOM, it safely skips the action
-     * without failing the test. Great for optional elements like cookie banners or promotional pop-ups.
-     * @param target - A Playwright Locator or Element pointing to the target element.
-     * @returns `true` if the element was visible and clicked, `false` if it was skipped.
-     * @deprecated Use `click(target, { ifPresent: true })` instead.
-     */
+    /** @deprecated Use `click(target, { ifPresent: true })` instead. */
     async clickIfPresent(target: Target): Promise<boolean> {
         return await this.click(target, { ifPresent: true }) as boolean;
     }
 
-    /**
-     * Clears any existing value in the target input field and types the provided text.
-     * @param target - A Playwright Locator or Element pointing to the input element.
-     * @param text - The string to type into the input field.
-     */
     async fill(target: Target, text: string): Promise<void> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'visible');
-        await locator.fill(text, { timeout: this.ELEMENT_TIMEOUT });
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'visible');
+        await element.fill(text, { timeout: this.ELEMENT_TIMEOUT });
     }
 
-    /**
-     * Uploads a local file to an `<input type="file">` element.
-     * @param target - A Playwright Locator or Element pointing to the file input element.
-     * @param filePath - The local file system path to the file you want to upload.
-     */
     async uploadFile(target: Target, filePath: string): Promise<void> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'attached');
-        await locator.setInputFiles(filePath, { timeout: this.ELEMENT_TIMEOUT });
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'attached');
+        await element.setInputFiles(filePath, { timeout: this.ELEMENT_TIMEOUT });
     }
 
     /**
      * Unified method to interact with `<select>` dropdown elements based on the specified `DropdownSelectType`.
-     * If no options are provided, it safely defaults to randomly selecting an enabled, non-empty option.
-     * @param target - A Playwright Locator or Element pointing to the `<select>` element.
-     * @param options - Configuration specifying whether to select by 'random', 'index', or 'value'.
-     * @returns A promise that resolves to the exact 'value' attribute of the newly selected option.
-     * @throws Error if 'value' or 'index' is missing when their respective types are chosen, or if no enabled options exist.
+     * If no options are provided, safely defaults to randomly selecting an enabled, non-empty option.
      */
     async selectDropdown(
         target: Target,
         options: DropdownSelectOptions = { type: DropdownSelectType.RANDOM }
     ): Promise<string> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'visible');
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'visible');
         const type = options.type ?? DropdownSelectType.RANDOM;
 
         if (type === DropdownSelectType.VALUE) {
             if (options.value === undefined) {
                 throw new Error('[Action] Error -> "value" must be provided when using DropdownSelectType.VALUE.');
             }
-            const selected = await locator.selectOption({ value: options.value }, { timeout: this.ELEMENT_TIMEOUT });
+            const selected = await element.selectOption({ value: options.value }, { timeout: this.ELEMENT_TIMEOUT });
             return selected[0];
         }
 
@@ -170,99 +127,92 @@ export class Interactions {
             if (options.index === undefined) {
                 throw new Error('[Action] Error -> "index" must be provided when using DropdownSelectType.INDEX.');
             }
-            const selected = await locator.selectOption({ index: options.index }, { timeout: this.ELEMENT_TIMEOUT });
+            const selected = await element.selectOption({ index: options.index }, { timeout: this.ELEMENT_TIMEOUT });
             return selected[0];
         }
 
-        const enabledOptions = locator.locator('option:not([disabled]):not([value=""])');
+        // Random path — look for enabled, non-empty <option> descendants.
+        // `locateChild` composes a CSS selector underneath the current element;
+        // this is part of the Element contract, not a raw locator call.
+        const enabledOptions = element.locateChild('option:not([disabled]):not([value=""])');
 
         await this.utils.waitForState(enabledOptions.first(), 'attached').catch(() => { });
 
         const count = await enabledOptions.count();
-
         if (count === 0) {
             throw new Error('[Action] Error -> No enabled options found to select!');
         }
 
         const randomIndex = Math.floor(Math.random() * count);
-        const valueToSelect = await enabledOptions.nth(randomIndex).getAttribute('value', { timeout: this.ELEMENT_TIMEOUT });
+        const valueToSelect = await enabledOptions.nth(randomIndex).getAttribute('value');
 
         if (valueToSelect === null) {
             throw new Error(`[Action] Error -> Option at index ${randomIndex} is missing a "value" attribute.`);
         }
 
-        const selected = await locator.selectOption({ value: valueToSelect }, { timeout: this.ELEMENT_TIMEOUT });
-
+        const selected = await element.selectOption({ value: valueToSelect }, { timeout: this.ELEMENT_TIMEOUT });
         return selected[0];
     }
 
-    /**
-     * Hovers over the specified element. Useful for triggering dropdowns or tooltips.
-     * @param target - A Playwright Locator or Element pointing to the target element.
-     */
     async hover(target: Target): Promise<void> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'visible');
-        await locator.hover({ timeout: this.ELEMENT_TIMEOUT });
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'visible');
+        await element.hover({ timeout: this.ELEMENT_TIMEOUT });
     }
 
-    /**
-     * Scrolls the element into view if it is not already visible in the viewport.
-     * @param target - A Playwright Locator or Element pointing to the target element.
-     */
     async scrollIntoView(target: Target): Promise<void> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'attached');
-        await locator.scrollIntoViewIfNeeded({ timeout: this.ELEMENT_TIMEOUT });
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'attached');
+        await element.scrollIntoView({ timeout: this.ELEMENT_TIMEOUT });
     }
 
     /**
-    * Drags an element either to a specified target element, a target element with an offset, or by a coordinate offset.
-    * @param target - A Playwright Locator or Element pointing to the element to drag.
-    * @param options - Configuration specifying a 'targetLocator', offsets, or both.
-    */
+     * Drags an element to a target element or by a coordinate offset.
+     * Absolute-offset drags use the page's mouse API (no Element equivalent
+     * exists today); all other paths route through `Element.dragTo`.
+     */
     async dragAndDrop(target: Target, options: DragAndDropOptions): Promise<void> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'visible');
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'visible');
 
         if (options.target) {
-            const dropTarget = resolveLocator(options.target);
-            await this.utils.waitForState(dropTarget, 'visible');
+            const dropElement = toElement(options.target);
+            await this.utils.waitForState(dropElement, 'visible');
 
             if (options.xOffset !== undefined && options.yOffset !== undefined) {
-                const targetBox = await dropTarget.boundingBox();
+                const targetBox = await dropElement.boundingBox();
                 if (!targetBox) {
-                    throw new Error(`[Action] Error -> Unable to get bounding box for target element.`);
+                    throw new Error('[Action] Error -> Unable to get bounding box for target element.');
                 }
 
                 const targetPosition = {
                     x: (targetBox.width / 2) + options.xOffset,
-                    y: (targetBox.height / 2) + options.yOffset
+                    y: (targetBox.height / 2) + options.yOffset,
                 };
 
-                await locator.dragTo(dropTarget, {
+                await element.dragTo(dropElement, {
                     targetPosition,
-                    timeout: this.ELEMENT_TIMEOUT
+                    timeout: this.ELEMENT_TIMEOUT,
                 });
                 return;
             }
 
-            await locator.dragTo(dropTarget, { timeout: this.ELEMENT_TIMEOUT });
+            await element.dragTo(dropElement, { timeout: this.ELEMENT_TIMEOUT });
             return;
         }
 
         if (options.xOffset !== undefined && options.yOffset !== undefined) {
-            const box = await locator.boundingBox();
+            const box = await element.boundingBox();
             if (!box) {
-                throw new Error(`[Action] Error -> Unable to get bounding box for element to perform drag action.`);
+                throw new Error('[Action] Error -> Unable to get bounding box for element to perform drag action.');
             }
 
             const startX = box.x + box.width / 2;
             const startY = box.y + box.height / 2;
 
+            // Mouse-level drag — no Element equivalent; page.mouse is the documented path.
             await this.page.mouse.move(startX, startY);
             await this.page.mouse.down();
-
             await this.page.mouse.move(startX + options.xOffset, startY + options.yOffset, { steps: 10 });
             await this.page.mouse.up();
             return;
@@ -272,182 +222,122 @@ export class Interactions {
     }
 
     /**
-       * Filters a locator list and returns the first element that contains the specified text.
-       * If the element is not found, it prints the available text contents of the base locator for debugging.
-       * @param baseTarget The base Playwright Locator or Element.
-       * @param desiredText The string of text to search for within the elements.
-       * @param strict If true, throws an error if the element is not found. Defaults to false.
-       * @returns A promise that resolves to the matched Playwright Locator, or null if not found.
-       */
+     * Filters a locator list and returns the first element matching the given text.
+     * Uses Element.filter composition (which delegates to Playwright's filter under the hood).
+     */
     public async getByText(
         baseTarget: Target,
         desiredText: string,
-        strict: boolean = false
-    ): Promise<ReturnType<Page['locator']> | null> {
-        const baseLocator = resolveLocator(baseTarget);
-        // Try case-sensitive match first
-        const caseSensitive = baseLocator.filter({ hasText: desiredText }).first();
+        strict: boolean = false,
+    ): Promise<Locator | null> {
+        const base = toElement(baseTarget);
 
+        const caseSensitive = base.filter({ hasText: desiredText }).first();
         if ((await caseSensitive.count()) > 0) {
-            return caseSensitive;
+            return (caseSensitive as WebElement).locator;
         }
 
-        // Fall back to case-insensitive match
         const escaped = desiredText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        const caseInsensitive = baseLocator.filter({ hasText: new RegExp(escaped, 'i') }).first();
-
+        const caseInsensitive = base.filter({ hasText: new RegExp(escaped, 'i') }).first();
         if ((await caseInsensitive.count()) > 0) {
-            return caseInsensitive;
+            return (caseInsensitive as WebElement).locator;
         }
 
-        const rawTexts = await baseLocator.allInnerTexts();
-
-        const availableTexts = rawTexts
-            .map((text: string) => text.trim())
-            .filter((text: string) => text.length > 0);
+        const all = await base.all();
+        const rawTexts = await Promise.all(all.map(e => e.textContent()));
+        const availableTexts = rawTexts.map(t => (t ?? '').trim()).filter(t => t.length > 0);
 
         const msg = `getByText: element with text "${desiredText}" not found.\nAvailable texts: ${availableTexts.length > 0 ? `\n- ${availableTexts.join('\n- ')}` : 'None'}`;
-
         if (strict) throw new Error(msg);
         return null;
     }
 
-    /**
-     * Types into the target element character by character with a specified delay.
-     * Use this for OTP inputs, search-as-you-type fields, or when `fill()`
-     * doesn't trigger necessary keyboard events (like 'keyup' or 'keydown').
-     * @param target - A Playwright Locator or Element pointing to the input element.
-     * @param text - The string of text to type sequentially.
-     * @param delay - Time in milliseconds to wait between key presses. Defaults to 100ms.
-     */
     async typeSequentially(target: Target, text: string, delay: number = 100): Promise<void> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'visible');
-        await locator.pressSequentially(text, {
-            delay,
-            timeout: this.ELEMENT_TIMEOUT
-        });
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'visible');
+        await element.pressSequentially(text, delay, { timeout: this.ELEMENT_TIMEOUT });
     }
 
-    /**
-     * Performs a right-click (context menu) on the given target.
-     * @param target - A Playwright Locator or Element pointing to the target element.
-     */
+    /** Right-click (context menu) on the given target. */
     async rightClick(target: Target): Promise<void> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'visible');
-        await locator.click({ button: 'right', timeout: this.ELEMENT_TIMEOUT });
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'visible');
+        await element.rightClick({ timeout: this.ELEMENT_TIMEOUT });
     }
 
-    /**
-     * Performs a double-click on the given target.
-     * @param target - A Playwright Locator or Element pointing to the target element.
-     */
     async doubleClick(target: Target): Promise<void> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'visible');
-        await locator.dblclick({ timeout: this.ELEMENT_TIMEOUT });
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'visible');
+        await element.doubleClick({ timeout: this.ELEMENT_TIMEOUT });
     }
 
-    /**
-     * Checks a checkbox or radio button. This is idempotent — if already checked, it does nothing.
-     * @param target - A Playwright Locator or Element pointing to the checkbox/radio element.
-     */
     async check(target: Target): Promise<void> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'visible');
-        await locator.check({ timeout: this.ELEMENT_TIMEOUT });
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'visible');
+        await element.check({ timeout: this.ELEMENT_TIMEOUT });
     }
 
-    /**
-     * Unchecks a checkbox. This is idempotent — if already unchecked, it does nothing.
-     * @param target - A Playwright Locator or Element pointing to the checkbox element.
-     */
     async uncheck(target: Target): Promise<void> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'visible');
-        await locator.uncheck({ timeout: this.ELEMENT_TIMEOUT });
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'visible');
+        await element.uncheck({ timeout: this.ELEMENT_TIMEOUT });
     }
 
-    /**
-     * Sets the value of a range/slider input element.
-     * @param target - A Playwright Locator or Element pointing to the range input element.
-     * @param value - The numeric value to set.
-     */
     async setSliderValue(target: Target, value: number): Promise<void> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'visible');
-        await locator.fill(String(value), { timeout: this.ELEMENT_TIMEOUT });
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'visible');
+        await element.fill(String(value), { timeout: this.ELEMENT_TIMEOUT });
     }
 
-    /**
-     * Presses a keyboard key at the page level.
-     * Useful for shortcuts like Escape, Enter, Tab, or modifier combos like 'Control+A'.
-     * @param key - The key to press (e.g. 'Escape', 'Enter', 'Tab', 'Control+A').
-     */
     async pressKey(key: string): Promise<void> {
         await this.page.keyboard.press(key);
     }
 
-    /**
-     * Clears the value of an input or textarea element without filling it with new text.
-     * @param target - A Playwright Locator or Element pointing to the input element.
-     */
     async clearInput(target: Target): Promise<void> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'visible');
-        await locator.clear({ timeout: this.ELEMENT_TIMEOUT });
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'visible');
+        await element.clear({ timeout: this.ELEMENT_TIMEOUT });
     }
 
-    /**
-     * Selects multiple options from a `<select multiple>` element by their `value` attributes.
-     * @param target - A Playwright Locator or Element pointing to the multi-select element.
-     * @param values - An array of `value` attribute strings to select.
-     * @returns An array of the actually selected `value` strings.
-     */
     async selectMultiple(target: Target, values: string[]): Promise<string[]> {
-        const locator = resolveLocator(target);
-        await this.utils.waitForState(locator, 'visible');
-        return await locator.selectOption(
-            values.map(v => ({ value: v })),
-            { timeout: this.ELEMENT_TIMEOUT }
-        );
+        const element = toElement(target);
+        await this.utils.waitForState(element, 'visible');
+        return element.selectOption(values.map(v => ({ value: v })), { timeout: this.ELEMENT_TIMEOUT });
     }
 
     /**
-     * Resolves a specific element from a list by matching its visible text or an HTML attribute.
-     * Optionally drills into a child element within the matched item.
+     * Resolves a specific element from a list by matching visible text or an attribute,
+     * with optional child-element drill-down.
      *
-     * This is the core utility behind `clickListedElement`, `verifyListedElement`,
-     * and `getListedElementData` in the Steps API.
-     *
-     * @param baseTarget - A Playwright Locator or Element that resolves to the list of elements (e.g. table rows, list items).
-     * @param options - Match criteria and optional child targeting. Must include either `text` or `attribute`.
-     * @param repo - Optional ElementRepository instance, required when `options.child` is a page-repo reference.
-     * @returns The resolved Playwright Locator for the matched (and optionally child-targeted) element.
-     * @throws Error if neither `text` nor `attribute` is specified, or if no matching element is found.
+     * Returns a Playwright `Locator` because callers downstream need it for
+     * `expect(locator).X()` assertions and child-selector composition that
+     * doesn't fit the Element abstraction (e.g. `.and()`). Internally, match
+     * discovery uses Element methods where possible.
      */
     async getListedElement(
         baseTarget: Target,
         options: ListedElementMatch,
-        repo?: { getSelector(elementName: string, pageName: string): string }
+        repo?: { getSelector(elementName: string, pageName: string): string },
     ): Promise<Locator> {
-        const baseLocator = resolveLocator(baseTarget);
-        let matched: Locator;
+        const baseElement = toElement(baseTarget);
+        let matched: Element;
 
         if (options.text) {
-            // Try case-sensitive match first, fall back to case-insensitive
-            const caseSensitive = baseLocator.filter({ hasText: options.text }).first();
+            const caseSensitive = baseElement.filter({ hasText: options.text }).first();
             if ((await caseSensitive.count()) > 0) {
                 matched = caseSensitive;
             } else {
                 const escaped = options.text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-                matched = baseLocator.filter({ hasText: new RegExp(escaped, 'i') }).first();
+                matched = baseElement.filter({ hasText: new RegExp(escaped, 'i') }).first();
             }
         } else if (options.attribute) {
-            matched = baseLocator.and(
-                this.page.locator(`[${options.attribute.name}="${options.attribute.value}"]`)
-            ).first();
+            // Locator.and() composition has no Element equivalent today — drop to Locator.
+            const baseLocator = (baseElement as WebElement).locator;
+            matched = new WebElement(
+                baseLocator
+                    .and(this.page.locator(`[${options.attribute.name}="${options.attribute.value}"]`))
+                    .first(),
+            );
         } else {
             throw new Error('ListedElementOptions requires either "text" or "attribute" to identify the element.');
         }
@@ -455,17 +345,17 @@ export class Interactions {
         await this.utils.waitForState(matched, 'visible');
 
         if (!options.child) {
-            return matched;
+            return (matched as WebElement).locator;
         }
 
         if (typeof options.child === 'string') {
-            return matched.locator(options.child);
+            return (matched.locateChild(options.child) as WebElement).locator;
         }
 
         if (!repo) {
             throw new Error('An ElementRepository instance is required when "child" is a page-repository reference.');
         }
         const childSelector = repo.getSelector(options.child.elementName, options.child.pageName);
-        return matched.locator(childSelector);
+        return (matched.locateChild(childSelector) as WebElement).locator;
     }
 }

--- a/src/interactions/Interaction.ts
+++ b/src/interactions/Interaction.ts
@@ -111,7 +111,8 @@ export class Interactions {
         target: Target,
         options: DropdownSelectOptions = { type: DropdownSelectType.RANDOM }
     ): Promise<string> {
-        const element = toElement(target);
+        // selectOption is a web-only method (HTML `<select>`); narrow to WebElement.
+        const element = toElement(target) as WebElement;
         await this.utils.waitForState(element, 'visible');
         const type = options.type ?? DropdownSelectType.RANDOM;
 
@@ -172,11 +173,12 @@ export class Interactions {
      * exists today); all other paths route through `Element.dragTo`.
      */
     async dragAndDrop(target: Target, options: DragAndDropOptions): Promise<void> {
-        const element = toElement(target);
+        // dragTo is web-only (HTML drag-and-drop); narrow to WebElement.
+        const element = toElement(target) as WebElement;
         await this.utils.waitForState(element, 'visible');
 
         if (options.target) {
-            const dropElement = toElement(options.target);
+            const dropElement = toElement(options.target) as WebElement;
             await this.utils.waitForState(dropElement, 'visible');
 
             if (options.xOffset !== undefined && options.yOffset !== undefined) {
@@ -258,9 +260,9 @@ export class Interactions {
         await element.pressSequentially(text, delay, { timeout: this.ELEMENT_TIMEOUT });
     }
 
-    /** Right-click (context menu) on the given target. */
+    /** Right-click (context menu) on the given target. Web-only. */
     async rightClick(target: Target): Promise<void> {
-        const element = toElement(target);
+        const element = toElement(target) as WebElement;
         await this.utils.waitForState(element, 'visible');
         await element.rightClick({ timeout: this.ELEMENT_TIMEOUT });
     }
@@ -300,7 +302,8 @@ export class Interactions {
     }
 
     async selectMultiple(target: Target, values: string[]): Promise<string[]> {
-        const element = toElement(target);
+        // selectOption is web-only; narrow to WebElement.
+        const element = toElement(target) as WebElement;
         await this.utils.waitForState(element, 'visible');
         return element.selectOption(values.map(v => ({ value: v })), { timeout: this.ELEMENT_TIMEOUT });
     }

--- a/src/interactions/Interaction.ts
+++ b/src/interactions/Interaction.ts
@@ -173,12 +173,11 @@ export class Interactions {
      * exists today); all other paths route through `Element.dragTo`.
      */
     async dragAndDrop(target: Target, options: DragAndDropOptions): Promise<void> {
-        // dragTo is web-only (HTML drag-and-drop); narrow to WebElement.
-        const element = toElement(target) as WebElement;
+        const element = toElement(target);
         await this.utils.waitForState(element, 'visible');
 
         if (options.target) {
-            const dropElement = toElement(options.target) as WebElement;
+            const dropElement = toElement(options.target);
             await this.utils.waitForState(dropElement, 'visible');
 
             if (options.xOffset !== undefined && options.yOffset !== undefined) {

--- a/src/interactions/Verification.ts
+++ b/src/interactions/Verification.ts
@@ -11,6 +11,11 @@ function resolveLocator(target: Target): Locator {
     return target as Locator;
 }
 
+function toElement(target: Target): Element {
+    if ('_type' in target) return target as Element;
+    return new WebElement(target as Locator);
+}
+
 /**
  * The `Verifications` class provides a unified wrapper around Playwright's `expect` assertions.
  * It standardizes timeouts and includes advanced custom, robust verifications
@@ -303,8 +308,9 @@ export class Verifications {
             throw new Error(`You must provide 'exact', 'greaterThan', or 'lessThan' in CountVerifyOptions.`);
         }
 
+        const element = toElement(target);
         await expect.poll(async () => {
-            const actualCount = await locator.count();
+            const actualCount = await element.count();
             if (options.greaterThan !== undefined && actualCount <= options.greaterThan) return false;
             if (options.lessThan !== undefined && actualCount >= options.lessThan) return false;
             return true;

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -623,11 +623,14 @@ export class Steps {
         const timeout = options?.timeout ?? 2000;
         log.verify('Probing visibility of "%s" in "%s" (timeout: %dms)', elementName, pageName, timeout);
         try {
+            // Use getSelector + construct a WebElement directly so the caller-supplied
+            // timeout is the only wait in play — repo.get() would block on its own
+            // repository resolution timeout (15s default) before our waitFor runs.
             const selector = this.repo.getSelector(elementName, pageName);
-            const locator = this.page.locator(selector).first();
-            await locator.waitFor({ state: 'visible', timeout });
+            const element = new WebElement(this.page.locator(selector).first());
+            await element.waitFor({ state: 'visible', timeout });
             if (options?.containsText) {
-                const text = await locator.textContent({ timeout }).catch(() => null);
+                const text = await element.textContent().catch(() => null);
                 return text !== null && text.includes(options.containsText);
             }
             return true;

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -6,7 +6,7 @@ import { EmailClientConfig, EmailSendOptions, EmailReceiveOptions, ReceivedEmail
 import { StepOptions, DropdownSelectOptions, TextVerifyOptions, CountVerifyOptions, DragAndDropOptions, ListedElementOptions, ListedElementMatch, VerifyListedOptions, GetListedDataOptions, FillFormValue, GetAllOptions, ScreenshotOptions, IsVisibleOptions } from '../enum/Options';
 import { logger } from '../logger/Logger';
 import { ElementAction } from './ElementAction';
-import { ExpectBuilder, ElementSnapshot } from './ExpectMatchers';
+import { ExpectBuilder } from './ExpectMatchers';
 
 /**
  * Extracts the underlying Playwright Locator from an Element wrapper.
@@ -769,47 +769,25 @@ export class Steps {
     /**
      * Entry point for the matcher tree. Resolves the named element and returns
      * an `ExpectBuilder` that exposes field-scoped matchers (`.text`, `.value`,
-     * `.attributes`, `.count`, `.visible`, `.enabled`, `.css(prop)`, and `.not`).
-     *
-     * Also serves as a predicate escape hatch — pass a third argument that
-     * returns `boolean` and the call asserts the predicate holds, retrying
-     * against a fresh snapshot until the element timeout expires.
+     * `.attributes`, `.count`, `.visible`, `.enabled`, `.css(prop)`, `.not`)
+     * plus the predicate escape hatch `.toBe(predicate)` for assertions the
+     * matcher tree doesn't cover.
      *
      * @example
      * // Matcher tree
      * await steps.expect('price', 'ProductPage').text.toBe('$19.99');
-     * await steps.expect('price', 'ProductPage').text.toMatch(/^\$/);
      * await steps.expect('items', 'ListPage').count.toBeGreaterThan(3);
-     * await steps.expect('submitBtn', 'Page').visible.toBeTrue();
      * await steps.expect('link', 'Page').attributes.get('href').toBe('/x');
      * await steps.expect('error', 'Page').not.text.toContain('crash');
      *
-     * // Predicate escape hatch
-     * await steps.expect(
-     *   'price', 'ProductPage',
-     *   el => parseFloat(el.text.slice(1)) > 10,
-     *   'price must be above $10'
-     * );
+     * // Predicate chain — assertion executes when awaited
+     * await steps.expect('price', 'ProductPage')
+     *   .toBe(el => parseFloat(el.text.slice(1)) > 10)
+     *   .throws('price must be above $10');
      */
-    expect(elementName: string, pageName: string): ExpectBuilder;
-    expect(
-        elementName: string,
-        pageName: string,
-        predicate: (el: ElementSnapshot) => boolean,
-        message?: string,
-    ): Promise<void>;
-    expect(
-        elementName: string,
-        pageName: string,
-        predicate?: (el: ElementSnapshot) => boolean,
-        message?: string,
-    ): ExpectBuilder | Promise<void> {
+    expect(elementName: string, pageName: string): ExpectBuilder {
         const interactions = new ElementInteractions(this.page, { timeout: this.timeout });
         const action = new ElementAction(this.repo, elementName, pageName, interactions, this.timeout);
-        if (typeof predicate === 'function') {
-            log.verify('Expecting predicate on "%s" in "%s"', elementName, pageName);
-            return action.expect(predicate, message);
-        }
         log.verify('Building matcher tree for "%s" in "%s"', elementName, pageName);
         return new ExpectBuilder(action.buildExpectContext());
     }

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -6,6 +6,7 @@ import { EmailClientConfig, EmailSendOptions, EmailReceiveOptions, ReceivedEmail
 import { StepOptions, DropdownSelectOptions, TextVerifyOptions, CountVerifyOptions, DragAndDropOptions, ListedElementOptions, ListedElementMatch, VerifyListedOptions, GetListedDataOptions, FillFormValue, GetAllOptions, ScreenshotOptions, IsVisibleOptions } from '../enum/Options';
 import { logger } from '../logger/Logger';
 import { ElementAction } from './ElementAction';
+import { ExpectBuilder, ElementSnapshot } from './ExpectMatchers';
 
 /**
  * Extracts the underlying Playwright Locator from an Element wrapper.
@@ -766,20 +767,51 @@ export class Steps {
     }
 
     /**
-     * Asserts that two extracted values are equal or not equal.
-     * Use after getText() or getInputValue() to compare two captured values.
-     * @param actual - The actual value captured from the page.
-     * @param expected - The value to compare against.
-     * @param options - Optional. Pass `{ not: true }` to assert the values differ instead.
+     * Entry point for the matcher tree. Resolves the named element and returns
+     * an `ExpectBuilder` that exposes field-scoped matchers (`.text`, `.value`,
+     * `.attributes`, `.count`, `.visible`, `.enabled`, `.css(prop)`, and `.not`).
+     *
+     * Also serves as a predicate escape hatch — pass a third argument that
+     * returns `boolean` and the call asserts the predicate holds, retrying
+     * against a fresh snapshot until the element timeout expires.
+     *
+     * @example
+     * // Matcher tree
+     * await steps.expect('price', 'ProductPage').text.toBe('$19.99');
+     * await steps.expect('price', 'ProductPage').text.toMatch(/^\$/);
+     * await steps.expect('items', 'ListPage').count.toBeGreaterThan(3);
+     * await steps.expect('submitBtn', 'Page').visible.toBeTrue();
+     * await steps.expect('link', 'Page').attributes.get('href').toBe('/x');
+     * await steps.expect('error', 'Page').not.text.toContain('crash');
+     *
+     * // Predicate escape hatch
+     * await steps.expect(
+     *   'price', 'ProductPage',
+     *   el => parseFloat(el.text.slice(1)) > 10,
+     *   'price must be above $10'
+     * );
      */
-    expect(actual: string | null, expected: string | null, options?: { not?: boolean }): void {
-        if (options?.not) {
-            log.verify('Expecting values to differ: "%s" !== "%s"', actual, expected);
-            this.verify.expectNotEqual(actual, expected);
-        } else {
-            log.verify('Expecting values to be equal: "%s" === "%s"', actual, expected);
-            this.verify.expectEqual(actual, expected);
+    expect(elementName: string, pageName: string): ExpectBuilder;
+    expect(
+        elementName: string,
+        pageName: string,
+        predicate: (el: ElementSnapshot) => boolean,
+        message?: string,
+    ): Promise<void>;
+    expect(
+        elementName: string,
+        pageName: string,
+        predicate?: (el: ElementSnapshot) => boolean,
+        message?: string,
+    ): ExpectBuilder | Promise<void> {
+        const interactions = new ElementInteractions(this.page, { timeout: this.timeout });
+        const action = new ElementAction(this.repo, elementName, pageName, interactions, this.timeout);
+        if (typeof predicate === 'function') {
+            log.verify('Expecting predicate on "%s" in "%s"', elementName, pageName);
+            return action.expect(predicate, message);
         }
+        log.verify('Building matcher tree for "%s" in "%s"', elementName, pageName);
+        return new ExpectBuilder(action.buildExpectContext());
     }
 
     /**

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -8,9 +8,6 @@ import {
     ExpectContext,
 } from './ExpectMatchers';
 
-/** DOM Element alias — disambiguates from the repository's `Element` wrapper in callbacks that run inside Playwright's browser context. */
-type DomElement = globalThis.Element;
-
 function toLocator(element: Element): Locator {
     return (element as WebElement).locator;
 }
@@ -115,8 +112,8 @@ export class ElementAction {
     private async shouldProceed(): Promise<boolean> {
         if (!this.conditionalVisible) return true;
         try {
-            const locator = await this.resolveLocator();
-            await locator.waitFor({ state: 'visible', timeout: this.visibilityTimeout });
+            const element = await this.resolve();
+            await element.waitFor({ state: 'visible', timeout: this.visibilityTimeout });
             return true;
         } catch {
             return false;
@@ -297,10 +294,10 @@ export class ElementAction {
     async isVisible(options?: IsVisibleOptions): Promise<boolean> {
         const timeout = options?.timeout ?? 2000;
         try {
-            const locator = await this.resolveLocator();
-            await locator.waitFor({ state: 'visible', timeout });
+            const element = await this.resolve();
+            await element.waitFor({ state: 'visible', timeout });
             if (options?.containsText) {
-                const text = await locator.textContent({ timeout }).catch(() => null);
+                const text = await element.textContent().catch(() => null);
                 return text !== null && text.includes(options.containsText);
             }
             return true;
@@ -405,25 +402,19 @@ export class ElementAction {
      * Snapshot fields are all primitives — no async access needed in predicates.
      */
     async captureSnapshot(): Promise<ElementSnapshot> {
-        const locator = await this.resolveLocator();
-        const first = locator.first();
+        const element = await this.resolve();
+        const first = element.first();
 
-        const [count, text, value, attributes, visible, enabled] = await Promise.all([
-            locator.count().catch(() => 0),
-            first.textContent().then(t => (t ?? '').trim()).catch(() => ''),
+        const [count, rawText, value, attributes, visible, enabled] = await Promise.all([
+            element.count().catch(() => 0),
+            first.textContent().catch(() => null),
             first.inputValue().catch(() => ''),
-            first.evaluate((el: DomElement) => {
-                const out: Record<string, string> = {};
-                for (const attr of Array.from(el.attributes)) {
-                    out[attr.name] = attr.value;
-                }
-                return out;
-            }).catch(() => ({} as Record<string, string>)),
+            first.getAllAttributes().catch(() => ({} as Record<string, string>)),
             first.isVisible().catch(() => false),
             first.isEnabled().catch(() => false),
         ]);
 
-        return { text, value, attributes, visible, enabled, count };
+        return { text: (rawText ?? '').trim(), value, attributes, visible, enabled, count };
     }
 
     /** Build the context object consumed by the matcher tree classes. */
@@ -434,7 +425,7 @@ export class ElementAction {
             timeout: this._timeout,
             conditionalVisible: this.conditionalVisible,
             visibilityTimeout: this.visibilityTimeout,
-            resolveLocator: () => this.resolveLocator(),
+            resolveElement: () => this.resolve(),
             captureSnapshot: () => this.captureSnapshot(),
         };
     }

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -3,15 +3,10 @@ import { ElementRepository, Element, WebElement, ElementResolutionOptions, Selec
 import { ElementInteractions } from '../interactions/facade/ElementInteractions';
 import { DropdownSelectOptions, TextVerifyOptions, CountVerifyOptions, DragAndDropOptions, ScreenshotOptions, IsVisibleOptions } from '../enum/Options';
 import {
-    AttributesMatcher,
-    BooleanMatcher,
-    CountMatcher,
-    CssMatcher,
     ElementSnapshot,
     ExpectBuilder,
     ExpectContext,
-    TextMatcher,
-    ValueMatcher,
+    PredicateAssertion,
 } from './ExpectMatchers';
 
 /** DOM Element alias — disambiguates from the repository's `Element` wrapper in callbacks that run inside Playwright's browser context. */
@@ -431,35 +426,23 @@ export class ElementAction {
         };
     }
 
-    /** Matcher entry for text content. */
-    get text(): TextMatcher {
-        return new TextMatcher(this.buildExpectContext());
+    /**
+     * Matcher tree rooted at this element. All field matchers (`text`, `value`,
+     * `count`, `visible`, `enabled`, `attributes`, `css(...)`) and the
+     * predicate form (`toBe(pred)`) are exposed via an internal `ExpectBuilder`
+     * so the surface stays consistent between `steps.on()` and `steps.expect()`.
+     */
+    private expectBuilder(negated: boolean = false): ExpectBuilder {
+        return new ExpectBuilder(this.buildExpectContext(), negated);
     }
 
-    /** Matcher entry for input value. */
-    get value(): ValueMatcher {
-        return new ValueMatcher(this.buildExpectContext());
-    }
-
-    /** Matcher entry for the count of matching elements. */
-    get count(): CountMatcher {
-        return new CountMatcher(this.buildExpectContext());
-    }
-
-    /** Matcher entry for visibility. */
-    get visible(): BooleanMatcher {
-        return new BooleanMatcher(this.buildExpectContext(), 'visible');
-    }
-
-    /** Matcher entry for enabled state. */
-    get enabled(): BooleanMatcher {
-        return new BooleanMatcher(this.buildExpectContext(), 'enabled');
-    }
-
-    /** Matcher entry for DOM attributes. */
-    get attributes(): AttributesMatcher {
-        return new AttributesMatcher(this.buildExpectContext());
-    }
+    get text() { return this.expectBuilder().text; }
+    get value() { return this.expectBuilder().value; }
+    get count() { return this.expectBuilder().count; }
+    get visible() { return this.expectBuilder().visible; }
+    get enabled() { return this.expectBuilder().enabled; }
+    get attributes() { return this.expectBuilder().attributes; }
+    css(property: string) { return this.expectBuilder().css(property); }
 
     /**
      * Returns a negated matcher tree. Flip the expected outcome of any matcher
@@ -470,65 +453,20 @@ export class ElementAction {
      * await steps.on('submitBtn', 'Page').not.enabled.toBe(false);
      */
     get not(): ExpectBuilder {
-        return new ExpectBuilder(this.buildExpectContext(), true);
-    }
-
-    /** Matcher entry for a specific computed CSS property. */
-    css(property: string): CssMatcher {
-        return new CssMatcher(this.buildExpectContext(), property);
+        return this.expectBuilder(true);
     }
 
     /**
-     * Predicate escape hatch for custom assertions the matcher tree doesn't
-     * cover. Runs the predicate against a fresh snapshot on every retry until
-     * the predicate returns `true` or the element timeout expires.
-     *
-     * @param predicate - Function receiving an `ElementSnapshot` that returns
-     *   `true` when the assertion holds.
-     * @param message - Optional custom error message shown on failure.
+     * Predicate escape hatch. Returns a chainable, awaitable assertion that
+     * passes when the predicate returns `true`. Use `.throws(message)` to
+     * override the failure message.
      *
      * @example
-     * await steps.on('price', 'ProductPage').expect(
-     *   el => parseFloat(el.text.slice(1)) > 10,
-     *   'price must be above $10'
-     * );
+     * await steps.on('price', 'ProductPage').toBe(el => parseFloat(el.text.slice(1)) > 10)
+     *   .throws('price must be above $10');
      */
-    async expect(
-        predicate: (el: ElementSnapshot) => boolean,
-        message?: string,
-    ): Promise<void> {
-        if (this.conditionalVisible) {
-            try {
-                const locator = await this.resolveLocator();
-                await locator.waitFor({ state: 'visible', timeout: this.visibilityTimeout });
-            } catch {
-                return;
-            }
-        }
-
-        const deadline = Date.now() + this.timeout;
-        const pollMs = 100;
-        let lastSnapshot: ElementSnapshot | null = null;
-        let lastError: unknown = null;
-
-        while (Date.now() < deadline) {
-            try {
-                lastSnapshot = await this.captureSnapshot();
-                if (predicate(lastSnapshot)) return;
-            } catch (err) {
-                lastError = err;
-            }
-            await new Promise(resolve => setTimeout(resolve, pollMs));
-        }
-
-        const header = message
-            ?? `expect() predicate failed on ${this.pageName}.${this.elementName} after ${this.timeout}ms`;
-        if (!lastSnapshot) {
-            const reason = lastError instanceof Error ? lastError.message : String(lastError ?? 'unknown');
-            throw new Error(`${header}\n  element could not be resolved: ${reason}`);
-        }
-        const snapshotJson = JSON.stringify(lastSnapshot, null, 2).replace(/^/gm, '    ');
-        throw new Error(`${header}\n  snapshot at timeout:\n${snapshotJson}`);
+    toBe(predicate: (el: ElementSnapshot) => boolean): PredicateAssertion {
+        return this.expectBuilder().toBe(predicate);
     }
 
     // -- Terminal actions: waiting --

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -404,14 +404,12 @@ export class ElementAction {
     async captureSnapshot(): Promise<ElementSnapshot> {
         const element = await this.resolve();
         const first = element.first();
-        // getAllAttributes is web-only; cast for this read.
-        const firstAsWeb = first as WebElement;
 
         const [count, rawText, value, attributes, visible, enabled] = await Promise.all([
             element.count().catch(() => 0),
             first.textContent().catch(() => null),
             first.inputValue().catch(() => ''),
-            firstAsWeb.getAllAttributes().catch(() => ({} as Record<string, string>)),
+            first.getAllAttributes().catch(() => ({} as Record<string, string>)),
             first.isVisible().catch(() => false),
             first.isEnabled().catch(() => false),
         ]);

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -28,7 +28,7 @@ function toLocator(element: Element): Locator {
  */
 export class ElementAction {
     private resolutionOptions: ElementResolutionOptions = {};
-    private timeout: number;
+    private _timeout: number;
     private conditionalVisible: boolean = false;
     private visibilityTimeout: number = 2000;
 
@@ -39,7 +39,21 @@ export class ElementAction {
         private interactions: ElementInteractions,
         private timeoutMs?: number,
     ) {
-        this.timeout = timeoutMs ?? 30000;
+        this._timeout = timeoutMs ?? 30000;
+    }
+
+    /**
+     * Override the retry timeout for any subsequent matcher or predicate call
+     * on this chain. Mutates self and returns `this` for fluent chaining —
+     * consistent with strategy selectors like `.first()` and `.nth()`.
+     *
+     * @example
+     * await steps.on('slowWidget', 'Page').timeout(5000).text.toBe('Ready');
+     * await steps.on('btn', 'Page').nth(2).timeout(1000).visible.toBeTrue();
+     */
+    timeout(ms: number): this {
+        this._timeout = ms;
+        return this;
     }
 
     // -- Strategy selectors --
@@ -149,21 +163,21 @@ export class ElementAction {
     async hover(): Promise<void> {
         if (!await this.shouldProceed()) return;
         const element = await this.resolve();
-        await element.action(this.timeout).hover();
+        await element.action(this._timeout).hover();
     }
 
     /** Clear and fill the resolved element with text. Skips silently if `ifVisible()` was set and element is hidden. */
     async fill(text: string): Promise<void> {
         if (!await this.shouldProceed()) return;
         const element = await this.resolve();
-        await element.action(this.timeout).fill(text);
+        await element.action(this._timeout).fill(text);
     }
 
     /** Scroll the resolved element into view. Skips silently if `ifVisible()` was set and element is hidden. */
     async scrollIntoView(): Promise<void> {
         if (!await this.shouldProceed()) return;
         const element = await this.resolve();
-        await element.action(this.timeout).scrollIntoView();
+        await element.action(this._timeout).scrollIntoView();
     }
 
     /** Select a dropdown option. */
@@ -176,20 +190,20 @@ export class ElementAction {
     async check(): Promise<void> {
         if (!await this.shouldProceed()) return;
         const element = await this.resolve();
-        await element.action(this.timeout).check();
+        await element.action(this._timeout).check();
     }
 
     /** Uncheck a checkbox. Skips silently if `ifVisible()` was set and element is hidden. */
     async uncheck(): Promise<void> {
         if (!await this.shouldProceed()) return;
         const element = await this.resolve();
-        await element.action(this.timeout).uncheck();
+        await element.action(this._timeout).uncheck();
     }
 
     /** Double-click the resolved element. */
     async doubleClick(): Promise<void> {
         const element = await this.resolve();
-        await element.action(this.timeout).doubleClick();
+        await element.action(this._timeout).doubleClick();
     }
 
     /** Right-click the resolved element. */
@@ -201,7 +215,7 @@ export class ElementAction {
     /** Type text character by character. */
     async typeSequentially(text: string, delay?: number): Promise<void> {
         const element = await this.resolve();
-        await element.action(this.timeout).pressSequentially(text, delay);
+        await element.action(this._timeout).pressSequentially(text, delay);
     }
 
     /** Upload a file to a file input. */
@@ -219,7 +233,7 @@ export class ElementAction {
     /** Clear the input value. */
     async clearInput(): Promise<void> {
         const element = await this.resolve();
-        await element.action(this.timeout).clear();
+        await element.action(this._timeout).clear();
     }
 
     /** Set slider value. */
@@ -239,13 +253,13 @@ export class ElementAction {
     /** Assert the element is visible. */
     async verifyPresence(): Promise<void> {
         const element = await this.resolve();
-        await element.action(this.timeout).verifyPresence();
+        await element.action(this._timeout).verifyPresence();
     }
 
     /** Assert the element is hidden or detached. */
     async verifyAbsence(): Promise<void> {
         const element = await this.resolve();
-        await element.action(this.timeout).verifyAbsence();
+        await element.action(this._timeout).verifyAbsence();
     }
 
     /** Assert the element's text content. If no expected text is given, asserts the element is not empty. */
@@ -258,20 +272,20 @@ export class ElementAction {
     /** Assert text contains a substring. */
     async verifyTextContains(expected: string): Promise<void> {
         const element = await this.resolve();
-        await element.action(this.timeout).verifyTextContains(expected);
+        await element.action(this._timeout).verifyTextContains(expected);
     }
 
     /** Assert the element count. */
     async verifyCount(options: CountVerifyOptions): Promise<void> {
         const element = await this.resolve();
-        await element.action(this.timeout).verifyCount(options);
+        await element.action(this._timeout).verifyCount(options);
     }
 
     /** Check if element is visible (boolean, no assertion). */
     async isPresent(): Promise<boolean> {
         try {
             const element = await this.resolve();
-            return await element.action(this.timeout).isPresent();
+            return await element.action(this._timeout).isPresent();
         } catch {
             return false;
         }
@@ -299,7 +313,7 @@ export class ElementAction {
     /** Assert an attribute value. */
     async verifyAttribute(attributeName: string, expectedValue: string): Promise<void> {
         const element = await this.resolve();
-        await element.action(this.timeout).verifyAttribute(attributeName, expectedValue);
+        await element.action(this._timeout).verifyAttribute(attributeName, expectedValue);
     }
 
     /** Assert input value. */
@@ -343,19 +357,19 @@ export class ElementAction {
     /** Get the text content of the resolved element. */
     async getText(): Promise<string | null> {
         const element = await this.resolve();
-        return element.action(this.timeout).getText();
+        return element.action(this._timeout).getText();
     }
 
     /** Get an attribute value. */
     async getAttribute(name: string): Promise<string | null> {
         const element = await this.resolve();
-        return element.action(this.timeout).getAttribute(name);
+        return element.action(this._timeout).getAttribute(name);
     }
 
     /** Get the count of matching elements. */
     async getCount(): Promise<number> {
         const element = await this.resolve();
-        return element.action(this.timeout).getCount();
+        return element.action(this._timeout).getCount();
     }
 
     /** Get all text contents from matching elements. */
@@ -367,7 +381,7 @@ export class ElementAction {
     /** Get input value. */
     async getInputValue(): Promise<string> {
         const element = await this.resolve();
-        return element.action(this.timeout).getInputValue();
+        return element.action(this._timeout).getInputValue();
     }
 
     /** Get computed CSS property value. */
@@ -418,7 +432,7 @@ export class ElementAction {
         return {
             elementName: this.elementName,
             pageName: this.pageName,
-            timeout: this.timeout,
+            timeout: this._timeout,
             conditionalVisible: this.conditionalVisible,
             visibilityTimeout: this.visibilityTimeout,
             resolveLocator: () => this.resolveLocator(),
@@ -474,6 +488,6 @@ export class ElementAction {
     /** Wait for the element to reach the specified state. */
     async waitForState(state: 'visible' | 'attached' | 'hidden' | 'detached' = 'visible'): Promise<void> {
         const element = await this.resolve();
-        await element.action(this.timeout).waitForState(state);
+        await element.action(this._timeout).waitForState(state);
     }
 }

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -404,12 +404,14 @@ export class ElementAction {
     async captureSnapshot(): Promise<ElementSnapshot> {
         const element = await this.resolve();
         const first = element.first();
+        // getAllAttributes is web-only; cast for this read.
+        const firstAsWeb = first as WebElement;
 
         const [count, rawText, value, attributes, visible, enabled] = await Promise.all([
             element.count().catch(() => 0),
             first.textContent().catch(() => null),
             first.inputValue().catch(() => ''),
-            first.getAllAttributes().catch(() => ({} as Record<string, string>)),
+            firstAsWeb.getAllAttributes().catch(() => ({} as Record<string, string>)),
             first.isVisible().catch(() => false),
             first.isEnabled().catch(() => false),
         ]);

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -2,6 +2,20 @@ import { Locator } from '@playwright/test';
 import { ElementRepository, Element, WebElement, ElementResolutionOptions, SelectionStrategy } from '@civitas-cerebrum/element-repository';
 import { ElementInteractions } from '../interactions/facade/ElementInteractions';
 import { DropdownSelectOptions, TextVerifyOptions, CountVerifyOptions, DragAndDropOptions, ScreenshotOptions, IsVisibleOptions } from '../enum/Options';
+import {
+    AttributesMatcher,
+    BooleanMatcher,
+    CountMatcher,
+    CssMatcher,
+    ElementSnapshot,
+    ExpectBuilder,
+    ExpectContext,
+    TextMatcher,
+    ValueMatcher,
+} from './ExpectMatchers';
+
+/** DOM Element alias — disambiguates from the repository's `Element` wrapper in callbacks that run inside Playwright's browser context. */
+type DomElement = globalThis.Element;
 
 function toLocator(element: Element): Locator {
     return (element as WebElement).locator;
@@ -373,47 +387,148 @@ export class ElementAction {
         return await this.interactions.extract.screenshot(locator, options);
     }
 
+    // -- Expect matcher tree + predicate escape hatch --
+
     /**
-     * Extracts a value from the element and asserts it matches the expected value.
+     * Captures a snapshot of the element's state at the current moment. Used
+     * by the matcher tree (`.text.toBe(...)`, `.count.toBeGreaterThan(...)`,
+     * etc.) and by the predicate form of `expect(...)`.
      *
-     * By default, compares against the element's text content. Use options to extract
-     * a specific attribute, input value, or CSS property instead.
-     *
-     * @param expected - The value to compare against.
-     * @param options.not - When true, asserts the extracted value does NOT equal the expected value.
-     * @param options.attribute - Extract the given HTML attribute (e.g. `'href'`, `'data-id'`).
-     * @param options.inputValue - Extract the input field's value instead of its text content.
-     * @param options.cssProperty - Extract the computed CSS property (e.g. `'color'`, `'font-size'`).
+     * Snapshot fields are all primitives — no async access needed in predicates.
+     */
+    async captureSnapshot(): Promise<ElementSnapshot> {
+        const locator = await this.resolveLocator();
+        const first = locator.first();
+
+        const [count, text, value, attributes, visible, enabled] = await Promise.all([
+            locator.count().catch(() => 0),
+            first.textContent().then(t => (t ?? '').trim()).catch(() => ''),
+            first.inputValue().catch(() => ''),
+            first.evaluate((el: DomElement) => {
+                const out: Record<string, string> = {};
+                for (const attr of Array.from(el.attributes)) {
+                    out[attr.name] = attr.value;
+                }
+                return out;
+            }).catch(() => ({} as Record<string, string>)),
+            first.isVisible().catch(() => false),
+            first.isEnabled().catch(() => false),
+        ]);
+
+        return { text, value, attributes, visible, enabled, count };
+    }
+
+    /** Build the context object consumed by the matcher tree classes. */
+    buildExpectContext(): ExpectContext {
+        return {
+            elementName: this.elementName,
+            pageName: this.pageName,
+            timeout: this.timeout,
+            conditionalVisible: this.conditionalVisible,
+            visibilityTimeout: this.visibilityTimeout,
+            resolveLocator: () => this.resolveLocator(),
+            captureSnapshot: () => this.captureSnapshot(),
+        };
+    }
+
+    /** Matcher entry for text content. */
+    get text(): TextMatcher {
+        return new TextMatcher(this.buildExpectContext());
+    }
+
+    /** Matcher entry for input value. */
+    get value(): ValueMatcher {
+        return new ValueMatcher(this.buildExpectContext());
+    }
+
+    /** Matcher entry for the count of matching elements. */
+    get count(): CountMatcher {
+        return new CountMatcher(this.buildExpectContext());
+    }
+
+    /** Matcher entry for visibility. */
+    get visible(): BooleanMatcher {
+        return new BooleanMatcher(this.buildExpectContext(), 'visible');
+    }
+
+    /** Matcher entry for enabled state. */
+    get enabled(): BooleanMatcher {
+        return new BooleanMatcher(this.buildExpectContext(), 'enabled');
+    }
+
+    /** Matcher entry for DOM attributes. */
+    get attributes(): AttributesMatcher {
+        return new AttributesMatcher(this.buildExpectContext());
+    }
+
+    /**
+     * Returns a negated matcher tree. Flip the expected outcome of any matcher
+     * reached from this object.
      *
      * @example
-     * await steps.on('title', 'Page').expect('Welcome');
-     * await steps.on('link', 'Page').expect('/dashboard', { attribute: 'href' });
-     * await steps.on('input', 'Page').expect('hello@example.com', { inputValue: true });
-     * await steps.on('banner', 'Page').expect('rgb(255, 0, 0)', { cssProperty: 'color' });
-     * await steps.on('price', 'Page').expect('$0.00', { not: true });
+     * await steps.on('error', 'Page').not.text.toContain('Error');
+     * await steps.on('submitBtn', 'Page').not.enabled.toBe(false);
+     */
+    get not(): ExpectBuilder {
+        return new ExpectBuilder(this.buildExpectContext(), true);
+    }
+
+    /** Matcher entry for a specific computed CSS property. */
+    css(property: string): CssMatcher {
+        return new CssMatcher(this.buildExpectContext(), property);
+    }
+
+    /**
+     * Predicate escape hatch for custom assertions the matcher tree doesn't
+     * cover. Runs the predicate against a fresh snapshot on every retry until
+     * the predicate returns `true` or the element timeout expires.
+     *
+     * @param predicate - Function receiving an `ElementSnapshot` that returns
+     *   `true` when the assertion holds.
+     * @param message - Optional custom error message shown on failure.
+     *
+     * @example
+     * await steps.on('price', 'ProductPage').expect(
+     *   el => parseFloat(el.text.slice(1)) > 10,
+     *   'price must be above $10'
+     * );
      */
     async expect(
-        expected: string | null,
-        options?: { not?: boolean; attribute?: string; inputValue?: boolean; cssProperty?: string }
+        predicate: (el: ElementSnapshot) => boolean,
+        message?: string,
     ): Promise<void> {
-        const locator = await this.resolveLocator();
-        let actual: string | null;
-
-        if (options?.attribute) {
-            actual = await this.interactions.extract.getAttribute(locator, options.attribute);
-        } else if (options?.inputValue) {
-            actual = await this.interactions.extract.getInputValue(locator);
-        } else if (options?.cssProperty) {
-            actual = await this.interactions.extract.getCssProperty(locator, options.cssProperty);
-        } else {
-            actual = await this.interactions.extract.getText(locator);
+        if (this.conditionalVisible) {
+            try {
+                const locator = await this.resolveLocator();
+                await locator.waitFor({ state: 'visible', timeout: this.visibilityTimeout });
+            } catch {
+                return;
+            }
         }
 
-        if (options?.not) {
-            this.interactions.verify.expectNotEqual(actual, expected);
-        } else {
-            this.interactions.verify.expectEqual(actual, expected);
+        const deadline = Date.now() + this.timeout;
+        const pollMs = 100;
+        let lastSnapshot: ElementSnapshot | null = null;
+        let lastError: unknown = null;
+
+        while (Date.now() < deadline) {
+            try {
+                lastSnapshot = await this.captureSnapshot();
+                if (predicate(lastSnapshot)) return;
+            } catch (err) {
+                lastError = err;
+            }
+            await new Promise(resolve => setTimeout(resolve, pollMs));
         }
+
+        const header = message
+            ?? `expect() predicate failed on ${this.pageName}.${this.elementName} after ${this.timeout}ms`;
+        if (!lastSnapshot) {
+            const reason = lastError instanceof Error ? lastError.message : String(lastError ?? 'unknown');
+            throw new Error(`${header}\n  element could not be resolved: ${reason}`);
+        }
+        const snapshotJson = JSON.stringify(lastSnapshot, null, 2).replace(/^/gm, '    ');
+        throw new Error(`${header}\n  snapshot at timeout:\n${snapshotJson}`);
     }
 
     // -- Terminal actions: waiting --

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -6,7 +6,6 @@ import {
     ElementSnapshot,
     ExpectBuilder,
     ExpectContext,
-    PredicateAssertion,
 } from './ExpectMatchers';
 
 /** DOM Element alias — disambiguates from the repository's `Element` wrapper in callbacks that run inside Playwright's browser context. */
@@ -471,15 +470,16 @@ export class ElementAction {
     }
 
     /**
-     * Predicate escape hatch. Returns a chainable, awaitable assertion that
-     * passes when the predicate returns `true`. Use `.throws(message)` to
-     * override the failure message.
+     * Predicate escape hatch. Queues a custom predicate assertion and returns
+     * the chain builder so more matchers can follow. End the chain with
+     * `.throws(message)` to override the failure message.
      *
      * @example
-     * await steps.on('price', 'ProductPage').toBe(el => parseFloat(el.text.slice(1)) > 10)
+     * await steps.on('price', 'ProductPage')
+     *   .toBe(el => parseFloat(el.text.slice(1)) > 10)
      *   .throws('price must be above $10');
      */
-    toBe(predicate: (el: ElementSnapshot) => boolean): PredicateAssertion {
+    toBe(predicate: (el: ElementSnapshot) => boolean): ExpectBuilder {
         return this.expectBuilder().toBe(predicate);
     }
 

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -404,12 +404,14 @@ export class ElementAction {
     async captureSnapshot(): Promise<ElementSnapshot> {
         const element = await this.resolve();
         const first = element.first();
+        // getAllAttributes is web-only (DOM iteration); narrow for that one read.
+        const firstAsWeb = first as WebElement;
 
         const [count, rawText, value, attributes, visible, enabled] = await Promise.all([
             element.count().catch(() => 0),
             first.textContent().catch(() => null),
             first.inputValue().catch(() => ''),
-            first.getAllAttributes().catch(() => ({} as Record<string, string>)),
+            firstAsWeb.getAllAttributes().catch(() => ({} as Record<string, string>)),
             first.isVisible().catch(() => false),
             first.isEnabled().catch(() => false),
         ]);

--- a/src/steps/ExpectMatchers.ts
+++ b/src/steps/ExpectMatchers.ts
@@ -55,6 +55,20 @@ function describeFailure(
 abstract class BaseMatcher {
     constructor(protected ctx: ExpectContext, protected negated: boolean = false) {}
 
+    /** Subclasses clone themselves with a new context (used by `timeout()`). */
+    protected abstract withCtx(ctx: ExpectContext): this;
+
+    /**
+     * Override the retry timeout for this matcher call. Returns a new matcher
+     * instance with the timeout replaced — does not mutate the original.
+     *
+     * @example
+     * await steps.expect('el', 'Page').text.timeout(5000).toBe('Ready');
+     */
+    timeout(ms: number): this {
+        return this.withCtx({ ...this.ctx, timeout: ms });
+    }
+
     protected async honorIfVisibleGate(): Promise<boolean> {
         if (!this.ctx.conditionalVisible) return true;
         try {
@@ -168,6 +182,9 @@ export class TextMatcher extends StringMatcher {
     get not(): TextMatcher {
         return new TextMatcher(this.ctx, !this.negated);
     }
+    protected withCtx(ctx: ExpectContext): this {
+        return new TextMatcher(ctx, this.negated) as this;
+    }
     protected fieldLabel(): string { return 'text'; }
     protected read(snap: ElementSnapshot): string { return snap.text; }
 }
@@ -175,6 +192,9 @@ export class TextMatcher extends StringMatcher {
 export class ValueMatcher extends StringMatcher {
     get not(): ValueMatcher {
         return new ValueMatcher(this.ctx, !this.negated);
+    }
+    protected withCtx(ctx: ExpectContext): this {
+        return new ValueMatcher(ctx, this.negated) as this;
     }
     protected fieldLabel(): string { return 'value'; }
     protected read(snap: ElementSnapshot): string { return snap.value; }
@@ -187,6 +207,9 @@ export class AttributeMatcher extends StringMatcher {
     get not(): AttributeMatcher {
         return new AttributeMatcher(this.ctx, this.attrName, !this.negated);
     }
+    protected withCtx(ctx: ExpectContext): this {
+        return new AttributeMatcher(ctx, this.attrName, this.negated) as this;
+    }
     protected fieldLabel(): string { return `attribute "${this.attrName}"`; }
     protected read(snap: ElementSnapshot): string { return snap.attributes[this.attrName] ?? ''; }
 }
@@ -194,6 +217,9 @@ export class AttributeMatcher extends StringMatcher {
 export class CountMatcher extends BaseMatcher {
     get not(): CountMatcher {
         return new CountMatcher(this.ctx, !this.negated);
+    }
+    protected withCtx(ctx: ExpectContext): this {
+        return new CountMatcher(ctx, this.negated) as this;
     }
 
     async toBe(expected: number): Promise<void> {
@@ -242,6 +268,9 @@ export class BooleanMatcher extends BaseMatcher {
     get not(): BooleanMatcher {
         return new BooleanMatcher(this.ctx, this.field, !this.negated);
     }
+    protected withCtx(ctx: ExpectContext): this {
+        return new BooleanMatcher(ctx, this.field, this.negated) as this;
+    }
 
     async toBe(expected: boolean): Promise<void> {
         await this.assertSnapshot(
@@ -257,6 +286,9 @@ export class BooleanMatcher extends BaseMatcher {
 export class AttributesMatcher extends BaseMatcher {
     get not(): AttributesMatcher {
         return new AttributesMatcher(this.ctx, !this.negated);
+    }
+    protected withCtx(ctx: ExpectContext): this {
+        return new AttributesMatcher(ctx, this.negated) as this;
     }
 
     get(name: string): AttributeMatcher {
@@ -279,6 +311,9 @@ export class CssMatcher extends BaseMatcher {
 
     get not(): CssMatcher {
         return new CssMatcher(this.ctx, this.property, !this.negated);
+    }
+    protected withCtx(ctx: ExpectContext): this {
+        return new CssMatcher(ctx, this.property, this.negated) as this;
     }
 
     private async runCss(
@@ -326,6 +361,11 @@ export class PredicateAssertion implements PromiseLike<void> {
     /** Override the error message shown when the predicate fails. */
     throws(message: string): PredicateAssertion {
         return new PredicateAssertion(this.ctx, this.predicate, this.negated, message);
+    }
+
+    /** Override the retry timeout for this predicate assertion. */
+    timeout(ms: number): PredicateAssertion {
+        return new PredicateAssertion({ ...this.ctx, timeout: ms }, this.predicate, this.negated, this.message);
     }
 
     then<TResult1 = void, TResult2 = never>(
@@ -381,6 +421,19 @@ export class ExpectBuilder {
 
     get not(): ExpectBuilder {
         return new ExpectBuilder(this.ctx, !this.negated);
+    }
+
+    /**
+     * Override the retry timeout for the matchers reached from this builder.
+     * Composes anywhere in the chain — before `.not`, after `.not`, before any
+     * field matcher. Returns a new builder with the override.
+     *
+     * @example
+     * await steps.expect('slow', 'Page').timeout(5000).text.toBe('Ready');
+     * await steps.expect('slow', 'Page').not.timeout(1000).visible.toBeTrue();
+     */
+    timeout(ms: number): ExpectBuilder {
+        return new ExpectBuilder({ ...this.ctx, timeout: ms }, this.negated);
     }
 
     get text(): TextMatcher { return new TextMatcher(this.ctx, this.negated); }

--- a/src/steps/ExpectMatchers.ts
+++ b/src/steps/ExpectMatchers.ts
@@ -1,4 +1,4 @@
-import { Element } from '@civitas-cerebrum/element-repository';
+import { Element, WebElement } from '@civitas-cerebrum/element-repository';
 
 /**
  * Snapshot of an element's state at a single point in time.
@@ -359,7 +359,8 @@ export class CssMatcher extends BaseMatcher {
             return assertWithLiveRead(
                 entry.ctx, negated,
                 async () => {
-                    const element = await entry.ctx.resolveElement();
+                    // getCssProperty is web-only; narrow to WebElement.
+                    const element = (await entry.ctx.resolveElement()) as WebElement;
                     lastValue = await element.getCssProperty(property);
                     return test(lastValue);
                 },

--- a/src/steps/ExpectMatchers.ts
+++ b/src/steps/ExpectMatchers.ts
@@ -1,11 +1,11 @@
-import { Locator } from '@playwright/test';
+import { Element } from '@civitas-cerebrum/element-repository';
 
 /**
  * Snapshot of an element's state at a single point in time.
  *
- * Passed to predicates in `steps.expect(el, page).toBe(predicate)` and
- * `steps.on(el, page).toBe(predicate)`. All fields are primitives or plain
- * data — no async methods, no Playwright types.
+ * Passed to predicates in `steps.on(el, page).toBe(predicate)` and
+ * `steps.expect(el, page).toBe(predicate)`. All fields are primitives or
+ * plain data — no async methods, no Playwright types.
  */
 export interface ElementSnapshot {
     readonly text: string;
@@ -17,10 +17,9 @@ export interface ElementSnapshot {
 }
 
 /**
- * Minimal surface the matcher tree needs from its host (typically an
- * `ElementAction`). Decouples matchers from `ElementAction` so the matcher
- * tree can be constructed from either the fluent builder or a top-level
- * `Steps.expect()` call.
+ * Surface the matcher tree needs from its host (typically an `ElementAction`).
+ * Decouples matchers from `ElementAction` so the builder can be constructed
+ * from either the fluent entry or the top-level `Steps.expect()` call.
  */
 export interface ExpectContext {
     readonly elementName: string;
@@ -28,26 +27,23 @@ export interface ExpectContext {
     readonly timeout: number;
     readonly conditionalVisible: boolean;
     readonly visibilityTimeout: number;
-    resolveLocator(): Promise<Locator>;
+    resolveElement(): Promise<Element>;
     captureSnapshot(): Promise<ElementSnapshot>;
 }
 
 /** One assertion queued on an `ExpectBuilder`. Executes when the builder is awaited. */
 interface QueuedAssertion {
-    /** The ctx snapshot captured when this assertion was queued. */
+    /** Ctx captured when enqueued; mutable so `.timeout()` / `.throws()` can retroactively update it. */
     ctx: ExpectContext;
-    /** Executes the assertion; may throw on failure. */
+    /** Runs the assertion; may throw on failure. Replaced with a concrete executor at enqueue time. */
     run(): Promise<void>;
-    /** Optional message that replaces the default failure header. */
+    /** Optional custom message that replaces the default failure header. */
     messageOverride?: string;
 }
 
-async function readCssProperty(locator: Locator, property: string): Promise<string> {
-    return locator.evaluate(
-        (el, prop) => window.getComputedStyle(el as Element).getPropertyValue(prop),
-        property,
-    );
-}
+// ─── Shared helpers ──────────────────────────────────────────────────
+
+const POLL_MS = 100;
 
 function describeFailure(
     ctx: ExpectContext,
@@ -65,14 +61,15 @@ function describeFailure(
 async function honorIfVisibleGate(ctx: ExpectContext): Promise<boolean> {
     if (!ctx.conditionalVisible) return true;
     try {
-        const locator = await ctx.resolveLocator();
-        await locator.waitFor({ state: 'visible', timeout: ctx.visibilityTimeout });
+        const element = await ctx.resolveElement();
+        await element.waitFor({ state: 'visible', timeout: ctx.visibilityTimeout });
         return true;
     } catch {
         return false;
     }
 }
 
+/** Retry-and-assert against a captured snapshot. Honors `ifVisible` gate. */
 async function assertWithSnapshot(
     ctx: ExpectContext,
     negated: boolean,
@@ -83,7 +80,6 @@ async function assertWithSnapshot(
     if (!(await honorIfVisibleGate(ctx))) return;
 
     const deadline = Date.now() + ctx.timeout;
-    const pollMs = 100;
     let lastSnapshot: ElementSnapshot | null = null;
     let lastError: unknown = null;
 
@@ -94,7 +90,7 @@ async function assertWithSnapshot(
         } catch (err) {
             lastError = err;
         }
-        await new Promise(resolve => setTimeout(resolve, pollMs));
+        await new Promise(resolve => setTimeout(resolve, POLL_MS));
     }
 
     if (!lastSnapshot) {
@@ -106,6 +102,7 @@ async function assertWithSnapshot(
     throw new Error(messageOverride ?? describe(lastSnapshot, negated));
 }
 
+/** Retry-and-assert against a live-read boolean evaluation. Honors `ifVisible` gate. */
 async function assertWithLiveRead(
     ctx: ExpectContext,
     negated: boolean,
@@ -116,7 +113,6 @@ async function assertWithLiveRead(
     if (!(await honorIfVisibleGate(ctx))) return;
 
     const deadline = Date.now() + ctx.timeout;
-    const pollMs = 100;
 
     while (Date.now() < deadline) {
         try {
@@ -124,12 +120,13 @@ async function assertWithLiveRead(
         } catch {
             // swallow and retry
         }
-        await new Promise(resolve => setTimeout(resolve, pollMs));
+        await new Promise(resolve => setTimeout(resolve, POLL_MS));
     }
 
     throw new Error(messageOverride ?? describe(negated));
 }
 
+/** Predicate-specific failure path — prints the captured snapshot for debugging. */
 async function assertPredicate(
     ctx: ExpectContext,
     negated: boolean,
@@ -139,7 +136,6 @@ async function assertPredicate(
     if (!(await honorIfVisibleGate(ctx))) return;
 
     const deadline = Date.now() + ctx.timeout;
-    const pollMs = 100;
     let lastSnapshot: ElementSnapshot | null = null;
     let lastError: unknown = null;
 
@@ -150,7 +146,7 @@ async function assertPredicate(
         } catch (err) {
             lastError = err;
         }
-        await new Promise(resolve => setTimeout(resolve, pollMs));
+        await new Promise(resolve => setTimeout(resolve, POLL_MS));
     }
 
     const header = messageOverride
@@ -163,28 +159,39 @@ async function assertPredicate(
     throw new Error(`${header}\n  snapshot at timeout:\n${snapshotJson}`);
 }
 
-// ─── Matcher adapters ────────────────────────────────────────────────
-//
-// These are lightweight wrappers exposed via getters on `ExpectBuilder`.
-// Each terminal method captures the builder's context + negation at the time
-// of the call, enqueues the assertion onto the builder, and returns the
-// builder so the chain can continue.
+// ─── Matcher base class ──────────────────────────────────────────────
 
-abstract class StringMatcher {
+/**
+ * Shared shape for all field matchers. Concrete subclasses provide:
+ *   - `withCtx(ctx)`  → clone with replaced context (used by `timeout(ms)`)
+ *   - `withNegated(n)` → clone with flipped negation (used by `get not()`)
+ *
+ * `timeout(ms)` and `get not()` then live on this base, not duplicated across
+ * every concrete matcher.
+ */
+abstract class BaseMatcher {
     constructor(
         protected builder: ExpectBuilder,
         protected ctx: ExpectContext,
         protected negated: boolean,
     ) {}
 
+    protected abstract withCtx(ctx: ExpectContext): this;
+    protected abstract withNegated(negated: boolean): this;
+
     /** Override the retry timeout for this matcher only. */
     timeout(ms: number): this {
-        const cloned = Object.create(Object.getPrototypeOf(this)) as StringMatcher;
-        Object.assign(cloned, this);
-        cloned.ctx = { ...this.ctx, timeout: ms };
-        return cloned as this;
+        return this.withCtx({ ...this.ctx, timeout: ms });
     }
 
+    /** Flip the expected outcome of this matcher. */
+    get not(): this {
+        return this.withNegated(!this.negated);
+    }
+}
+
+/** Shared string-matcher surface: text / value / attribute / (css uses its own live-read). */
+abstract class StringMatcher extends BaseMatcher {
     protected abstract fieldLabel(): string;
     protected abstract read(snap: ElementSnapshot): string;
 
@@ -194,28 +201,24 @@ abstract class StringMatcher {
             (s, n) => describeFailure(this.ctx, this.fieldLabel(), 'to be', expected, this.read(s), n),
         );
     }
-
     toContain(expected: string): ExpectBuilder {
         return this.enqueue(
             s => this.read(s).includes(expected),
             (s, n) => describeFailure(this.ctx, this.fieldLabel(), 'to contain', expected, this.read(s), n),
         );
     }
-
     toMatch(re: RegExp): ExpectBuilder {
         return this.enqueue(
             s => re.test(this.read(s)),
             (s, n) => describeFailure(this.ctx, this.fieldLabel(), 'to match', re, this.read(s), n),
         );
     }
-
     toStartWith(prefix: string): ExpectBuilder {
         return this.enqueue(
             s => this.read(s).startsWith(prefix),
             (s, n) => describeFailure(this.ctx, this.fieldLabel(), 'to start with', prefix, this.read(s), n),
         );
     }
-
     toEndWith(suffix: string): ExpectBuilder {
         return this.enqueue(
             s => this.read(s).endsWith(suffix),
@@ -228,19 +231,24 @@ abstract class StringMatcher {
         describe: (snap: ElementSnapshot, negated: boolean) => string,
     ): ExpectBuilder {
         const negated = this.negated;
-        return this.builder.enqueue({ ctx: this.ctx, run: () => undefined as unknown as Promise<void> },
-            entry => assertWithSnapshot(entry.ctx, negated, predicate, describe, entry.messageOverride));
+        return this.builder.enqueue(this.ctx, (entry) =>
+            assertWithSnapshot(entry.ctx, negated, predicate, describe, entry.messageOverride),
+        );
     }
 }
 
+// ─── Concrete field matchers ─────────────────────────────────────────
+
 export class TextMatcher extends StringMatcher {
-    get not(): TextMatcher { return new TextMatcher(this.builder, this.ctx, !this.negated); }
+    protected withCtx(ctx: ExpectContext): this { return new TextMatcher(this.builder, ctx, this.negated) as this; }
+    protected withNegated(negated: boolean): this { return new TextMatcher(this.builder, this.ctx, negated) as this; }
     protected fieldLabel(): string { return 'text'; }
     protected read(snap: ElementSnapshot): string { return snap.text; }
 }
 
 export class ValueMatcher extends StringMatcher {
-    get not(): ValueMatcher { return new ValueMatcher(this.builder, this.ctx, !this.negated); }
+    protected withCtx(ctx: ExpectContext): this { return new ValueMatcher(this.builder, ctx, this.negated) as this; }
+    protected withNegated(negated: boolean): this { return new ValueMatcher(this.builder, this.ctx, negated) as this; }
     protected fieldLabel(): string { return 'value'; }
     protected read(snap: ElementSnapshot): string { return snap.value; }
 }
@@ -249,128 +257,80 @@ export class AttributeMatcher extends StringMatcher {
     constructor(builder: ExpectBuilder, ctx: ExpectContext, private attrName: string, negated: boolean) {
         super(builder, ctx, negated);
     }
-    get not(): AttributeMatcher { return new AttributeMatcher(this.builder, this.ctx, this.attrName, !this.negated); }
+    protected withCtx(ctx: ExpectContext): this { return new AttributeMatcher(this.builder, ctx, this.attrName, this.negated) as this; }
+    protected withNegated(negated: boolean): this { return new AttributeMatcher(this.builder, this.ctx, this.attrName, negated) as this; }
     protected fieldLabel(): string { return `attribute "${this.attrName}"`; }
     protected read(snap: ElementSnapshot): string { return snap.attributes[this.attrName] ?? ''; }
 }
 
-export class CountMatcher {
-    constructor(
-        private builder: ExpectBuilder,
-        private ctx: ExpectContext,
-        private negated: boolean,
-    ) {}
-
-    get not(): CountMatcher {
-        return new CountMatcher(this.builder, this.ctx, !this.negated);
-    }
-
-    timeout(ms: number): CountMatcher {
-        return new CountMatcher(this.builder, { ...this.ctx, timeout: ms }, this.negated);
-    }
+export class CountMatcher extends BaseMatcher {
+    protected withCtx(ctx: ExpectContext): this { return new CountMatcher(this.builder, ctx, this.negated) as this; }
+    protected withNegated(negated: boolean): this { return new CountMatcher(this.builder, this.ctx, negated) as this; }
 
     toBe(expected: number): ExpectBuilder {
-        return this.enqueue(
-            s => s.count === expected,
-            (s, n) => describeFailure(this.ctx, 'count', 'to be', expected, s.count, n),
-        );
+        return this.enqueue(s => s.count === expected, 'to be', expected);
     }
-
     toBeGreaterThan(n: number): ExpectBuilder {
-        return this.enqueue(
-            s => s.count > n,
-            (s, neg) => describeFailure(this.ctx, 'count', 'to be greater than', n, s.count, neg),
-        );
+        return this.enqueue(s => s.count > n, 'to be greater than', n);
     }
-
     toBeLessThan(n: number): ExpectBuilder {
-        return this.enqueue(
-            s => s.count < n,
-            (s, neg) => describeFailure(this.ctx, 'count', 'to be less than', n, s.count, neg),
-        );
+        return this.enqueue(s => s.count < n, 'to be less than', n);
     }
-
     toBeGreaterThanOrEqual(n: number): ExpectBuilder {
-        return this.enqueue(
-            s => s.count >= n,
-            (s, neg) => describeFailure(this.ctx, 'count', 'to be greater than or equal to', n, s.count, neg),
-        );
+        return this.enqueue(s => s.count >= n, 'to be greater than or equal to', n);
     }
-
     toBeLessThanOrEqual(n: number): ExpectBuilder {
-        return this.enqueue(
-            s => s.count <= n,
-            (s, neg) => describeFailure(this.ctx, 'count', 'to be less than or equal to', n, s.count, neg),
-        );
+        return this.enqueue(s => s.count <= n, 'to be less than or equal to', n);
     }
 
-    private enqueue(
-        predicate: (snap: ElementSnapshot) => boolean,
-        describe: (snap: ElementSnapshot, negated: boolean) => string,
-    ): ExpectBuilder {
+    private enqueue(predicate: (s: ElementSnapshot) => boolean, verb: string, expected: number): ExpectBuilder {
         const negated = this.negated;
-        return this.builder.enqueue({ ctx: this.ctx, run: () => undefined as unknown as Promise<void> },
-            entry => assertWithSnapshot(entry.ctx, negated, predicate, describe, entry.messageOverride));
+        return this.builder.enqueue(this.ctx, (entry) =>
+            assertWithSnapshot(
+                entry.ctx, negated, predicate,
+                (s, n) => describeFailure(entry.ctx, 'count', verb, expected, s.count, n),
+                entry.messageOverride,
+            ));
     }
 }
 
 type BooleanField = 'visible' | 'enabled';
 
-export class BooleanMatcher {
-    constructor(
-        private builder: ExpectBuilder,
-        private ctx: ExpectContext,
-        private field: BooleanField,
-        private negated: boolean,
-    ) {}
-
-    get not(): BooleanMatcher {
-        return new BooleanMatcher(this.builder, this.ctx, this.field, !this.negated);
+export class BooleanMatcher extends BaseMatcher {
+    constructor(builder: ExpectBuilder, ctx: ExpectContext, private field: BooleanField, negated: boolean) {
+        super(builder, ctx, negated);
     }
-
-    timeout(ms: number): BooleanMatcher {
-        return new BooleanMatcher(this.builder, { ...this.ctx, timeout: ms }, this.field, this.negated);
-    }
+    protected withCtx(ctx: ExpectContext): this { return new BooleanMatcher(this.builder, ctx, this.field, this.negated) as this; }
+    protected withNegated(negated: boolean): this { return new BooleanMatcher(this.builder, this.ctx, this.field, negated) as this; }
 
     toBe(expected: boolean): ExpectBuilder {
         const negated = this.negated;
         const field = this.field;
-        return this.builder.enqueue({ ctx: this.ctx, run: () => undefined as unknown as Promise<void> },
-            entry => assertWithSnapshot(
+        return this.builder.enqueue(this.ctx, (entry) =>
+            assertWithSnapshot(
                 entry.ctx, negated,
                 s => s[field] === expected,
                 (s, n) => describeFailure(entry.ctx, field, 'to be', expected, s[field], n),
                 entry.messageOverride,
             ));
     }
-
     toBeTrue(): ExpectBuilder { return this.toBe(true); }
     toBeFalse(): ExpectBuilder { return this.toBe(false); }
 }
 
-export class AttributesMatcher {
-    constructor(
-        private builder: ExpectBuilder,
-        private ctx: ExpectContext,
-        private negated: boolean,
-    ) {}
+export class AttributesMatcher extends BaseMatcher {
+    protected withCtx(ctx: ExpectContext): this { return new AttributesMatcher(this.builder, ctx, this.negated) as this; }
+    protected withNegated(negated: boolean): this { return new AttributesMatcher(this.builder, this.ctx, negated) as this; }
 
-    get not(): AttributesMatcher {
-        return new AttributesMatcher(this.builder, this.ctx, !this.negated);
-    }
-
-    timeout(ms: number): AttributesMatcher {
-        return new AttributesMatcher(this.builder, { ...this.ctx, timeout: ms }, this.negated);
-    }
-
+    /** Navigate into a specific attribute. The resulting matcher supports the full string-matcher surface. */
     get(name: string): AttributeMatcher {
         return new AttributeMatcher(this.builder, this.ctx, name, this.negated);
     }
 
     toHaveKey(name: string): ExpectBuilder {
         const negated = this.negated;
-        return this.builder.enqueue({ ctx: this.ctx, run: () => undefined as unknown as Promise<void> },
-            entry => assertWithSnapshot(
+        return this.builder.enqueue(this.ctx, (entry) =>
+            assertWithSnapshot(
                 entry.ctx, negated,
                 s => name in s.attributes,
                 (s, n) =>
@@ -380,21 +340,12 @@ export class AttributesMatcher {
     }
 }
 
-export class CssMatcher {
-    constructor(
-        private builder: ExpectBuilder,
-        private ctx: ExpectContext,
-        private property: string,
-        private negated: boolean,
-    ) {}
-
-    get not(): CssMatcher {
-        return new CssMatcher(this.builder, this.ctx, this.property, !this.negated);
+export class CssMatcher extends BaseMatcher {
+    constructor(builder: ExpectBuilder, ctx: ExpectContext, private property: string, negated: boolean) {
+        super(builder, ctx, negated);
     }
-
-    timeout(ms: number): CssMatcher {
-        return new CssMatcher(this.builder, { ...this.ctx, timeout: ms }, this.property, this.negated);
-    }
+    protected withCtx(ctx: ExpectContext): this { return new CssMatcher(this.builder, ctx, this.property, this.negated) as this; }
+    protected withNegated(negated: boolean): this { return new CssMatcher(this.builder, this.ctx, this.property, negated) as this; }
 
     toBe(expected: string): ExpectBuilder { return this.enqueue(v => v === expected, 'to be', expected); }
     toContain(expected: string): ExpectBuilder { return this.enqueue(v => v.includes(expected), 'to contain', expected); }
@@ -403,28 +354,29 @@ export class CssMatcher {
     private enqueue(test: (value: string) => boolean, verb: string, expected: unknown): ExpectBuilder {
         const negated = this.negated;
         const property = this.property;
-        return this.builder.enqueue({ ctx: this.ctx, run: () => undefined as unknown as Promise<void> },
-            entry => {
-                let lastValue = '';
-                return assertWithLiveRead(
-                    entry.ctx, negated,
-                    async () => {
-                        const locator = await entry.ctx.resolveLocator();
-                        lastValue = await readCssProperty(locator, property);
-                        return test(lastValue);
-                    },
-                    n => describeFailure(entry.ctx, `css "${property}"`, verb, expected, lastValue, n),
-                    entry.messageOverride,
-                );
-            });
+        return this.builder.enqueue(this.ctx, (entry) => {
+            let lastValue = '';
+            return assertWithLiveRead(
+                entry.ctx, negated,
+                async () => {
+                    const element = await entry.ctx.resolveElement();
+                    lastValue = await element.getCssProperty(property);
+                    return test(lastValue);
+                },
+                n => describeFailure(entry.ctx, `css "${property}"`, verb, expected, lastValue, n),
+                entry.messageOverride,
+            );
+        });
     }
 }
+
+// ─── The builder ─────────────────────────────────────────────────────
 
 /**
  * Root of the matcher tree and the queue-backed chain builder.
  *
- * Every matcher call enqueues an assertion and returns this builder, so you
- * can chain multiple verifications in one expression:
+ * Every matcher call enqueues an assertion and returns the builder so chains
+ * of multiple verifications are expressed in one await-able expression:
  *
  * ```ts
  * await steps.on('submitBtn', 'CheckoutPage')
@@ -434,15 +386,15 @@ export class CssMatcher {
  *   .visible.toBeTrue();
  * ```
  *
- * The builder is a `PromiseLike<void>` — awaiting it executes every queued
- * assertion in the order they were added, short-circuiting on the first
- * failure (the await throws, subsequent queued assertions do not run).
- *
- * - `.not` toggles negation for the *next* matcher only (one-shot).
- * - `.throws(message)` overrides the failure message of the most recently
- *   queued assertion.
- * - `.timeout(ms)` mutates the builder's ctx, affecting every matcher that
- *   runs after it. Per-matcher `.timeout(ms)` applies only to that matcher.
+ * Semantics:
+ *   - `.not` toggles negation for the *next* matcher only (one-shot).
+ *   - `.throws(message)` replaces the failure message of the most recently
+ *     queued assertion.
+ *   - `.timeout(ms)` mutates the forward context AND retroactively updates
+ *     the most recently queued assertion. Per-matcher `.timeout(ms)`
+ *     (e.g. `.text.timeout(500).toBe(...)`) scopes to that matcher only.
+ *   - Awaiting executes every queued assertion sequentially; the first
+ *     failure throws and subsequent assertions do not run.
  */
 export class ExpectBuilder implements PromiseLike<void> {
     private ctx: ExpectContext;
@@ -454,27 +406,17 @@ export class ExpectBuilder implements PromiseLike<void> {
         this.pendingNot = initialNegated;
     }
 
-    /** One-shot negation. Flips the expected outcome of the *next* matcher only. */
+    /** One-shot negation for the next matcher reached from this builder. */
     get not(): this {
         this.pendingNot = !this.pendingNot;
         return this;
     }
 
-    private consumeNegation(): boolean {
-        const n = this.pendingNot;
-        this.pendingNot = false;
-        return n;
-    }
-
     /**
-     * Override the retry timeout. Mutates the builder's context so every
-     * matcher queued after this point runs with the new timeout, and also
-     * updates the most recently queued assertion so positioning like
-     * `.toBe(pred).timeout(500)` still scopes to that predicate.
-     *
-     * Per-matcher `.timeout(ms)` (e.g. `.text.timeout(500).toBe(...)`) remains
-     * the right choice when you want the override to apply only to the next
-     * matcher without leaking to assertions queued after it.
+     * Override the retry timeout. Mutates the forward context so every matcher
+     * queued after this call uses the new timeout; retroactively updates the
+     * most recently queued assertion so trailing `.toBe(pred).timeout(ms)`
+     * scopes to that predicate.
      */
     timeout(ms: number): this {
         this.ctx = { ...this.ctx, timeout: ms };
@@ -483,25 +425,24 @@ export class ExpectBuilder implements PromiseLike<void> {
         return this;
     }
 
-    // Field matcher getters — each consumes a pending .not and carries it
-    // into the matcher that is about to be constructed.
-    get text(): TextMatcher { return new TextMatcher(this, this.ctx, this.consumeNegation()); }
-    get value(): ValueMatcher { return new ValueMatcher(this, this.ctx, this.consumeNegation()); }
-    get count(): CountMatcher { return new CountMatcher(this, this.ctx, this.consumeNegation()); }
-    get visible(): BooleanMatcher { return new BooleanMatcher(this, this.ctx, 'visible', this.consumeNegation()); }
-    get enabled(): BooleanMatcher { return new BooleanMatcher(this, this.ctx, 'enabled', this.consumeNegation()); }
-    get attributes(): AttributesMatcher { return new AttributesMatcher(this, this.ctx, this.consumeNegation()); }
-    css(property: string): CssMatcher { return new CssMatcher(this, this.ctx, property, this.consumeNegation()); }
+    get text(): TextMatcher { return new TextMatcher(this, this.ctx, this.consumeNot()); }
+    get value(): ValueMatcher { return new ValueMatcher(this, this.ctx, this.consumeNot()); }
+    get count(): CountMatcher { return new CountMatcher(this, this.ctx, this.consumeNot()); }
+    get visible(): BooleanMatcher { return new BooleanMatcher(this, this.ctx, 'visible', this.consumeNot()); }
+    get enabled(): BooleanMatcher { return new BooleanMatcher(this, this.ctx, 'enabled', this.consumeNot()); }
+    get attributes(): AttributesMatcher { return new AttributesMatcher(this, this.ctx, this.consumeNot()); }
+    css(property: string): CssMatcher { return new CssMatcher(this, this.ctx, property, this.consumeNot()); }
 
     /**
      * Predicate escape hatch. Queues a custom predicate assertion on this
-     * builder. Chain further matchers or end with `.throws(message)` to
+     * builder. Chain further matchers or finish with `.throws(message)` to
      * override the failure message.
      */
     toBe(predicate: (el: ElementSnapshot) => boolean): this {
-        const negated = this.consumeNegation();
-        this.enqueue({ ctx: this.ctx, run: () => undefined as unknown as Promise<void> },
-            entry => assertPredicate(entry.ctx, negated, predicate, entry.messageOverride));
+        const negated = this.consumeNot();
+        this.enqueue(this.ctx, (entry) =>
+            assertPredicate(entry.ctx, negated, predicate, entry.messageOverride),
+        );
         return this;
     }
 
@@ -512,23 +453,32 @@ export class ExpectBuilder implements PromiseLike<void> {
         return this;
     }
 
-    /**
-     * Add an assertion to the queue. Matchers call this to push their
-     * terminal check. The `run` field is patched in place with the matcher's
-     * executor so the matcher can reference `entry.messageOverride` (set later
-     * by `.throws()`) without capturing a stale value.
-     */
-    enqueue(entry: QueuedAssertion, runFactory: (entry: QueuedAssertion) => Promise<void>): this {
-        entry.run = () => runFactory(entry);
-        this.queue.push(entry);
-        return this;
-    }
-
     then<TResult1 = void, TResult2 = never>(
         onfulfilled?: ((value: void) => TResult1 | PromiseLike<TResult1>) | null | undefined,
         onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null | undefined,
     ): PromiseLike<TResult1 | TResult2> {
         return this.flush().then(onfulfilled, onrejected);
+    }
+
+    // ─── internals used by matchers ─────────────────────────────────
+
+    /**
+     * Enqueue an assertion. Matchers call this with the context they captured
+     * at matcher-creation time and a runner that reads `entry.ctx` and
+     * `entry.messageOverride` at run time so later modifications by
+     * `.timeout()` / `.throws()` flow through.
+     */
+    enqueue(ctx: ExpectContext, run: (entry: QueuedAssertion) => Promise<void>): this {
+        const entry: QueuedAssertion = { ctx, run: async () => {} };
+        entry.run = () => run(entry);
+        this.queue.push(entry);
+        return this;
+    }
+
+    private consumeNot(): boolean {
+        const n = this.pendingNot;
+        this.pendingNot = false;
+        return n;
     }
 
     private async flush(): Promise<void> {

--- a/src/steps/ExpectMatchers.ts
+++ b/src/steps/ExpectMatchers.ts
@@ -3,9 +3,9 @@ import { Locator } from '@playwright/test';
 /**
  * Snapshot of an element's state at a single point in time.
  *
- * Passed to predicates in `steps.expect(el, page, predicate)` and
- * `steps.on(el, page).expect(predicate)`. All fields are primitives or
- * plain data — no async methods, no Playwright types.
+ * Passed to predicates in `steps.expect(el, page).toBe(predicate)` and
+ * `steps.on(el, page).toBe(predicate)`. All fields are primitives or plain
+ * data — no async methods, no Playwright types.
  */
 export interface ElementSnapshot {
     readonly text: string;
@@ -39,21 +39,38 @@ async function readCssProperty(locator: Locator, property: string): Promise<stri
     );
 }
 
+function describeFailure(
+    ctx: ExpectContext,
+    field: string,
+    verb: string,
+    expected: unknown,
+    actual: unknown,
+    negated: boolean,
+): string {
+    const quote = (v: unknown) => (typeof v === 'string' ? `"${v}"` : String(v));
+    const neg = negated ? 'not ' : '';
+    return `expected ${ctx.pageName}.${ctx.elementName} ${field} ${neg}${verb} ${quote(expected)}, got ${quote(actual)}`;
+}
+
 abstract class BaseMatcher {
     constructor(protected ctx: ExpectContext, protected negated: boolean = false) {}
+
+    protected async honorIfVisibleGate(): Promise<boolean> {
+        if (!this.ctx.conditionalVisible) return true;
+        try {
+            const locator = await this.ctx.resolveLocator();
+            await locator.waitFor({ state: 'visible', timeout: this.ctx.visibilityTimeout });
+            return true;
+        } catch {
+            return false;
+        }
+    }
 
     protected async assertSnapshot(
         predicate: (snap: ElementSnapshot) => boolean,
         describe: (snap: ElementSnapshot, negated: boolean) => string,
     ): Promise<void> {
-        if (this.ctx.conditionalVisible) {
-            try {
-                const locator = await this.ctx.resolveLocator();
-                await locator.waitFor({ state: 'visible', timeout: this.ctx.visibilityTimeout });
-            } catch {
-                return;
-            }
-        }
+        if (!(await this.honorIfVisibleGate())) return;
 
         const deadline = Date.now() + this.ctx.timeout;
         const pollMs = 100;
@@ -63,8 +80,7 @@ abstract class BaseMatcher {
         while (Date.now() < deadline) {
             try {
                 lastSnapshot = await this.ctx.captureSnapshot();
-                const rawResult = predicate(lastSnapshot);
-                if (rawResult !== this.negated) return;
+                if (predicate(lastSnapshot) !== this.negated) return;
             } catch (err) {
                 lastError = err;
             }
@@ -84,22 +100,14 @@ abstract class BaseMatcher {
         evaluate: () => Promise<boolean>,
         describe: (negated: boolean) => string,
     ): Promise<void> {
-        if (this.ctx.conditionalVisible) {
-            try {
-                const locator = await this.ctx.resolveLocator();
-                await locator.waitFor({ state: 'visible', timeout: this.ctx.visibilityTimeout });
-            } catch {
-                return;
-            }
-        }
+        if (!(await this.honorIfVisibleGate())) return;
 
         const deadline = Date.now() + this.ctx.timeout;
         const pollMs = 100;
 
         while (Date.now() < deadline) {
             try {
-                const rawResult = await evaluate();
-                if (rawResult !== this.negated) return;
+                if ((await evaluate()) !== this.negated) return;
             } catch {
                 // swallow and retry
             }
@@ -110,96 +118,77 @@ abstract class BaseMatcher {
     }
 }
 
-export class TextMatcher extends BaseMatcher {
-    get not(): TextMatcher {
-        return new TextMatcher(this.ctx, !this.negated);
-    }
+/**
+ * Shared string-matcher surface for any field whose value reduces to a string:
+ * element text, input value, a specific attribute, a computed CSS property.
+ * Subclasses supply a `label` (for error messages) and a `read` (how to fetch
+ * the string — from the snapshot or a live read).
+ */
+abstract class StringMatcher extends BaseMatcher {
+    protected abstract fieldLabel(): string;
+    protected abstract read(snap: ElementSnapshot): string;
 
     async toBe(expected: string): Promise<void> {
         await this.assertSnapshot(
-            s => s.text === expected,
-            (s, n) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} text ${n ? 'not ' : ''}to be "${expected}", got "${s.text}"`,
+            s => this.read(s) === expected,
+            (s, n) => describeFailure(this.ctx, this.fieldLabel(), 'to be', expected, this.read(s), n),
         );
     }
 
     async toContain(expected: string): Promise<void> {
         await this.assertSnapshot(
-            s => s.text.includes(expected),
-            (s, n) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} text ${n ? 'not ' : ''}to contain "${expected}", got "${s.text}"`,
+            s => this.read(s).includes(expected),
+            (s, n) => describeFailure(this.ctx, this.fieldLabel(), 'to contain', expected, this.read(s), n),
         );
     }
 
     async toMatch(re: RegExp): Promise<void> {
         await this.assertSnapshot(
-            s => re.test(s.text),
-            (s, n) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} text ${n ? 'not ' : ''}to match ${re}, got "${s.text}"`,
+            s => re.test(this.read(s)),
+            (s, n) => describeFailure(this.ctx, this.fieldLabel(), 'to match', re, this.read(s), n),
         );
     }
 
     async toStartWith(prefix: string): Promise<void> {
         await this.assertSnapshot(
-            s => s.text.startsWith(prefix),
-            (s, n) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} text ${n ? 'not ' : ''}to start with "${prefix}", got "${s.text}"`,
+            s => this.read(s).startsWith(prefix),
+            (s, n) => describeFailure(this.ctx, this.fieldLabel(), 'to start with', prefix, this.read(s), n),
         );
     }
 
     async toEndWith(suffix: string): Promise<void> {
         await this.assertSnapshot(
-            s => s.text.endsWith(suffix),
-            (s, n) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} text ${n ? 'not ' : ''}to end with "${suffix}", got "${s.text}"`,
+            s => this.read(s).endsWith(suffix),
+            (s, n) => describeFailure(this.ctx, this.fieldLabel(), 'to end with', suffix, this.read(s), n),
         );
     }
 }
 
-export class ValueMatcher extends BaseMatcher {
+export class TextMatcher extends StringMatcher {
+    get not(): TextMatcher {
+        return new TextMatcher(this.ctx, !this.negated);
+    }
+    protected fieldLabel(): string { return 'text'; }
+    protected read(snap: ElementSnapshot): string { return snap.text; }
+}
+
+export class ValueMatcher extends StringMatcher {
     get not(): ValueMatcher {
         return new ValueMatcher(this.ctx, !this.negated);
     }
+    protected fieldLabel(): string { return 'value'; }
+    protected read(snap: ElementSnapshot): string { return snap.value; }
+}
 
-    async toBe(expected: string): Promise<void> {
-        await this.assertSnapshot(
-            s => s.value === expected,
-            (s, n) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} value ${n ? 'not ' : ''}to be "${expected}", got "${s.value}"`,
-        );
+export class AttributeMatcher extends StringMatcher {
+    constructor(ctx: ExpectContext, private attrName: string, negated: boolean = false) {
+        super(ctx, negated);
     }
-
-    async toContain(expected: string): Promise<void> {
-        await this.assertSnapshot(
-            s => s.value.includes(expected),
-            (s, n) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} value ${n ? 'not ' : ''}to contain "${expected}", got "${s.value}"`,
-        );
+    get not(): AttributeMatcher {
+        return new AttributeMatcher(this.ctx, this.attrName, !this.negated);
     }
-
-    async toMatch(re: RegExp): Promise<void> {
-        await this.assertSnapshot(
-            s => re.test(s.value),
-            (s, n) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} value ${n ? 'not ' : ''}to match ${re}, got "${s.value}"`,
-        );
-    }
-
-    async toStartWith(prefix: string): Promise<void> {
-        await this.assertSnapshot(
-            s => s.value.startsWith(prefix),
-            (s, n) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} value ${n ? 'not ' : ''}to start with "${prefix}", got "${s.value}"`,
-        );
-    }
-
-    async toEndWith(suffix: string): Promise<void> {
-        await this.assertSnapshot(
-            s => s.value.endsWith(suffix),
-            (s, n) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} value ${n ? 'not ' : ''}to end with "${suffix}", got "${s.value}"`,
-        );
-    }
+    protected fieldLabel(): string { return `attribute "${this.attrName}"`; }
+    protected read(snap: ElementSnapshot): string { return snap.attributes[this.attrName] ?? ''; }
 }
 
 export class CountMatcher extends BaseMatcher {
@@ -210,40 +199,35 @@ export class CountMatcher extends BaseMatcher {
     async toBe(expected: number): Promise<void> {
         await this.assertSnapshot(
             s => s.count === expected,
-            (s, n) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} count ${n ? 'not ' : ''}to be ${expected}, got ${s.count}`,
+            (s, n) => describeFailure(this.ctx, 'count', 'to be', expected, s.count, n),
         );
     }
 
     async toBeGreaterThan(n: number): Promise<void> {
         await this.assertSnapshot(
             s => s.count > n,
-            (s, neg) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} count ${neg ? 'not ' : ''}to be greater than ${n}, got ${s.count}`,
+            (s, neg) => describeFailure(this.ctx, 'count', 'to be greater than', n, s.count, neg),
         );
     }
 
     async toBeLessThan(n: number): Promise<void> {
         await this.assertSnapshot(
             s => s.count < n,
-            (s, neg) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} count ${neg ? 'not ' : ''}to be less than ${n}, got ${s.count}`,
+            (s, neg) => describeFailure(this.ctx, 'count', 'to be less than', n, s.count, neg),
         );
     }
 
     async toBeGreaterThanOrEqual(n: number): Promise<void> {
         await this.assertSnapshot(
             s => s.count >= n,
-            (s, neg) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} count ${neg ? 'not ' : ''}to be greater than or equal to ${n}, got ${s.count}`,
+            (s, neg) => describeFailure(this.ctx, 'count', 'to be greater than or equal to', n, s.count, neg),
         );
     }
 
     async toBeLessThanOrEqual(n: number): Promise<void> {
         await this.assertSnapshot(
             s => s.count <= n,
-            (s, neg) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} count ${neg ? 'not ' : ''}to be less than or equal to ${n}, got ${s.count}`,
+            (s, neg) => describeFailure(this.ctx, 'count', 'to be less than or equal to', n, s.count, neg),
         );
     }
 }
@@ -262,52 +246,12 @@ export class BooleanMatcher extends BaseMatcher {
     async toBe(expected: boolean): Promise<void> {
         await this.assertSnapshot(
             s => s[this.field] === expected,
-            (s, n) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} ${this.field} ${n ? 'not ' : ''}to be ${expected}, got ${s[this.field]}`,
+            (s, n) => describeFailure(this.ctx, this.field, 'to be', expected, s[this.field], n),
         );
     }
 
-    async toBeTrue(): Promise<void> {
-        await this.toBe(true);
-    }
-
-    async toBeFalse(): Promise<void> {
-        await this.toBe(false);
-    }
-}
-
-export class AttributeMatcher extends BaseMatcher {
-    constructor(ctx: ExpectContext, private attrName: string, negated: boolean = false) {
-        super(ctx, negated);
-    }
-
-    get not(): AttributeMatcher {
-        return new AttributeMatcher(this.ctx, this.attrName, !this.negated);
-    }
-
-    async toBe(expected: string): Promise<void> {
-        await this.assertSnapshot(
-            s => s.attributes[this.attrName] === expected,
-            (s, n) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} attribute "${this.attrName}" ${n ? 'not ' : ''}to be "${expected}", got "${s.attributes[this.attrName] ?? '<missing>'}"`,
-        );
-    }
-
-    async toContain(expected: string): Promise<void> {
-        await this.assertSnapshot(
-            s => (s.attributes[this.attrName] ?? '').includes(expected),
-            (s, n) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} attribute "${this.attrName}" ${n ? 'not ' : ''}to contain "${expected}", got "${s.attributes[this.attrName] ?? '<missing>'}"`,
-        );
-    }
-
-    async toMatch(re: RegExp): Promise<void> {
-        await this.assertSnapshot(
-            s => re.test(s.attributes[this.attrName] ?? ''),
-            (s, n) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} attribute "${this.attrName}" ${n ? 'not ' : ''}to match ${re}, got "${s.attributes[this.attrName] ?? '<missing>'}"`,
-        );
-    }
+    async toBeTrue(): Promise<void> { await this.toBe(true); }
+    async toBeFalse(): Promise<void> { await this.toBe(false); }
 }
 
 export class AttributesMatcher extends BaseMatcher {
@@ -337,43 +281,93 @@ export class CssMatcher extends BaseMatcher {
         return new CssMatcher(this.ctx, this.property, !this.negated);
     }
 
-    async toBe(expected: string): Promise<void> {
+    private async runCss(
+        test: (value: string) => boolean,
+        verb: string,
+        expected: unknown,
+    ): Promise<void> {
         let lastValue = '';
         await this.assertCustom(
             async () => {
                 const locator = await this.ctx.resolveLocator();
                 lastValue = await readCssProperty(locator, this.property);
-                return lastValue === expected;
+                return test(lastValue);
             },
-            n =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} css "${this.property}" ${n ? 'not ' : ''}to be "${expected}", got "${lastValue}"`,
+            n => describeFailure(this.ctx, `css "${this.property}"`, verb, expected, lastValue, n),
         );
+    }
+
+    async toBe(expected: string): Promise<void> {
+        await this.runCss(v => v === expected, 'to be', expected);
     }
 
     async toContain(expected: string): Promise<void> {
-        let lastValue = '';
-        await this.assertCustom(
-            async () => {
-                const locator = await this.ctx.resolveLocator();
-                lastValue = await readCssProperty(locator, this.property);
-                return lastValue.includes(expected);
-            },
-            n =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} css "${this.property}" ${n ? 'not ' : ''}to contain "${expected}", got "${lastValue}"`,
-        );
+        await this.runCss(v => v.includes(expected), 'to contain', expected);
     }
 
     async toMatch(re: RegExp): Promise<void> {
-        let lastValue = '';
-        await this.assertCustom(
-            async () => {
+        await this.runCss(v => re.test(v), 'to match', re);
+    }
+}
+
+/**
+ * A chainable, awaitable predicate assertion. Built by `.toBe(predicate)` at
+ * the builder or fluent level. Use `.throws(message)` to override the failure
+ * message; `await` the result (or any `.then`-compatible context) to execute.
+ */
+export class PredicateAssertion implements PromiseLike<void> {
+    constructor(
+        private ctx: ExpectContext,
+        private predicate: (el: ElementSnapshot) => boolean,
+        private negated: boolean = false,
+        private message?: string,
+    ) {}
+
+    /** Override the error message shown when the predicate fails. */
+    throws(message: string): PredicateAssertion {
+        return new PredicateAssertion(this.ctx, this.predicate, this.negated, message);
+    }
+
+    then<TResult1 = void, TResult2 = never>(
+        onfulfilled?: ((value: void) => TResult1 | PromiseLike<TResult1>) | null | undefined,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null | undefined,
+    ): PromiseLike<TResult1 | TResult2> {
+        return this.execute().then(onfulfilled, onrejected);
+    }
+
+    private async execute(): Promise<void> {
+        if (this.ctx.conditionalVisible) {
+            try {
                 const locator = await this.ctx.resolveLocator();
-                lastValue = await readCssProperty(locator, this.property);
-                return re.test(lastValue);
-            },
-            n =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} css "${this.property}" ${n ? 'not ' : ''}to match ${re}, got "${lastValue}"`,
-        );
+                await locator.waitFor({ state: 'visible', timeout: this.ctx.visibilityTimeout });
+            } catch {
+                return;
+            }
+        }
+
+        const deadline = Date.now() + this.ctx.timeout;
+        const pollMs = 100;
+        let lastSnapshot: ElementSnapshot | null = null;
+        let lastError: unknown = null;
+
+        while (Date.now() < deadline) {
+            try {
+                lastSnapshot = await this.ctx.captureSnapshot();
+                if (this.predicate(lastSnapshot) !== this.negated) return;
+            } catch (err) {
+                lastError = err;
+            }
+            await new Promise(resolve => setTimeout(resolve, pollMs));
+        }
+
+        const header = this.message
+            ?? `expect().toBe(predicate) failed on ${this.ctx.pageName}.${this.ctx.elementName} after ${this.ctx.timeout}ms`;
+        if (!lastSnapshot) {
+            const reason = lastError instanceof Error ? lastError.message : String(lastError ?? 'unknown');
+            throw new Error(`${header}\n  element could not be resolved: ${reason}`);
+        }
+        const snapshotJson = JSON.stringify(lastSnapshot, null, 2).replace(/^/gm, '    ');
+        throw new Error(`${header}\n  snapshot at timeout:\n${snapshotJson}`);
     }
 }
 
@@ -389,31 +383,25 @@ export class ExpectBuilder {
         return new ExpectBuilder(this.ctx, !this.negated);
     }
 
-    get text(): TextMatcher {
-        return new TextMatcher(this.ctx, this.negated);
-    }
+    get text(): TextMatcher { return new TextMatcher(this.ctx, this.negated); }
+    get value(): ValueMatcher { return new ValueMatcher(this.ctx, this.negated); }
+    get count(): CountMatcher { return new CountMatcher(this.ctx, this.negated); }
+    get visible(): BooleanMatcher { return new BooleanMatcher(this.ctx, 'visible', this.negated); }
+    get enabled(): BooleanMatcher { return new BooleanMatcher(this.ctx, 'enabled', this.negated); }
+    get attributes(): AttributesMatcher { return new AttributesMatcher(this.ctx, this.negated); }
+    css(property: string): CssMatcher { return new CssMatcher(this.ctx, property, this.negated); }
 
-    get value(): ValueMatcher {
-        return new ValueMatcher(this.ctx, this.negated);
-    }
-
-    get count(): CountMatcher {
-        return new CountMatcher(this.ctx, this.negated);
-    }
-
-    get visible(): BooleanMatcher {
-        return new BooleanMatcher(this.ctx, 'visible', this.negated);
-    }
-
-    get enabled(): BooleanMatcher {
-        return new BooleanMatcher(this.ctx, 'enabled', this.negated);
-    }
-
-    get attributes(): AttributesMatcher {
-        return new AttributesMatcher(this.ctx, this.negated);
-    }
-
-    css(property: string): CssMatcher {
-        return new CssMatcher(this.ctx, property, this.negated);
+    /**
+     * Predicate escape hatch. Returns a chainable, awaitable assertion that
+     * passes when the predicate returns `true` (or `false` if the builder is
+     * negated). Use `.throws(message)` to override the failure message.
+     *
+     * @example
+     * await steps.expect('price', 'ProductPage').toBe(el => parseFloat(el.text.slice(1)) > 10);
+     * await steps.expect('price', 'ProductPage').toBe(el => el.visible && el.enabled)
+     *   .throws('price must be visible and enabled');
+     */
+    toBe(predicate: (el: ElementSnapshot) => boolean): PredicateAssertion {
+        return new PredicateAssertion(this.ctx, predicate, this.negated);
     }
 }

--- a/src/steps/ExpectMatchers.ts
+++ b/src/steps/ExpectMatchers.ts
@@ -1,4 +1,4 @@
-import { Element, WebElement } from '@civitas-cerebrum/element-repository';
+import { Element } from '@civitas-cerebrum/element-repository';
 
 /**
  * Snapshot of an element's state at a single point in time.
@@ -359,8 +359,7 @@ export class CssMatcher extends BaseMatcher {
             return assertWithLiveRead(
                 entry.ctx, negated,
                 async () => {
-                    // getCssProperty is web-only; narrow to WebElement.
-                    const element = (await entry.ctx.resolveElement()) as WebElement;
+                    const element = await entry.ctx.resolveElement();
                     lastValue = await element.getCssProperty(property);
                     return test(lastValue);
                 },

--- a/src/steps/ExpectMatchers.ts
+++ b/src/steps/ExpectMatchers.ts
@@ -32,6 +32,16 @@ export interface ExpectContext {
     captureSnapshot(): Promise<ElementSnapshot>;
 }
 
+/** One assertion queued on an `ExpectBuilder`. Executes when the builder is awaited. */
+interface QueuedAssertion {
+    /** The ctx snapshot captured when this assertion was queued. */
+    ctx: ExpectContext;
+    /** Executes the assertion; may throw on failure. */
+    run(): Promise<void>;
+    /** Optional message that replaces the default failure header. */
+    messageOverride?: string;
+}
+
 async function readCssProperty(locator: Locator, property: string): Promise<string> {
     return locator.evaluate(
         (el, prop) => window.getComputedStyle(el as Element).getPropertyValue(prop),
@@ -52,409 +62,479 @@ function describeFailure(
     return `expected ${ctx.pageName}.${ctx.elementName} ${field} ${neg}${verb} ${quote(expected)}, got ${quote(actual)}`;
 }
 
-abstract class BaseMatcher {
-    constructor(protected ctx: ExpectContext, protected negated: boolean = false) {}
-
-    /** Subclasses clone themselves with a new context (used by `timeout()`). */
-    protected abstract withCtx(ctx: ExpectContext): this;
-
-    /**
-     * Override the retry timeout for this matcher call. Returns a new matcher
-     * instance with the timeout replaced — does not mutate the original.
-     *
-     * @example
-     * await steps.expect('el', 'Page').text.timeout(5000).toBe('Ready');
-     */
-    timeout(ms: number): this {
-        return this.withCtx({ ...this.ctx, timeout: ms });
-    }
-
-    protected async honorIfVisibleGate(): Promise<boolean> {
-        if (!this.ctx.conditionalVisible) return true;
-        try {
-            const locator = await this.ctx.resolveLocator();
-            await locator.waitFor({ state: 'visible', timeout: this.ctx.visibilityTimeout });
-            return true;
-        } catch {
-            return false;
-        }
-    }
-
-    protected async assertSnapshot(
-        predicate: (snap: ElementSnapshot) => boolean,
-        describe: (snap: ElementSnapshot, negated: boolean) => string,
-    ): Promise<void> {
-        if (!(await this.honorIfVisibleGate())) return;
-
-        const deadline = Date.now() + this.ctx.timeout;
-        const pollMs = 100;
-        let lastSnapshot: ElementSnapshot | null = null;
-        let lastError: unknown = null;
-
-        while (Date.now() < deadline) {
-            try {
-                lastSnapshot = await this.ctx.captureSnapshot();
-                if (predicate(lastSnapshot) !== this.negated) return;
-            } catch (err) {
-                lastError = err;
-            }
-            await new Promise(resolve => setTimeout(resolve, pollMs));
-        }
-
-        if (!lastSnapshot) {
-            const reason = lastError instanceof Error ? lastError.message : String(lastError ?? 'unknown');
-            throw new Error(
-                `expect() failed on ${this.ctx.pageName}.${this.ctx.elementName}: could not resolve element within ${this.ctx.timeout}ms — ${reason}`,
-            );
-        }
-        throw new Error(describe(lastSnapshot, this.negated));
-    }
-
-    protected async assertCustom(
-        evaluate: () => Promise<boolean>,
-        describe: (negated: boolean) => string,
-    ): Promise<void> {
-        if (!(await this.honorIfVisibleGate())) return;
-
-        const deadline = Date.now() + this.ctx.timeout;
-        const pollMs = 100;
-
-        while (Date.now() < deadline) {
-            try {
-                if ((await evaluate()) !== this.negated) return;
-            } catch {
-                // swallow and retry
-            }
-            await new Promise(resolve => setTimeout(resolve, pollMs));
-        }
-
-        throw new Error(describe(this.negated));
+async function honorIfVisibleGate(ctx: ExpectContext): Promise<boolean> {
+    if (!ctx.conditionalVisible) return true;
+    try {
+        const locator = await ctx.resolveLocator();
+        await locator.waitFor({ state: 'visible', timeout: ctx.visibilityTimeout });
+        return true;
+    } catch {
+        return false;
     }
 }
 
-/**
- * Shared string-matcher surface for any field whose value reduces to a string:
- * element text, input value, a specific attribute, a computed CSS property.
- * Subclasses supply a `label` (for error messages) and a `read` (how to fetch
- * the string — from the snapshot or a live read).
- */
-abstract class StringMatcher extends BaseMatcher {
+async function assertWithSnapshot(
+    ctx: ExpectContext,
+    negated: boolean,
+    predicate: (snap: ElementSnapshot) => boolean,
+    describe: (snap: ElementSnapshot, negated: boolean) => string,
+    messageOverride?: string,
+): Promise<void> {
+    if (!(await honorIfVisibleGate(ctx))) return;
+
+    const deadline = Date.now() + ctx.timeout;
+    const pollMs = 100;
+    let lastSnapshot: ElementSnapshot | null = null;
+    let lastError: unknown = null;
+
+    while (Date.now() < deadline) {
+        try {
+            lastSnapshot = await ctx.captureSnapshot();
+            if (predicate(lastSnapshot) !== negated) return;
+        } catch (err) {
+            lastError = err;
+        }
+        await new Promise(resolve => setTimeout(resolve, pollMs));
+    }
+
+    if (!lastSnapshot) {
+        const reason = lastError instanceof Error ? lastError.message : String(lastError ?? 'unknown');
+        throw new Error(
+            `expect() failed on ${ctx.pageName}.${ctx.elementName}: could not resolve element within ${ctx.timeout}ms — ${reason}`,
+        );
+    }
+    throw new Error(messageOverride ?? describe(lastSnapshot, negated));
+}
+
+async function assertWithLiveRead(
+    ctx: ExpectContext,
+    negated: boolean,
+    evaluate: () => Promise<boolean>,
+    describe: (negated: boolean) => string,
+    messageOverride?: string,
+): Promise<void> {
+    if (!(await honorIfVisibleGate(ctx))) return;
+
+    const deadline = Date.now() + ctx.timeout;
+    const pollMs = 100;
+
+    while (Date.now() < deadline) {
+        try {
+            if ((await evaluate()) !== negated) return;
+        } catch {
+            // swallow and retry
+        }
+        await new Promise(resolve => setTimeout(resolve, pollMs));
+    }
+
+    throw new Error(messageOverride ?? describe(negated));
+}
+
+async function assertPredicate(
+    ctx: ExpectContext,
+    negated: boolean,
+    predicate: (el: ElementSnapshot) => boolean,
+    messageOverride?: string,
+): Promise<void> {
+    if (!(await honorIfVisibleGate(ctx))) return;
+
+    const deadline = Date.now() + ctx.timeout;
+    const pollMs = 100;
+    let lastSnapshot: ElementSnapshot | null = null;
+    let lastError: unknown = null;
+
+    while (Date.now() < deadline) {
+        try {
+            lastSnapshot = await ctx.captureSnapshot();
+            if (predicate(lastSnapshot) !== negated) return;
+        } catch (err) {
+            lastError = err;
+        }
+        await new Promise(resolve => setTimeout(resolve, pollMs));
+    }
+
+    const header = messageOverride
+        ?? `expect().toBe(predicate) failed on ${ctx.pageName}.${ctx.elementName} after ${ctx.timeout}ms`;
+    if (!lastSnapshot) {
+        const reason = lastError instanceof Error ? lastError.message : String(lastError ?? 'unknown');
+        throw new Error(`${header}\n  element could not be resolved: ${reason}`);
+    }
+    const snapshotJson = JSON.stringify(lastSnapshot, null, 2).replace(/^/gm, '    ');
+    throw new Error(`${header}\n  snapshot at timeout:\n${snapshotJson}`);
+}
+
+// ─── Matcher adapters ────────────────────────────────────────────────
+//
+// These are lightweight wrappers exposed via getters on `ExpectBuilder`.
+// Each terminal method captures the builder's context + negation at the time
+// of the call, enqueues the assertion onto the builder, and returns the
+// builder so the chain can continue.
+
+abstract class StringMatcher {
+    constructor(
+        protected builder: ExpectBuilder,
+        protected ctx: ExpectContext,
+        protected negated: boolean,
+    ) {}
+
+    /** Override the retry timeout for this matcher only. */
+    timeout(ms: number): this {
+        const cloned = Object.create(Object.getPrototypeOf(this)) as StringMatcher;
+        Object.assign(cloned, this);
+        cloned.ctx = { ...this.ctx, timeout: ms };
+        return cloned as this;
+    }
+
     protected abstract fieldLabel(): string;
     protected abstract read(snap: ElementSnapshot): string;
 
-    async toBe(expected: string): Promise<void> {
-        await this.assertSnapshot(
+    toBe(expected: string): ExpectBuilder {
+        return this.enqueue(
             s => this.read(s) === expected,
             (s, n) => describeFailure(this.ctx, this.fieldLabel(), 'to be', expected, this.read(s), n),
         );
     }
 
-    async toContain(expected: string): Promise<void> {
-        await this.assertSnapshot(
+    toContain(expected: string): ExpectBuilder {
+        return this.enqueue(
             s => this.read(s).includes(expected),
             (s, n) => describeFailure(this.ctx, this.fieldLabel(), 'to contain', expected, this.read(s), n),
         );
     }
 
-    async toMatch(re: RegExp): Promise<void> {
-        await this.assertSnapshot(
+    toMatch(re: RegExp): ExpectBuilder {
+        return this.enqueue(
             s => re.test(this.read(s)),
             (s, n) => describeFailure(this.ctx, this.fieldLabel(), 'to match', re, this.read(s), n),
         );
     }
 
-    async toStartWith(prefix: string): Promise<void> {
-        await this.assertSnapshot(
+    toStartWith(prefix: string): ExpectBuilder {
+        return this.enqueue(
             s => this.read(s).startsWith(prefix),
             (s, n) => describeFailure(this.ctx, this.fieldLabel(), 'to start with', prefix, this.read(s), n),
         );
     }
 
-    async toEndWith(suffix: string): Promise<void> {
-        await this.assertSnapshot(
+    toEndWith(suffix: string): ExpectBuilder {
+        return this.enqueue(
             s => this.read(s).endsWith(suffix),
             (s, n) => describeFailure(this.ctx, this.fieldLabel(), 'to end with', suffix, this.read(s), n),
         );
     }
+
+    private enqueue(
+        predicate: (snap: ElementSnapshot) => boolean,
+        describe: (snap: ElementSnapshot, negated: boolean) => string,
+    ): ExpectBuilder {
+        const negated = this.negated;
+        return this.builder.enqueue({ ctx: this.ctx, run: () => undefined as unknown as Promise<void> },
+            entry => assertWithSnapshot(entry.ctx, negated, predicate, describe, entry.messageOverride));
+    }
 }
 
 export class TextMatcher extends StringMatcher {
-    get not(): TextMatcher {
-        return new TextMatcher(this.ctx, !this.negated);
-    }
-    protected withCtx(ctx: ExpectContext): this {
-        return new TextMatcher(ctx, this.negated) as this;
-    }
+    get not(): TextMatcher { return new TextMatcher(this.builder, this.ctx, !this.negated); }
     protected fieldLabel(): string { return 'text'; }
     protected read(snap: ElementSnapshot): string { return snap.text; }
 }
 
 export class ValueMatcher extends StringMatcher {
-    get not(): ValueMatcher {
-        return new ValueMatcher(this.ctx, !this.negated);
-    }
-    protected withCtx(ctx: ExpectContext): this {
-        return new ValueMatcher(ctx, this.negated) as this;
-    }
+    get not(): ValueMatcher { return new ValueMatcher(this.builder, this.ctx, !this.negated); }
     protected fieldLabel(): string { return 'value'; }
     protected read(snap: ElementSnapshot): string { return snap.value; }
 }
 
 export class AttributeMatcher extends StringMatcher {
-    constructor(ctx: ExpectContext, private attrName: string, negated: boolean = false) {
-        super(ctx, negated);
+    constructor(builder: ExpectBuilder, ctx: ExpectContext, private attrName: string, negated: boolean) {
+        super(builder, ctx, negated);
     }
-    get not(): AttributeMatcher {
-        return new AttributeMatcher(this.ctx, this.attrName, !this.negated);
-    }
-    protected withCtx(ctx: ExpectContext): this {
-        return new AttributeMatcher(ctx, this.attrName, this.negated) as this;
-    }
+    get not(): AttributeMatcher { return new AttributeMatcher(this.builder, this.ctx, this.attrName, !this.negated); }
     protected fieldLabel(): string { return `attribute "${this.attrName}"`; }
     protected read(snap: ElementSnapshot): string { return snap.attributes[this.attrName] ?? ''; }
 }
 
-export class CountMatcher extends BaseMatcher {
+export class CountMatcher {
+    constructor(
+        private builder: ExpectBuilder,
+        private ctx: ExpectContext,
+        private negated: boolean,
+    ) {}
+
     get not(): CountMatcher {
-        return new CountMatcher(this.ctx, !this.negated);
-    }
-    protected withCtx(ctx: ExpectContext): this {
-        return new CountMatcher(ctx, this.negated) as this;
+        return new CountMatcher(this.builder, this.ctx, !this.negated);
     }
 
-    async toBe(expected: number): Promise<void> {
-        await this.assertSnapshot(
+    timeout(ms: number): CountMatcher {
+        return new CountMatcher(this.builder, { ...this.ctx, timeout: ms }, this.negated);
+    }
+
+    toBe(expected: number): ExpectBuilder {
+        return this.enqueue(
             s => s.count === expected,
             (s, n) => describeFailure(this.ctx, 'count', 'to be', expected, s.count, n),
         );
     }
 
-    async toBeGreaterThan(n: number): Promise<void> {
-        await this.assertSnapshot(
+    toBeGreaterThan(n: number): ExpectBuilder {
+        return this.enqueue(
             s => s.count > n,
             (s, neg) => describeFailure(this.ctx, 'count', 'to be greater than', n, s.count, neg),
         );
     }
 
-    async toBeLessThan(n: number): Promise<void> {
-        await this.assertSnapshot(
+    toBeLessThan(n: number): ExpectBuilder {
+        return this.enqueue(
             s => s.count < n,
             (s, neg) => describeFailure(this.ctx, 'count', 'to be less than', n, s.count, neg),
         );
     }
 
-    async toBeGreaterThanOrEqual(n: number): Promise<void> {
-        await this.assertSnapshot(
+    toBeGreaterThanOrEqual(n: number): ExpectBuilder {
+        return this.enqueue(
             s => s.count >= n,
             (s, neg) => describeFailure(this.ctx, 'count', 'to be greater than or equal to', n, s.count, neg),
         );
     }
 
-    async toBeLessThanOrEqual(n: number): Promise<void> {
-        await this.assertSnapshot(
+    toBeLessThanOrEqual(n: number): ExpectBuilder {
+        return this.enqueue(
             s => s.count <= n,
             (s, neg) => describeFailure(this.ctx, 'count', 'to be less than or equal to', n, s.count, neg),
         );
+    }
+
+    private enqueue(
+        predicate: (snap: ElementSnapshot) => boolean,
+        describe: (snap: ElementSnapshot, negated: boolean) => string,
+    ): ExpectBuilder {
+        const negated = this.negated;
+        return this.builder.enqueue({ ctx: this.ctx, run: () => undefined as unknown as Promise<void> },
+            entry => assertWithSnapshot(entry.ctx, negated, predicate, describe, entry.messageOverride));
     }
 }
 
 type BooleanField = 'visible' | 'enabled';
 
-export class BooleanMatcher extends BaseMatcher {
-    constructor(ctx: ExpectContext, private field: BooleanField, negated: boolean = false) {
-        super(ctx, negated);
-    }
+export class BooleanMatcher {
+    constructor(
+        private builder: ExpectBuilder,
+        private ctx: ExpectContext,
+        private field: BooleanField,
+        private negated: boolean,
+    ) {}
 
     get not(): BooleanMatcher {
-        return new BooleanMatcher(this.ctx, this.field, !this.negated);
-    }
-    protected withCtx(ctx: ExpectContext): this {
-        return new BooleanMatcher(ctx, this.field, this.negated) as this;
+        return new BooleanMatcher(this.builder, this.ctx, this.field, !this.negated);
     }
 
-    async toBe(expected: boolean): Promise<void> {
-        await this.assertSnapshot(
-            s => s[this.field] === expected,
-            (s, n) => describeFailure(this.ctx, this.field, 'to be', expected, s[this.field], n),
-        );
+    timeout(ms: number): BooleanMatcher {
+        return new BooleanMatcher(this.builder, { ...this.ctx, timeout: ms }, this.field, this.negated);
     }
 
-    async toBeTrue(): Promise<void> { await this.toBe(true); }
-    async toBeFalse(): Promise<void> { await this.toBe(false); }
+    toBe(expected: boolean): ExpectBuilder {
+        const negated = this.negated;
+        const field = this.field;
+        return this.builder.enqueue({ ctx: this.ctx, run: () => undefined as unknown as Promise<void> },
+            entry => assertWithSnapshot(
+                entry.ctx, negated,
+                s => s[field] === expected,
+                (s, n) => describeFailure(entry.ctx, field, 'to be', expected, s[field], n),
+                entry.messageOverride,
+            ));
+    }
+
+    toBeTrue(): ExpectBuilder { return this.toBe(true); }
+    toBeFalse(): ExpectBuilder { return this.toBe(false); }
 }
 
-export class AttributesMatcher extends BaseMatcher {
+export class AttributesMatcher {
+    constructor(
+        private builder: ExpectBuilder,
+        private ctx: ExpectContext,
+        private negated: boolean,
+    ) {}
+
     get not(): AttributesMatcher {
-        return new AttributesMatcher(this.ctx, !this.negated);
+        return new AttributesMatcher(this.builder, this.ctx, !this.negated);
     }
-    protected withCtx(ctx: ExpectContext): this {
-        return new AttributesMatcher(ctx, this.negated) as this;
+
+    timeout(ms: number): AttributesMatcher {
+        return new AttributesMatcher(this.builder, { ...this.ctx, timeout: ms }, this.negated);
     }
 
     get(name: string): AttributeMatcher {
-        return new AttributeMatcher(this.ctx, name, this.negated);
+        return new AttributeMatcher(this.builder, this.ctx, name, this.negated);
     }
 
-    async toHaveKey(name: string): Promise<void> {
-        await this.assertSnapshot(
-            s => name in s.attributes,
-            (s, n) =>
-                `expected ${this.ctx.pageName}.${this.ctx.elementName} attributes ${n ? 'not ' : ''}to have key "${name}", present keys: [${Object.keys(s.attributes).join(', ')}]`,
-        );
+    toHaveKey(name: string): ExpectBuilder {
+        const negated = this.negated;
+        return this.builder.enqueue({ ctx: this.ctx, run: () => undefined as unknown as Promise<void> },
+            entry => assertWithSnapshot(
+                entry.ctx, negated,
+                s => name in s.attributes,
+                (s, n) =>
+                    `expected ${entry.ctx.pageName}.${entry.ctx.elementName} attributes ${n ? 'not ' : ''}to have key "${name}", present keys: [${Object.keys(s.attributes).join(', ')}]`,
+                entry.messageOverride,
+            ));
     }
 }
 
-export class CssMatcher extends BaseMatcher {
-    constructor(ctx: ExpectContext, private property: string, negated: boolean = false) {
-        super(ctx, negated);
-    }
+export class CssMatcher {
+    constructor(
+        private builder: ExpectBuilder,
+        private ctx: ExpectContext,
+        private property: string,
+        private negated: boolean,
+    ) {}
 
     get not(): CssMatcher {
-        return new CssMatcher(this.ctx, this.property, !this.negated);
-    }
-    protected withCtx(ctx: ExpectContext): this {
-        return new CssMatcher(ctx, this.property, this.negated) as this;
+        return new CssMatcher(this.builder, this.ctx, this.property, !this.negated);
     }
 
-    private async runCss(
-        test: (value: string) => boolean,
-        verb: string,
-        expected: unknown,
-    ): Promise<void> {
-        let lastValue = '';
-        await this.assertCustom(
-            async () => {
-                const locator = await this.ctx.resolveLocator();
-                lastValue = await readCssProperty(locator, this.property);
-                return test(lastValue);
-            },
-            n => describeFailure(this.ctx, `css "${this.property}"`, verb, expected, lastValue, n),
-        );
+    timeout(ms: number): CssMatcher {
+        return new CssMatcher(this.builder, { ...this.ctx, timeout: ms }, this.property, this.negated);
     }
 
-    async toBe(expected: string): Promise<void> {
-        await this.runCss(v => v === expected, 'to be', expected);
-    }
+    toBe(expected: string): ExpectBuilder { return this.enqueue(v => v === expected, 'to be', expected); }
+    toContain(expected: string): ExpectBuilder { return this.enqueue(v => v.includes(expected), 'to contain', expected); }
+    toMatch(re: RegExp): ExpectBuilder { return this.enqueue(v => re.test(v), 'to match', re); }
 
-    async toContain(expected: string): Promise<void> {
-        await this.runCss(v => v.includes(expected), 'to contain', expected);
-    }
-
-    async toMatch(re: RegExp): Promise<void> {
-        await this.runCss(v => re.test(v), 'to match', re);
+    private enqueue(test: (value: string) => boolean, verb: string, expected: unknown): ExpectBuilder {
+        const negated = this.negated;
+        const property = this.property;
+        return this.builder.enqueue({ ctx: this.ctx, run: () => undefined as unknown as Promise<void> },
+            entry => {
+                let lastValue = '';
+                return assertWithLiveRead(
+                    entry.ctx, negated,
+                    async () => {
+                        const locator = await entry.ctx.resolveLocator();
+                        lastValue = await readCssProperty(locator, property);
+                        return test(lastValue);
+                    },
+                    n => describeFailure(entry.ctx, `css "${property}"`, verb, expected, lastValue, n),
+                    entry.messageOverride,
+                );
+            });
     }
 }
 
 /**
- * A chainable, awaitable predicate assertion. Built by `.toBe(predicate)` at
- * the builder or fluent level. Use `.throws(message)` to override the failure
- * message; `await` the result (or any `.then`-compatible context) to execute.
+ * Root of the matcher tree and the queue-backed chain builder.
+ *
+ * Every matcher call enqueues an assertion and returns this builder, so you
+ * can chain multiple verifications in one expression:
+ *
+ * ```ts
+ * await steps.on('submitBtn', 'CheckoutPage')
+ *   .text.toBe('Place Order')
+ *   .enabled.toBeTrue()
+ *   .attributes.get('data-variant').toBe('primary')
+ *   .visible.toBeTrue();
+ * ```
+ *
+ * The builder is a `PromiseLike<void>` — awaiting it executes every queued
+ * assertion in the order they were added, short-circuiting on the first
+ * failure (the await throws, subsequent queued assertions do not run).
+ *
+ * - `.not` toggles negation for the *next* matcher only (one-shot).
+ * - `.throws(message)` overrides the failure message of the most recently
+ *   queued assertion.
+ * - `.timeout(ms)` mutates the builder's ctx, affecting every matcher that
+ *   runs after it. Per-matcher `.timeout(ms)` applies only to that matcher.
  */
-export class PredicateAssertion implements PromiseLike<void> {
-    constructor(
-        private ctx: ExpectContext,
-        private predicate: (el: ElementSnapshot) => boolean,
-        private negated: boolean = false,
-        private message?: string,
-    ) {}
+export class ExpectBuilder implements PromiseLike<void> {
+    private ctx: ExpectContext;
+    private queue: QueuedAssertion[] = [];
+    private pendingNot: boolean;
 
-    /** Override the error message shown when the predicate fails. */
-    throws(message: string): PredicateAssertion {
-        return new PredicateAssertion(this.ctx, this.predicate, this.negated, message);
+    constructor(ctx: ExpectContext, initialNegated: boolean = false) {
+        this.ctx = ctx;
+        this.pendingNot = initialNegated;
     }
 
-    /** Override the retry timeout for this predicate assertion. */
-    timeout(ms: number): PredicateAssertion {
-        return new PredicateAssertion({ ...this.ctx, timeout: ms }, this.predicate, this.negated, this.message);
+    /** One-shot negation. Flips the expected outcome of the *next* matcher only. */
+    get not(): this {
+        this.pendingNot = !this.pendingNot;
+        return this;
+    }
+
+    private consumeNegation(): boolean {
+        const n = this.pendingNot;
+        this.pendingNot = false;
+        return n;
+    }
+
+    /**
+     * Override the retry timeout. Mutates the builder's context so every
+     * matcher queued after this point runs with the new timeout, and also
+     * updates the most recently queued assertion so positioning like
+     * `.toBe(pred).timeout(500)` still scopes to that predicate.
+     *
+     * Per-matcher `.timeout(ms)` (e.g. `.text.timeout(500).toBe(...)`) remains
+     * the right choice when you want the override to apply only to the next
+     * matcher without leaking to assertions queued after it.
+     */
+    timeout(ms: number): this {
+        this.ctx = { ...this.ctx, timeout: ms };
+        const last = this.queue[this.queue.length - 1];
+        if (last) last.ctx = { ...last.ctx, timeout: ms };
+        return this;
+    }
+
+    // Field matcher getters — each consumes a pending .not and carries it
+    // into the matcher that is about to be constructed.
+    get text(): TextMatcher { return new TextMatcher(this, this.ctx, this.consumeNegation()); }
+    get value(): ValueMatcher { return new ValueMatcher(this, this.ctx, this.consumeNegation()); }
+    get count(): CountMatcher { return new CountMatcher(this, this.ctx, this.consumeNegation()); }
+    get visible(): BooleanMatcher { return new BooleanMatcher(this, this.ctx, 'visible', this.consumeNegation()); }
+    get enabled(): BooleanMatcher { return new BooleanMatcher(this, this.ctx, 'enabled', this.consumeNegation()); }
+    get attributes(): AttributesMatcher { return new AttributesMatcher(this, this.ctx, this.consumeNegation()); }
+    css(property: string): CssMatcher { return new CssMatcher(this, this.ctx, property, this.consumeNegation()); }
+
+    /**
+     * Predicate escape hatch. Queues a custom predicate assertion on this
+     * builder. Chain further matchers or end with `.throws(message)` to
+     * override the failure message.
+     */
+    toBe(predicate: (el: ElementSnapshot) => boolean): this {
+        const negated = this.consumeNegation();
+        this.enqueue({ ctx: this.ctx, run: () => undefined as unknown as Promise<void> },
+            entry => assertPredicate(entry.ctx, negated, predicate, entry.messageOverride));
+        return this;
+    }
+
+    /** Replace the failure message of the most recently queued assertion. */
+    throws(message: string): this {
+        const last = this.queue[this.queue.length - 1];
+        if (last) last.messageOverride = message;
+        return this;
+    }
+
+    /**
+     * Add an assertion to the queue. Matchers call this to push their
+     * terminal check. The `run` field is patched in place with the matcher's
+     * executor so the matcher can reference `entry.messageOverride` (set later
+     * by `.throws()`) without capturing a stale value.
+     */
+    enqueue(entry: QueuedAssertion, runFactory: (entry: QueuedAssertion) => Promise<void>): this {
+        entry.run = () => runFactory(entry);
+        this.queue.push(entry);
+        return this;
     }
 
     then<TResult1 = void, TResult2 = never>(
         onfulfilled?: ((value: void) => TResult1 | PromiseLike<TResult1>) | null | undefined,
         onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null | undefined,
     ): PromiseLike<TResult1 | TResult2> {
-        return this.execute().then(onfulfilled, onrejected);
+        return this.flush().then(onfulfilled, onrejected);
     }
 
-    private async execute(): Promise<void> {
-        if (this.ctx.conditionalVisible) {
-            try {
-                const locator = await this.ctx.resolveLocator();
-                await locator.waitFor({ state: 'visible', timeout: this.ctx.visibilityTimeout });
-            } catch {
-                return;
-            }
+    private async flush(): Promise<void> {
+        while (this.queue.length > 0) {
+            const assertion = this.queue.shift()!;
+            await assertion.run();
         }
-
-        const deadline = Date.now() + this.ctx.timeout;
-        const pollMs = 100;
-        let lastSnapshot: ElementSnapshot | null = null;
-        let lastError: unknown = null;
-
-        while (Date.now() < deadline) {
-            try {
-                lastSnapshot = await this.ctx.captureSnapshot();
-                if (this.predicate(lastSnapshot) !== this.negated) return;
-            } catch (err) {
-                lastError = err;
-            }
-            await new Promise(resolve => setTimeout(resolve, pollMs));
-        }
-
-        const header = this.message
-            ?? `expect().toBe(predicate) failed on ${this.ctx.pageName}.${this.ctx.elementName} after ${this.ctx.timeout}ms`;
-        if (!lastSnapshot) {
-            const reason = lastError instanceof Error ? lastError.message : String(lastError ?? 'unknown');
-            throw new Error(`${header}\n  element could not be resolved: ${reason}`);
-        }
-        const snapshotJson = JSON.stringify(lastSnapshot, null, 2).replace(/^/gm, '    ');
-        throw new Error(`${header}\n  snapshot at timeout:\n${snapshotJson}`);
-    }
-}
-
-/**
- * Root of the matcher tree. Returned by `steps.expect(el, page)` and exposed
- * via `.not` on `ElementAction`. Every matcher reached from here carries the
- * negated flag inherited from this root.
- */
-export class ExpectBuilder {
-    constructor(private ctx: ExpectContext, private negated: boolean = false) {}
-
-    get not(): ExpectBuilder {
-        return new ExpectBuilder(this.ctx, !this.negated);
-    }
-
-    /**
-     * Override the retry timeout for the matchers reached from this builder.
-     * Composes anywhere in the chain — before `.not`, after `.not`, before any
-     * field matcher. Returns a new builder with the override.
-     *
-     * @example
-     * await steps.expect('slow', 'Page').timeout(5000).text.toBe('Ready');
-     * await steps.expect('slow', 'Page').not.timeout(1000).visible.toBeTrue();
-     */
-    timeout(ms: number): ExpectBuilder {
-        return new ExpectBuilder({ ...this.ctx, timeout: ms }, this.negated);
-    }
-
-    get text(): TextMatcher { return new TextMatcher(this.ctx, this.negated); }
-    get value(): ValueMatcher { return new ValueMatcher(this.ctx, this.negated); }
-    get count(): CountMatcher { return new CountMatcher(this.ctx, this.negated); }
-    get visible(): BooleanMatcher { return new BooleanMatcher(this.ctx, 'visible', this.negated); }
-    get enabled(): BooleanMatcher { return new BooleanMatcher(this.ctx, 'enabled', this.negated); }
-    get attributes(): AttributesMatcher { return new AttributesMatcher(this.ctx, this.negated); }
-    css(property: string): CssMatcher { return new CssMatcher(this.ctx, property, this.negated); }
-
-    /**
-     * Predicate escape hatch. Returns a chainable, awaitable assertion that
-     * passes when the predicate returns `true` (or `false` if the builder is
-     * negated). Use `.throws(message)` to override the failure message.
-     *
-     * @example
-     * await steps.expect('price', 'ProductPage').toBe(el => parseFloat(el.text.slice(1)) > 10);
-     * await steps.expect('price', 'ProductPage').toBe(el => el.visible && el.enabled)
-     *   .throws('price must be visible and enabled');
-     */
-    toBe(predicate: (el: ElementSnapshot) => boolean): PredicateAssertion {
-        return new PredicateAssertion(this.ctx, predicate, this.negated);
     }
 }

--- a/src/steps/ExpectMatchers.ts
+++ b/src/steps/ExpectMatchers.ts
@@ -1,0 +1,419 @@
+import { Locator } from '@playwright/test';
+
+/**
+ * Snapshot of an element's state at a single point in time.
+ *
+ * Passed to predicates in `steps.expect(el, page, predicate)` and
+ * `steps.on(el, page).expect(predicate)`. All fields are primitives or
+ * plain data — no async methods, no Playwright types.
+ */
+export interface ElementSnapshot {
+    readonly text: string;
+    readonly value: string;
+    readonly attributes: Readonly<Record<string, string>>;
+    readonly visible: boolean;
+    readonly enabled: boolean;
+    readonly count: number;
+}
+
+/**
+ * Minimal surface the matcher tree needs from its host (typically an
+ * `ElementAction`). Decouples matchers from `ElementAction` so the matcher
+ * tree can be constructed from either the fluent builder or a top-level
+ * `Steps.expect()` call.
+ */
+export interface ExpectContext {
+    readonly elementName: string;
+    readonly pageName: string;
+    readonly timeout: number;
+    readonly conditionalVisible: boolean;
+    readonly visibilityTimeout: number;
+    resolveLocator(): Promise<Locator>;
+    captureSnapshot(): Promise<ElementSnapshot>;
+}
+
+async function readCssProperty(locator: Locator, property: string): Promise<string> {
+    return locator.evaluate(
+        (el, prop) => window.getComputedStyle(el as Element).getPropertyValue(prop),
+        property,
+    );
+}
+
+abstract class BaseMatcher {
+    constructor(protected ctx: ExpectContext, protected negated: boolean = false) {}
+
+    protected async assertSnapshot(
+        predicate: (snap: ElementSnapshot) => boolean,
+        describe: (snap: ElementSnapshot, negated: boolean) => string,
+    ): Promise<void> {
+        if (this.ctx.conditionalVisible) {
+            try {
+                const locator = await this.ctx.resolveLocator();
+                await locator.waitFor({ state: 'visible', timeout: this.ctx.visibilityTimeout });
+            } catch {
+                return;
+            }
+        }
+
+        const deadline = Date.now() + this.ctx.timeout;
+        const pollMs = 100;
+        let lastSnapshot: ElementSnapshot | null = null;
+        let lastError: unknown = null;
+
+        while (Date.now() < deadline) {
+            try {
+                lastSnapshot = await this.ctx.captureSnapshot();
+                const rawResult = predicate(lastSnapshot);
+                if (rawResult !== this.negated) return;
+            } catch (err) {
+                lastError = err;
+            }
+            await new Promise(resolve => setTimeout(resolve, pollMs));
+        }
+
+        if (!lastSnapshot) {
+            const reason = lastError instanceof Error ? lastError.message : String(lastError ?? 'unknown');
+            throw new Error(
+                `expect() failed on ${this.ctx.pageName}.${this.ctx.elementName}: could not resolve element within ${this.ctx.timeout}ms — ${reason}`,
+            );
+        }
+        throw new Error(describe(lastSnapshot, this.negated));
+    }
+
+    protected async assertCustom(
+        evaluate: () => Promise<boolean>,
+        describe: (negated: boolean) => string,
+    ): Promise<void> {
+        if (this.ctx.conditionalVisible) {
+            try {
+                const locator = await this.ctx.resolveLocator();
+                await locator.waitFor({ state: 'visible', timeout: this.ctx.visibilityTimeout });
+            } catch {
+                return;
+            }
+        }
+
+        const deadline = Date.now() + this.ctx.timeout;
+        const pollMs = 100;
+
+        while (Date.now() < deadline) {
+            try {
+                const rawResult = await evaluate();
+                if (rawResult !== this.negated) return;
+            } catch {
+                // swallow and retry
+            }
+            await new Promise(resolve => setTimeout(resolve, pollMs));
+        }
+
+        throw new Error(describe(this.negated));
+    }
+}
+
+export class TextMatcher extends BaseMatcher {
+    get not(): TextMatcher {
+        return new TextMatcher(this.ctx, !this.negated);
+    }
+
+    async toBe(expected: string): Promise<void> {
+        await this.assertSnapshot(
+            s => s.text === expected,
+            (s, n) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} text ${n ? 'not ' : ''}to be "${expected}", got "${s.text}"`,
+        );
+    }
+
+    async toContain(expected: string): Promise<void> {
+        await this.assertSnapshot(
+            s => s.text.includes(expected),
+            (s, n) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} text ${n ? 'not ' : ''}to contain "${expected}", got "${s.text}"`,
+        );
+    }
+
+    async toMatch(re: RegExp): Promise<void> {
+        await this.assertSnapshot(
+            s => re.test(s.text),
+            (s, n) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} text ${n ? 'not ' : ''}to match ${re}, got "${s.text}"`,
+        );
+    }
+
+    async toStartWith(prefix: string): Promise<void> {
+        await this.assertSnapshot(
+            s => s.text.startsWith(prefix),
+            (s, n) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} text ${n ? 'not ' : ''}to start with "${prefix}", got "${s.text}"`,
+        );
+    }
+
+    async toEndWith(suffix: string): Promise<void> {
+        await this.assertSnapshot(
+            s => s.text.endsWith(suffix),
+            (s, n) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} text ${n ? 'not ' : ''}to end with "${suffix}", got "${s.text}"`,
+        );
+    }
+}
+
+export class ValueMatcher extends BaseMatcher {
+    get not(): ValueMatcher {
+        return new ValueMatcher(this.ctx, !this.negated);
+    }
+
+    async toBe(expected: string): Promise<void> {
+        await this.assertSnapshot(
+            s => s.value === expected,
+            (s, n) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} value ${n ? 'not ' : ''}to be "${expected}", got "${s.value}"`,
+        );
+    }
+
+    async toContain(expected: string): Promise<void> {
+        await this.assertSnapshot(
+            s => s.value.includes(expected),
+            (s, n) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} value ${n ? 'not ' : ''}to contain "${expected}", got "${s.value}"`,
+        );
+    }
+
+    async toMatch(re: RegExp): Promise<void> {
+        await this.assertSnapshot(
+            s => re.test(s.value),
+            (s, n) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} value ${n ? 'not ' : ''}to match ${re}, got "${s.value}"`,
+        );
+    }
+
+    async toStartWith(prefix: string): Promise<void> {
+        await this.assertSnapshot(
+            s => s.value.startsWith(prefix),
+            (s, n) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} value ${n ? 'not ' : ''}to start with "${prefix}", got "${s.value}"`,
+        );
+    }
+
+    async toEndWith(suffix: string): Promise<void> {
+        await this.assertSnapshot(
+            s => s.value.endsWith(suffix),
+            (s, n) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} value ${n ? 'not ' : ''}to end with "${suffix}", got "${s.value}"`,
+        );
+    }
+}
+
+export class CountMatcher extends BaseMatcher {
+    get not(): CountMatcher {
+        return new CountMatcher(this.ctx, !this.negated);
+    }
+
+    async toBe(expected: number): Promise<void> {
+        await this.assertSnapshot(
+            s => s.count === expected,
+            (s, n) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} count ${n ? 'not ' : ''}to be ${expected}, got ${s.count}`,
+        );
+    }
+
+    async toBeGreaterThan(n: number): Promise<void> {
+        await this.assertSnapshot(
+            s => s.count > n,
+            (s, neg) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} count ${neg ? 'not ' : ''}to be greater than ${n}, got ${s.count}`,
+        );
+    }
+
+    async toBeLessThan(n: number): Promise<void> {
+        await this.assertSnapshot(
+            s => s.count < n,
+            (s, neg) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} count ${neg ? 'not ' : ''}to be less than ${n}, got ${s.count}`,
+        );
+    }
+
+    async toBeGreaterThanOrEqual(n: number): Promise<void> {
+        await this.assertSnapshot(
+            s => s.count >= n,
+            (s, neg) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} count ${neg ? 'not ' : ''}to be greater than or equal to ${n}, got ${s.count}`,
+        );
+    }
+
+    async toBeLessThanOrEqual(n: number): Promise<void> {
+        await this.assertSnapshot(
+            s => s.count <= n,
+            (s, neg) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} count ${neg ? 'not ' : ''}to be less than or equal to ${n}, got ${s.count}`,
+        );
+    }
+}
+
+type BooleanField = 'visible' | 'enabled';
+
+export class BooleanMatcher extends BaseMatcher {
+    constructor(ctx: ExpectContext, private field: BooleanField, negated: boolean = false) {
+        super(ctx, negated);
+    }
+
+    get not(): BooleanMatcher {
+        return new BooleanMatcher(this.ctx, this.field, !this.negated);
+    }
+
+    async toBe(expected: boolean): Promise<void> {
+        await this.assertSnapshot(
+            s => s[this.field] === expected,
+            (s, n) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} ${this.field} ${n ? 'not ' : ''}to be ${expected}, got ${s[this.field]}`,
+        );
+    }
+
+    async toBeTrue(): Promise<void> {
+        await this.toBe(true);
+    }
+
+    async toBeFalse(): Promise<void> {
+        await this.toBe(false);
+    }
+}
+
+export class AttributeMatcher extends BaseMatcher {
+    constructor(ctx: ExpectContext, private attrName: string, negated: boolean = false) {
+        super(ctx, negated);
+    }
+
+    get not(): AttributeMatcher {
+        return new AttributeMatcher(this.ctx, this.attrName, !this.negated);
+    }
+
+    async toBe(expected: string): Promise<void> {
+        await this.assertSnapshot(
+            s => s.attributes[this.attrName] === expected,
+            (s, n) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} attribute "${this.attrName}" ${n ? 'not ' : ''}to be "${expected}", got "${s.attributes[this.attrName] ?? '<missing>'}"`,
+        );
+    }
+
+    async toContain(expected: string): Promise<void> {
+        await this.assertSnapshot(
+            s => (s.attributes[this.attrName] ?? '').includes(expected),
+            (s, n) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} attribute "${this.attrName}" ${n ? 'not ' : ''}to contain "${expected}", got "${s.attributes[this.attrName] ?? '<missing>'}"`,
+        );
+    }
+
+    async toMatch(re: RegExp): Promise<void> {
+        await this.assertSnapshot(
+            s => re.test(s.attributes[this.attrName] ?? ''),
+            (s, n) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} attribute "${this.attrName}" ${n ? 'not ' : ''}to match ${re}, got "${s.attributes[this.attrName] ?? '<missing>'}"`,
+        );
+    }
+}
+
+export class AttributesMatcher extends BaseMatcher {
+    get not(): AttributesMatcher {
+        return new AttributesMatcher(this.ctx, !this.negated);
+    }
+
+    get(name: string): AttributeMatcher {
+        return new AttributeMatcher(this.ctx, name, this.negated);
+    }
+
+    async toHaveKey(name: string): Promise<void> {
+        await this.assertSnapshot(
+            s => name in s.attributes,
+            (s, n) =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} attributes ${n ? 'not ' : ''}to have key "${name}", present keys: [${Object.keys(s.attributes).join(', ')}]`,
+        );
+    }
+}
+
+export class CssMatcher extends BaseMatcher {
+    constructor(ctx: ExpectContext, private property: string, negated: boolean = false) {
+        super(ctx, negated);
+    }
+
+    get not(): CssMatcher {
+        return new CssMatcher(this.ctx, this.property, !this.negated);
+    }
+
+    async toBe(expected: string): Promise<void> {
+        let lastValue = '';
+        await this.assertCustom(
+            async () => {
+                const locator = await this.ctx.resolveLocator();
+                lastValue = await readCssProperty(locator, this.property);
+                return lastValue === expected;
+            },
+            n =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} css "${this.property}" ${n ? 'not ' : ''}to be "${expected}", got "${lastValue}"`,
+        );
+    }
+
+    async toContain(expected: string): Promise<void> {
+        let lastValue = '';
+        await this.assertCustom(
+            async () => {
+                const locator = await this.ctx.resolveLocator();
+                lastValue = await readCssProperty(locator, this.property);
+                return lastValue.includes(expected);
+            },
+            n =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} css "${this.property}" ${n ? 'not ' : ''}to contain "${expected}", got "${lastValue}"`,
+        );
+    }
+
+    async toMatch(re: RegExp): Promise<void> {
+        let lastValue = '';
+        await this.assertCustom(
+            async () => {
+                const locator = await this.ctx.resolveLocator();
+                lastValue = await readCssProperty(locator, this.property);
+                return re.test(lastValue);
+            },
+            n =>
+                `expected ${this.ctx.pageName}.${this.ctx.elementName} css "${this.property}" ${n ? 'not ' : ''}to match ${re}, got "${lastValue}"`,
+        );
+    }
+}
+
+/**
+ * Root of the matcher tree. Returned by `steps.expect(el, page)` and exposed
+ * via `.not` on `ElementAction`. Every matcher reached from here carries the
+ * negated flag inherited from this root.
+ */
+export class ExpectBuilder {
+    constructor(private ctx: ExpectContext, private negated: boolean = false) {}
+
+    get not(): ExpectBuilder {
+        return new ExpectBuilder(this.ctx, !this.negated);
+    }
+
+    get text(): TextMatcher {
+        return new TextMatcher(this.ctx, this.negated);
+    }
+
+    get value(): ValueMatcher {
+        return new ValueMatcher(this.ctx, this.negated);
+    }
+
+    get count(): CountMatcher {
+        return new CountMatcher(this.ctx, this.negated);
+    }
+
+    get visible(): BooleanMatcher {
+        return new BooleanMatcher(this.ctx, 'visible', this.negated);
+    }
+
+    get enabled(): BooleanMatcher {
+        return new BooleanMatcher(this.ctx, 'enabled', this.negated);
+    }
+
+    get attributes(): AttributesMatcher {
+        return new AttributesMatcher(this.ctx, this.negated);
+    }
+
+    css(property: string): CssMatcher {
+        return new CssMatcher(this.ctx, property, this.negated);
+    }
+}

--- a/src/utils/ElementUtilities.ts
+++ b/src/utils/ElementUtilities.ts
@@ -1,21 +1,28 @@
 import { Locator } from '@playwright/test';
+import { Element, WebElement } from '@civitas-cerebrum/element-repository';
 import { log } from '../logger/Logger';
+
+/** Accepts either a Playwright `Locator` or an element-repository `Element`. */
+type Waitable = Locator | Element;
+
+function toElement(target: Waitable): Element {
+    if ('_type' in target) return target as Element;
+    return new WebElement(target as Locator);
+}
 
 /**
  * Utility class to handle standardized waiting logic across the framework.
+ *
+ * All waits go through `Element.waitFor` rather than raw Playwright so the
+ * framework works consistently across web and platform drivers.
  */
 export class Utils {
     private readonly timeout: number;
-    /**
-     * @param timeout - Optional timeout in milliseconds. Defaults to 30000.
-     */
     constructor(timeout: number = 30000) {
         this.timeout = timeout;
     }
 
-    /**
-     * Returns the current timeout value.
-     */
+    /** Returns the current timeout value. */
     public getTimeout(): number {
         return this.timeout;
     }
@@ -23,25 +30,29 @@ export class Utils {
     /**
      * Standardized wait logic for element states.
      * Does not fail the test on timeout; logs a warning instead.
-     * If the locator resolves to multiple elements (strict mode violation),
+     * If the resolver yields multiple elements (strict mode violation),
      * the wait is retried automatically on the first matched element.
-     * @param locator - The Playwright Locator to wait on.
-     * @param state - The DOM state to wait for. Defaults to `'visible'`.
-     * @returns A Promise that resolves when the element reaches the desired state,
-     * or silently continues if the timeout is exceeded.
+     *
+     * @param target - An `Element` or Playwright `Locator` to wait on.
+     * @param state  - The state to wait for. Defaults to `'visible'`.
      */
     async waitForState(
-        locator: Locator,
-        state: 'visible' | 'attached' | 'hidden' | 'detached' = 'visible'
+        target: Waitable,
+        state: 'visible' | 'attached' | 'hidden' | 'detached' = 'visible',
     ): Promise<void> {
-        try { await locator.waitFor({ state, timeout: this.timeout }); }
-        catch (error) {
+        const element = toElement(target);
+        try {
+            await element.waitFor({ state, timeout: this.timeout });
+        } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
 
             if (message.includes('strict mode violation')) {
-                console.warn(`Locator resolved to multiple elements. Waiting on first element instead.`);
-                try { await locator.first().waitFor({ state, timeout: this.timeout }); }
-                catch { log.warn(`First element failed to reach state '${state}' within ${this.timeout}ms...`); }
+                console.warn('Locator resolved to multiple elements. Waiting on first element instead.');
+                try {
+                    await element.first().waitFor({ state, timeout: this.timeout });
+                } catch {
+                    log.warn(`First element failed to reach state '${state}' within ${this.timeout}ms...`);
+                }
                 return;
             }
 

--- a/tests/expect-chaining.spec.ts
+++ b/tests/expect-chaining.spec.ts
@@ -197,6 +197,146 @@ test.describe('steps.on() chain — .not is one-shot', () => {
     });
 });
 
+test.describe('steps.on() chain — repeated .not behavior', () => {
+    test.beforeEach(async ({ steps }) => { await gotoButtons(steps); });
+
+    test('.not.not cancels out — builder level', async ({ steps }) => {
+        // Equivalent to .text.toBe('Primary') — double negation = no negation
+        await steps.on('primaryButton', 'ButtonsPage').not.not.text.toBe('Primary');
+    });
+
+    test('.not.not.not collapses to .not — builder level', async ({ steps }) => {
+        // Three toggles → true. Equivalent to .not.text.toBe('Wrong')
+        await steps.on('primaryButton', 'ButtonsPage').not.not.not.text.toBe('Wrong');
+    });
+
+    test('.not.not cancels out — matcher level', async ({ steps }) => {
+        // Matcher-level `.not` flips `negated` flag on the matcher
+        await steps.on('primaryButton', 'ButtonsPage').text.not.not.toBe('Primary');
+    });
+
+    test('.not.not.not collapses to .not — matcher level', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').text.not.not.not.toBe('Wrong');
+    });
+
+    test('builder-level .not + matcher-level .not compose (both negate → cancel)', async ({ steps }) => {
+        // builder .not → pendingNot=true → consumed by .text → matcher negated=true
+        // matcher .not → negated=false → toBe runs NOT negated → must match 'Primary'
+        await steps.on('primaryButton', 'ButtonsPage').not.text.not.toBe('Primary');
+    });
+
+    test('builder-level .not cancels out, then matcher-level .not negates', async ({ steps }) => {
+        // .not.not → builder pendingNot=false → text gets negated=false
+        // .not → matcher negated=true → toBe runs negated → must NOT be 'Wrong'
+        await steps.on('primaryButton', 'ButtonsPage').not.not.text.not.toBe('Wrong');
+    });
+
+    test('.not consumed by one matcher does not re-apply to later matchers', async ({ steps }) => {
+        // .not → text negated=true → text.toBe('Wrong') negated = passes
+        // Next .text getter reads pendingNot=false (consumed) → NOT negated
+        await steps.on('primaryButton', 'ButtonsPage')
+            .not.text.toBe('Wrong')
+            .text.toBe('Primary');
+    });
+
+    test('alternating .not across several matchers in one chain', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage')
+            .not.text.toBe('Wrong')      // passes (negated, text IS 'Primary')
+            .count.toBe(1)                // passes (no negation)
+            .not.enabled.toBeFalse()      // passes (negated, enabled IS true)
+            .visible.toBeTrue()           // passes (no negation)
+            .not.not.attributes.toHaveKey('data-testid'); // no negation, passes
+    });
+
+    test('long chain — alternating not/normal/not across 12 verifications', async ({ steps }) => {
+        // Every line verifies something true about primaryButton.
+        // Negation states alternate to prove .not is reliably one-shot and
+        // the chain does not leak negation state between matchers.
+        await steps.on('primaryButton', 'ButtonsPage')
+            .text.toBe('Primary')                                      // normal
+            .not.text.toBe('Wrong')                                    // builder-level .not
+            .text.toContain('rim')                                     // normal
+            .text.not.toContain('Secondary')                           // matcher-level .not
+            .visible.toBeTrue()                                        // normal
+            .not.visible.toBeFalse()                                   // builder-level .not
+            .enabled.toBeTrue()                                        // normal
+            .enabled.not.toBe(false)                                   // matcher-level .not
+            .count.toBe(1)                                             // normal
+            .not.count.toBe(99)                                        // builder-level .not
+            .attributes.toHaveKey('data-testid')                       // normal
+            .attributes.not.toHaveKey('disabled')                      // matcher-level .not
+            .attributes.get('data-testid').toBe('btn-primary')         // normal
+            .attributes.get('data-testid').not.toBe('wrong-id')        // matcher-level .not
+            .css('cursor').toMatch(/pointer|default|auto/)             // normal
+            .css('cursor').not.toBe('not-a-real-cursor');              // matcher-level .not
+    });
+
+    test('long chain — mixed builder-level and matcher-level .not interleaved', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage')
+            .not.text.toBe('Wrong')                       // builder-.not
+            .text.not.toContain('xyz')                    // matcher-.not
+            .not.text.not.toBe('Primary')                 // builder-.not + matcher-.not → cancels, passes
+            .visible.toBeTrue()                           // normal
+            .not.visible.toBeFalse()                      // builder-.not
+            .not.not.enabled.toBeTrue()                   // double builder-.not cancels, normal
+            .attributes.not.toHaveKey('disabled')         // matcher-.not
+            .not.attributes.get('data-testid').toBe('no'); // builder-.not propagated into AttributeMatcher
+    });
+
+    test('long chain — predicate form alternated with matcher forms, all negated correctly', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage')
+            .text.toBe('Primary')                                         // normal field
+            .not.toBe(el => el.text === 'Wrong')                          // negated predicate
+            .count.toBe(1)                                                // normal field
+            .toBe(el => el.visible && el.enabled)                         // normal predicate
+            .not.attributes.toHaveKey('nonexistent')                      // negated field
+            .not.toBe(el => el.text === 'NotPrimary')                     // negated predicate
+            .visible.toBeTrue()                                           // normal field
+            .toBe(el => el.attributes['data-testid'] === 'btn-primary');  // normal predicate
+    });
+
+    test('long chain fails at a specific mid-chain negated assertion — short-circuits remaining', async ({ page, repo }) => {
+        const fast = new ElementInteractions(page, { timeout: FAST_TIMEOUT });
+        const action = new ElementAction(repo, 'primaryButton', 'ButtonsPage', fast, FAST_TIMEOUT);
+
+        await page.goto('/');
+        await page.click('[data-testid=\'nav-item-buttons\']');
+
+        // First three pass, fourth is a negated assertion that's actually true
+        // (so the negation fails), short-circuiting the remaining matchers.
+        let tailCalls = 0;
+        const chain = action
+            .text.toBe('Primary')                               // passes
+            .visible.toBeTrue()                                 // passes
+            .not.count.toBe(99)                                 // passes (count=1, not=99, so negated-against-99 passes)
+            .not.text.toBe('Primary')                           // FAILS — text IS 'Primary' and we assert NOT Primary
+            .text.toContain('rim')                              // must not run
+            .toBe(el => { tailCalls += 1; return true; })       // must not run
+            .count.toBe(1);                                     // must not run
+
+        await expect(chain).rejects.toThrow(/text not to be "Primary"/);
+        expect(tailCalls).toBe(0);
+    });
+
+    test('repeated .not toggles still honor short-circuit on failure', async ({ page, repo }) => {
+        const fast = new ElementInteractions(page, { timeout: FAST_TIMEOUT });
+        const action = new ElementAction(repo, 'primaryButton', 'ButtonsPage', fast, FAST_TIMEOUT);
+
+        await page.goto('/');
+        await page.click('[data-testid=\'nav-item-buttons\']');
+
+        // .not.not.text.toBe('WRONG') → no negation, text is 'Primary' not 'WRONG' → FAILS fast
+        // subsequent matcher must NOT run
+        let lateCalls = 0;
+        const chain = action
+            .not.not.text.toBe('WRONG')
+            .toBe(el => { lateCalls += 1; return true; });
+
+        await expect(chain).rejects.toThrow(/text to be "WRONG"/);
+        expect(lateCalls).toBe(0);
+    });
+});
+
 test.describe('steps.on() chain — short-circuit on first failure', () => {
     test('second assertion is not evaluated after first fails', async ({ page, repo }) => {
         const fast = new ElementInteractions(page, { timeout: FAST_TIMEOUT });

--- a/tests/expect-chaining.spec.ts
+++ b/tests/expect-chaining.spec.ts
@@ -1,0 +1,275 @@
+import { test, expect } from './fixture/StepFixture';
+import { ElementAction, ElementInteractions } from '../src';
+
+/**
+ * Chained multi-verification on `steps.on()`. Each matcher call enqueues an
+ * assertion and returns the builder; awaiting flushes the queue sequentially;
+ * first failure short-circuits the rest.
+ *
+ * The tests exercise:
+ *   - Multiple field matchers in one chained expression
+ *   - `.not` as a one-shot flag (applies only to the next matcher)
+ *   - `.throws(msg)` attaching to the most recently queued assertion
+ *   - `.timeout(ms)` scoping retroactively to the last queued assertion
+ *   - Short-circuit — assertions after the first failure do not execute
+ *   - Predicate form mixed with field matchers in the same chain
+ */
+
+const FAST_TIMEOUT = 500;
+
+async function gotoButtons(steps: any) {
+    await steps.navigateTo('/');
+    await steps.click('buttonsLink', 'SidebarNav');
+    await steps.verifyUrlContains('/buttons');
+}
+
+test.describe('steps.on() — chained multi-verification', () => {
+    test.beforeEach(async ({ steps }) => { await gotoButtons(steps); });
+
+    test('two matchers chained on one element both pass', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage')
+            .text.toBe('Primary')
+            .visible.toBeTrue();
+    });
+
+    test('four matchers chained on one element all pass', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage')
+            .text.toBe('Primary')
+            .visible.toBeTrue()
+            .enabled.toBeTrue()
+            .count.toBe(1);
+    });
+
+    test('chain mixes field matchers with attribute matchers', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage')
+            .text.toContain('rim')
+            .attributes.get('data-testid').toBe('btn-primary')
+            .visible.toBeTrue();
+    });
+
+    test('chain with css matcher works', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage')
+            .text.toBe('Primary')
+            .css('cursor').toMatch(/pointer|default|auto/);
+    });
+
+    test('predicate form in the middle of a chain', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage')
+            .text.toBe('Primary')
+            .toBe(el => el.visible && el.enabled)
+            .count.toBe(1);
+    });
+
+    test('kitchen sink — 8 chained verifications on a single element', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage')
+            .text.toBe('Primary')
+            .text.toContain('rim')
+            .text.toMatch(/^Prim/)
+            .visible.toBeTrue()
+            .enabled.toBeTrue()
+            .count.toBe(1)
+            .attributes.get('data-testid').toBe('btn-primary')
+            .attributes.toHaveKey('data-testid')
+            .css('cursor').toMatch(/pointer|default|auto/)
+            .toBe(el => el.visible && el.enabled && el.text === 'Primary');
+    });
+
+    test('realistic submit-button scenario — text, state, attributes, negation, predicate', async ({ steps }) => {
+        // A realistic assertion a test author would write about a "submit"-style
+        // button: it has the right label, is visible and enabled, carries the
+        // expected data-testid, is not disabled, has a valid cursor style, and
+        // its overall shape satisfies a compound predicate.
+        await steps.on('primaryButton', 'ButtonsPage')
+            .text.toBe('Primary')
+            .visible.toBeTrue()
+            .enabled.toBeTrue()
+            .attributes.get('data-testid').toBe('btn-primary')
+            .not.attributes.toHaveKey('disabled')
+            .css('cursor').toMatch(/pointer|default|auto/)
+            .toBe(el => el.text === 'Primary' && el.visible && el.enabled);
+    });
+
+    test('long chain with mixed matcher-level timeouts — each scoped correctly', async ({ steps }) => {
+        // Every assertion in the chain sets its own timeout; all should pass,
+        // proving each timeout is honored without leaking into neighbors.
+        await steps.on('primaryButton', 'ButtonsPage')
+            .text.timeout(5000).toBe('Primary')
+            .visible.timeout(100).toBeTrue()
+            .enabled.timeout(2000).toBeTrue()
+            .count.timeout(500).toBe(1)
+            .attributes.timeout(100).toHaveKey('data-testid')
+            .attributes.get('data-testid').timeout(3000).toBe('btn-primary')
+            .css('cursor').timeout(200).toMatch(/pointer|default|auto/);
+    });
+
+    test('builder-level timeout(long) with a single matcher-level timeout(short) override', async ({ steps }) => {
+        // Builder sets a generous 5s default for every matcher.
+        // One specific matcher overrides with a tight 200ms that still passes.
+        // The remaining matchers all use the 5s default.
+        await steps.on('primaryButton', 'ButtonsPage')
+            .timeout(5000)
+            .text.toBe('Primary')
+            .visible.toBeTrue()
+            .enabled.timeout(200).toBeTrue()    // tight override, still passes
+            .count.toBe(1)
+            .attributes.get('data-testid').toBe('btn-primary');
+    });
+
+    test('short per-matcher timeout on a failing assertion fails fast inside a long chain', async ({ page, repo }) => {
+        const fast = new ElementInteractions(page, { timeout: 30000 });
+        const action = new ElementAction(repo, 'primaryButton', 'ButtonsPage', fast, 30000);
+
+        await page.goto('/');
+        await page.click('[data-testid=\'nav-item-buttons\']');
+
+        // Chain where the 3rd matcher has a 300ms timeout on a value that
+        // never matches. The whole chain should fail inside ~1s, not the
+        // default 30s — proving the per-matcher timeout is honored.
+        const start = Date.now();
+        await expect(
+            action
+                .text.toBe('Primary')
+                .visible.toBeTrue()
+                .text.timeout(300).toBe('NEVER_MATCHES'),
+        ).rejects.toThrow(/text to be "NEVER_MATCHES"/);
+        const elapsed = Date.now() - start;
+        expect(elapsed).toBeLessThan(2000);
+    });
+
+    test('trailing builder-level timeout() scopes retroactively to preceding assertion only', async ({ page, repo }) => {
+        const fast = new ElementInteractions(page, { timeout: 30000 });
+        const action = new ElementAction(repo, 'primaryButton', 'ButtonsPage', fast, 30000);
+
+        await page.goto('/');
+        await page.click('[data-testid=\'nav-item-buttons\']');
+
+        // `.toBe(pred).timeout(400)` retroactively tightens the predicate's
+        // timeout. First failing assertion here is the predicate; must fail
+        // within ~1s regardless of the builder's 30s default.
+        const start = Date.now();
+        await expect(
+            action
+                .text.toBe('Primary')
+                .toBe(el => el.text === 'NEVER_MATCHES').timeout(400),
+        ).rejects.toThrow(/predicate|snapshot at timeout/i);
+        const elapsed = Date.now() - start;
+        expect(elapsed).toBeLessThan(2000);
+    });
+
+    test('kitchen sink short-circuits on first failure out of 8', async ({ page, repo }) => {
+        const fast = new ElementInteractions(page, { timeout: FAST_TIMEOUT });
+        const action = new ElementAction(repo, 'primaryButton', 'ButtonsPage', fast, FAST_TIMEOUT);
+
+        await page.goto('/');
+        await page.click('[data-testid=\'nav-item-buttons\']');
+
+        let latePredicateCalls = 0;
+        const chain = action
+            .text.toBe('Primary')                           // passes
+            .visible.toBeTrue()                             // passes
+            .enabled.toBeTrue()                             // passes
+            .text.toBe('WRONG')                             // fails — short-circuit
+            .toBe(el => { latePredicateCalls += 1; return true; }) // must NOT run
+            .count.toBe(1);                                 // must NOT run
+
+        await expect(chain).rejects.toThrow(/text to be "WRONG"/);
+        expect(latePredicateCalls).toBe(0);
+    });
+});
+
+test.describe('steps.on() chain — .not is one-shot', () => {
+    test.beforeEach(async ({ steps }) => { await gotoButtons(steps); });
+
+    test('.not applies only to the next matcher, not the rest of the chain', async ({ steps }) => {
+        // text.not.toBe('Nope') → passes (text IS Primary, not "Nope")
+        // count.toBe(1)          → passes (count IS 1, no negation leaks in)
+        await steps.on('primaryButton', 'ButtonsPage')
+            .not.text.toBe('Nope')
+            .count.toBe(1);
+    });
+
+    test('two separate .not applications in one chain', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage')
+            .not.text.toBe('Wrong')
+            .visible.toBeTrue()
+            .not.count.toBe(99)
+            .enabled.toBeTrue();
+    });
+});
+
+test.describe('steps.on() chain — short-circuit on first failure', () => {
+    test('second assertion is not evaluated after first fails', async ({ page, repo }) => {
+        const fast = new ElementInteractions(page, { timeout: FAST_TIMEOUT });
+        const action = new ElementAction(repo, 'primaryButton', 'ButtonsPage', fast, FAST_TIMEOUT);
+
+        // Navigate so the element resolves
+        await page.goto('/');
+        await page.click('[data-testid=\'nav-item-buttons\']');
+
+        let secondPredicateCalls = 0;
+        const chain = action
+            .text.toBe('WRONG')                            // first — will fail
+            .toBe(el => { secondPredicateCalls += 1; return true; }); // second — must NOT run
+
+        await expect(chain).rejects.toThrow(/text to be "WRONG"/);
+        expect(secondPredicateCalls).toBe(0);
+    });
+});
+
+test.describe('steps.on() chain — .throws() attaches to last queued assertion', () => {
+    test('.throws() overrides the message of the preceding matcher', async ({ page, repo }) => {
+        const fast = new ElementInteractions(page, { timeout: FAST_TIMEOUT });
+        const action = new ElementAction(repo, 'primaryButton', 'ButtonsPage', fast, FAST_TIMEOUT);
+
+        await page.goto('/');
+        await page.click('[data-testid=\'nav-item-buttons\']');
+
+        await expect(
+            action.text.toBe('WRONG').throws('text override message'),
+        ).rejects.toThrow(/text override message/);
+    });
+
+    test('.throws() applies to the predicate form too', async ({ page, repo }) => {
+        const fast = new ElementInteractions(page, { timeout: FAST_TIMEOUT });
+        const action = new ElementAction(repo, 'primaryButton', 'ButtonsPage', fast, FAST_TIMEOUT);
+
+        await page.goto('/');
+        await page.click('[data-testid=\'nav-item-buttons\']');
+
+        await expect(
+            action.toBe(el => el.text === 'WRONG').throws('predicate override'),
+        ).rejects.toThrow(/predicate override/);
+    });
+});
+
+test.describe('steps.on() chain — .timeout() scopes to last queued assertion', () => {
+    test('trailing .timeout() shortens the preceding assertion', async ({ page, repo }) => {
+        const fast = new ElementInteractions(page, { timeout: 30000 });
+        const action = new ElementAction(repo, 'primaryButton', 'ButtonsPage', fast, 30000);
+
+        await page.goto('/');
+        await page.click('[data-testid=\'nav-item-buttons\']');
+
+        const start = Date.now();
+        await expect(
+            action.text.toBe('WRONG').timeout(500),
+        ).rejects.toThrow(/text to be/);
+        const elapsed = Date.now() - start;
+        expect(elapsed).toBeLessThan(2000);
+    });
+
+    test('.timeout() on builder also affects future matchers (persistent mutation)', async ({ page, repo }) => {
+        const fast = new ElementInteractions(page, { timeout: 30000 });
+        const action = new ElementAction(repo, 'primaryButton', 'ButtonsPage', fast, 30000);
+
+        await page.goto('/');
+        await page.click('[data-testid=\'nav-item-buttons\']');
+
+        const start = Date.now();
+        await expect(
+            action.timeout(500).text.toBe('WRONG'),
+        ).rejects.toThrow(/text to be/);
+        const elapsed = Date.now() - start;
+        expect(elapsed).toBeLessThan(2000);
+    });
+});

--- a/tests/expect-combinatorial.spec.ts
+++ b/tests/expect-combinatorial.spec.ts
@@ -1,0 +1,427 @@
+import { test, expect } from './fixture/StepFixture';
+
+/**
+ * Combinatorial coverage for the new matcher tree:
+ *   - Every strategy selector × every matcher field (fluent)
+ *   - Every matcher field at the top level (steps.expect)
+ *   - Strategy selectors composed with `.not` and predicate forms
+ *
+ * Kept separate from expect-matchers.spec.ts (which focuses on per-matcher
+ * positive / negative correctness) so this file can stay a pure matrix.
+ */
+
+async function gotoButtons(steps: any) {
+    await steps.navigateTo('/');
+    await steps.click('buttonsLink', 'SidebarNav');
+    await steps.verifyUrlContains('/buttons');
+}
+
+async function gotoTextInputs(steps: any) {
+    await steps.navigateTo('/');
+    await steps.click('textInputsLink', 'SidebarNav');
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Fluent matcher tree × strategy selectors
+// ───────────────────────────────────────────────────────────────────────
+
+test.describe('on().first() × matchers', () => {
+    test.beforeEach(async ({ steps }) => { await gotoButtons(steps); });
+
+    test('first() × text.toBe', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').first().text.toBe('Primary');
+    });
+
+    test('first() × count.toBe', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').first().count.toBe(1);
+    });
+
+    test('first() × visible.toBeTrue', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').first().visible.toBeTrue();
+    });
+
+    test('first() × enabled.toBeTrue', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').first().enabled.toBeTrue();
+    });
+
+    test('first() × attributes.get().toBe', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').first().attributes.get('data-testid').toBe('btn-primary');
+    });
+
+    test('first() × css().toMatch', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').first().css('cursor').toMatch(/pointer|default|auto/);
+    });
+
+    test('first() × expect(predicate)', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').first().expect(el => el.text === 'Primary');
+    });
+
+    test('first() × not.text.toBe', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').first().not.text.toBe('Nope');
+    });
+});
+
+test.describe('on().nth() × matchers', () => {
+    test.beforeEach(async ({ steps }) => { await gotoButtons(steps); });
+
+    test('nth(0) × text.toContain', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').nth(0).text.toContain('rim');
+    });
+
+    test('nth(0) × count.toBe', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').nth(0).count.toBe(1);
+    });
+
+    test('nth(0) × visible.toBe(true)', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').nth(0).visible.toBe(true);
+    });
+
+    test('nth(0) × enabled.toBeTrue', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').nth(0).enabled.toBeTrue();
+    });
+
+    test('nth(0) × attributes.toHaveKey', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').nth(0).attributes.toHaveKey('data-testid');
+    });
+
+    test('nth(0) × css().toBe', async ({ steps }) => {
+        const cursor = await steps.getCssProperty('primaryButton', 'ButtonsPage', 'cursor');
+        await steps.on('primaryButton', 'ButtonsPage').nth(0).css('cursor').toBe(cursor);
+    });
+
+    test('nth(0) × expect(predicate)', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').nth(0).expect(el => el.enabled && el.visible);
+    });
+
+    test('nth(0) × not.text.toContain', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').nth(0).not.text.toContain('xyz');
+    });
+});
+
+test.describe('on().random() × matchers', () => {
+    test.beforeEach(async ({ steps }) => { await gotoButtons(steps); });
+
+    test('random() × text.toBe', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').random().text.toBe('Primary');
+    });
+
+    test('random() × count.toBeGreaterThan', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').random().count.toBeGreaterThan(0);
+    });
+
+    test('random() × visible.toBeTrue', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').random().visible.toBeTrue();
+    });
+
+    test('random() × enabled.toBeTrue', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').random().enabled.toBeTrue();
+    });
+
+    test('random() × attributes.get().toMatch', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').random().attributes.get('data-testid').toMatch(/^btn-/);
+    });
+
+    test('random() × expect(predicate)', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').random().expect(el => el.text.length > 0);
+    });
+
+    test('random() × not.text.toBe', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').random().not.text.toBe('not-this');
+    });
+});
+
+test.describe('on().byText() × matchers', () => {
+    test.beforeEach(async ({ steps }) => { await gotoButtons(steps); });
+
+    test('byText() × text.toBe', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').byText('Primary').text.toBe('Primary');
+    });
+
+    test('byText() × count.toBeGreaterThan', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').byText('Primary').count.toBeGreaterThan(0);
+    });
+
+    test('byText() × visible.toBeTrue', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').byText('Primary').visible.toBeTrue();
+    });
+
+    test('byText() × enabled.toBeTrue', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').byText('Primary').enabled.toBeTrue();
+    });
+
+    test('byText() × attributes.get().toBe', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').byText('Primary').attributes.get('data-testid').toBe('btn-primary');
+    });
+
+    test('byText() × expect(predicate)', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').byText('Primary').expect(el => el.visible);
+    });
+
+    test('byText() × not.text.toContain', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').byText('Primary').not.text.toContain('Secondary');
+    });
+});
+
+test.describe('on().byAttribute() × matchers', () => {
+    test.beforeEach(async ({ steps }) => { await gotoButtons(steps); });
+
+    test('byAttribute() × text.toBe', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').byAttribute('data-testid', 'btn-primary').text.toBe('Primary');
+    });
+
+    test('byAttribute() × count.toBe', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').byAttribute('data-testid', 'btn-primary').count.toBe(1);
+    });
+
+    test('byAttribute() × visible.toBeTrue', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').byAttribute('data-testid', 'btn-primary').visible.toBeTrue();
+    });
+
+    test('byAttribute() × attributes.get().toBe', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').byAttribute('data-testid', 'btn-primary').attributes.get('data-testid').toBe('btn-primary');
+    });
+
+    test('byAttribute() × expect(predicate)', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').byAttribute('data-testid', 'btn-primary').expect(el => el.text === 'Primary');
+    });
+
+    test('byAttribute() × not.attributes.get().toBe', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').byAttribute('data-testid', 'btn-primary').not.attributes.get('data-testid').toBe('wrong');
+    });
+});
+
+test.describe('on().ifVisible() × matchers', () => {
+    test.beforeEach(async ({ steps }) => { await gotoButtons(steps); });
+
+    test('ifVisible() × text.toBe — present element runs the assertion', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').ifVisible().text.toBe('Primary');
+    });
+
+    test('ifVisible() × count.toBe — present element runs', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').ifVisible().count.toBe(1);
+    });
+
+    test('ifVisible() × attributes.toHaveKey — present element runs', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').ifVisible().attributes.toHaveKey('data-testid');
+    });
+
+    test('ifVisible() × css().toMatch — present element runs', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').ifVisible().css('cursor').toMatch(/pointer|default|auto/);
+    });
+
+    test('ifVisible() × predicate — present element runs', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').ifVisible().expect(el => el.text === 'Primary');
+    });
+
+    test('ifVisible() × text.toBe on hidden element — silently skips', async ({ steps }) => {
+        await steps.on('noSuchElement', 'ButtonsPage').ifVisible(200).text.toBe('whatever');
+    });
+
+    test('ifVisible() × count.toBe on hidden — silently skips', async ({ steps }) => {
+        await steps.on('noSuchElement', 'ButtonsPage').ifVisible(200).count.toBe(99);
+    });
+
+    test('ifVisible() × visible.toBeTrue on hidden — silently skips', async ({ steps }) => {
+        await steps.on('noSuchElement', 'ButtonsPage').ifVisible(200).visible.toBeTrue();
+    });
+
+    test('ifVisible() × attributes.toHaveKey on hidden — silently skips', async ({ steps }) => {
+        await steps.on('noSuchElement', 'ButtonsPage').ifVisible(200).attributes.toHaveKey('anything');
+    });
+
+    test('ifVisible() × css().toBe on hidden — silently skips', async ({ steps }) => {
+        await steps.on('noSuchElement', 'ButtonsPage').ifVisible(200).css('color').toBe('irrelevant');
+    });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// steps.expect() — full top-level coverage
+// ───────────────────────────────────────────────────────────────────────
+
+test.describe('steps.expect() × every field matcher (top-level)', () => {
+    test.beforeEach(async ({ steps }) => { await gotoButtons(steps); });
+
+    test('.text.toBe', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').text.toBe('Primary');
+    });
+
+    test('.text.toContain', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').text.toContain('rim');
+    });
+
+    test('.text.toMatch', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').text.toMatch(/^Prim/);
+    });
+
+    test('.text.toStartWith', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').text.toStartWith('Prim');
+    });
+
+    test('.text.toEndWith', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').text.toEndWith('mary');
+    });
+
+    test('.count.toBe', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').count.toBe(1);
+    });
+
+    test('.count.toBeGreaterThan', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').count.toBeGreaterThan(0);
+    });
+
+    test('.count.toBeLessThan', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').count.toBeLessThan(10);
+    });
+
+    test('.count.toBeGreaterThanOrEqual', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').count.toBeGreaterThanOrEqual(1);
+    });
+
+    test('.count.toBeLessThanOrEqual', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').count.toBeLessThanOrEqual(1);
+    });
+
+    test('.visible.toBeTrue', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').visible.toBeTrue();
+    });
+
+    test('.visible.toBe(true)', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').visible.toBe(true);
+    });
+
+    test('.visible.toBeFalse on disabled (but visible) is flipped via .not', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').not.visible.toBeFalse();
+    });
+
+    test('.enabled.toBeTrue', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').enabled.toBeTrue();
+    });
+
+    test('.enabled.toBeFalse on disabled button', async ({ steps }) => {
+        await steps.expect('disabledButton', 'ButtonsPage').enabled.toBeFalse();
+    });
+
+    test('.attributes.get().toBe', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').attributes.get('data-testid').toBe('btn-primary');
+    });
+
+    test('.attributes.get().toContain', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').attributes.get('data-testid').toContain('primary');
+    });
+
+    test('.attributes.get().toMatch', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').attributes.get('data-testid').toMatch(/^btn-/);
+    });
+
+    test('.attributes.toHaveKey', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').attributes.toHaveKey('data-testid');
+    });
+
+    test('.css().toBe', async ({ steps }) => {
+        const cursor = await steps.getCssProperty('primaryButton', 'ButtonsPage', 'cursor');
+        await steps.expect('primaryButton', 'ButtonsPage').css('cursor').toBe(cursor);
+    });
+
+    test('.css().toContain', async ({ steps }) => {
+        const cursor = await steps.getCssProperty('primaryButton', 'ButtonsPage', 'cursor');
+        await steps.expect('primaryButton', 'ButtonsPage').css('cursor').toContain(cursor.slice(0, 3));
+    });
+
+    test('.css().toMatch', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').css('cursor').toMatch(/pointer|default|auto/);
+    });
+
+    test('predicate overload — positive', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage', el => el.text === 'Primary');
+    });
+
+    test('predicate overload — with message', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage', el => el.visible && el.enabled, 'must be visible and enabled');
+    });
+});
+
+test.describe('steps.expect() — value matcher (input fields)', () => {
+    test.beforeEach(async ({ steps }) => { await gotoTextInputs(steps); });
+
+    test('.value.toBe on typed input', async ({ steps }) => {
+        await steps.fill('textInput', 'TextInputsPage', 'Alice');
+        await steps.expect('textInput', 'TextInputsPage').value.toBe('Alice');
+    });
+
+    test('.value.toContain / toMatch / toStartWith / toEndWith', async ({ steps }) => {
+        await steps.fill('textInput', 'TextInputsPage', 'Alice Example');
+        await steps.expect('textInput', 'TextInputsPage').value.toContain('lice');
+        await steps.expect('textInput', 'TextInputsPage').value.toMatch(/^Alice/);
+        await steps.expect('textInput', 'TextInputsPage').value.toStartWith('Alice');
+        await steps.expect('textInput', 'TextInputsPage').value.toEndWith('Example');
+    });
+
+    test('.value.not.toBe', async ({ steps }) => {
+        await steps.fill('textInput', 'TextInputsPage', 'Alice');
+        await steps.expect('textInput', 'TextInputsPage').value.not.toBe('Bob');
+    });
+});
+
+test.describe('steps.expect() — .not negation on every field', () => {
+    test.beforeEach(async ({ steps }) => { await gotoButtons(steps); });
+
+    test('.not.text.toBe', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').not.text.toBe('Nope');
+    });
+
+    test('.text.not.toContain', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').text.not.toContain('xyz');
+    });
+
+    test('.not.count.toBe', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').not.count.toBe(99);
+    });
+
+    test('.count.not.toBe', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').count.not.toBe(99);
+    });
+
+    test('.not.visible.toBeFalse (visible element)', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').not.visible.toBeFalse();
+    });
+
+    test('.visible.not.toBeFalse', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').visible.not.toBeFalse();
+    });
+
+    test('.not.enabled.toBeFalse (enabled element)', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').not.enabled.toBeFalse();
+    });
+
+    test('.not.attributes.toHaveKey', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').not.attributes.toHaveKey('nonexistent');
+    });
+
+    test('.attributes.not.toHaveKey', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').attributes.not.toHaveKey('nonexistent');
+    });
+
+    test('.attributes.get().not.toBe', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').attributes.get('data-testid').not.toBe('btn-secondary');
+    });
+
+    test('.not.attributes.get().toBe (via ExpectBuilder.not propagation)', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').not.attributes.get('data-testid').toBe('btn-secondary');
+    });
+
+    test('.not.css().toBe', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').not.css('cursor').toBe('not-a-real-cursor');
+    });
+
+    test('.css().not.toBe', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').css('cursor').not.toBe('not-a-real-cursor');
+    });
+
+    test('.css().not.toContain', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').css('cursor').not.toContain('nonsense');
+    });
+
+    test('.css().not.toMatch', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').css('cursor').not.toMatch(/nonsense/);
+    });
+});

--- a/tests/expect-combinatorial.spec.ts
+++ b/tests/expect-combinatorial.spec.ts
@@ -53,7 +53,7 @@ test.describe('on().first() × matchers', () => {
     });
 
     test('first() × expect(predicate)', async ({ steps }) => {
-        await steps.on('primaryButton', 'ButtonsPage').first().expect(el => el.text === 'Primary');
+        await steps.on('primaryButton', 'ButtonsPage').first().toBe(el => el.text === 'Primary');
     });
 
     test('first() × not.text.toBe', async ({ steps }) => {
@@ -90,7 +90,7 @@ test.describe('on().nth() × matchers', () => {
     });
 
     test('nth(0) × expect(predicate)', async ({ steps }) => {
-        await steps.on('primaryButton', 'ButtonsPage').nth(0).expect(el => el.enabled && el.visible);
+        await steps.on('primaryButton', 'ButtonsPage').nth(0).toBe(el => el.enabled && el.visible);
     });
 
     test('nth(0) × not.text.toContain', async ({ steps }) => {
@@ -122,7 +122,7 @@ test.describe('on().random() × matchers', () => {
     });
 
     test('random() × expect(predicate)', async ({ steps }) => {
-        await steps.on('primaryButton', 'ButtonsPage').random().expect(el => el.text.length > 0);
+        await steps.on('primaryButton', 'ButtonsPage').random().toBe(el => el.text.length > 0);
     });
 
     test('random() × not.text.toBe', async ({ steps }) => {
@@ -154,7 +154,7 @@ test.describe('on().byText() × matchers', () => {
     });
 
     test('byText() × expect(predicate)', async ({ steps }) => {
-        await steps.on('primaryButton', 'ButtonsPage').byText('Primary').expect(el => el.visible);
+        await steps.on('primaryButton', 'ButtonsPage').byText('Primary').toBe(el => el.visible);
     });
 
     test('byText() × not.text.toContain', async ({ steps }) => {
@@ -182,7 +182,7 @@ test.describe('on().byAttribute() × matchers', () => {
     });
 
     test('byAttribute() × expect(predicate)', async ({ steps }) => {
-        await steps.on('primaryButton', 'ButtonsPage').byAttribute('data-testid', 'btn-primary').expect(el => el.text === 'Primary');
+        await steps.on('primaryButton', 'ButtonsPage').byAttribute('data-testid', 'btn-primary').toBe(el => el.text === 'Primary');
     });
 
     test('byAttribute() × not.attributes.get().toBe', async ({ steps }) => {
@@ -210,7 +210,7 @@ test.describe('on().ifVisible() × matchers', () => {
     });
 
     test('ifVisible() × predicate — present element runs', async ({ steps }) => {
-        await steps.on('primaryButton', 'ButtonsPage').ifVisible().expect(el => el.text === 'Primary');
+        await steps.on('primaryButton', 'ButtonsPage').ifVisible().toBe(el => el.text === 'Primary');
     });
 
     test('ifVisible() × text.toBe on hidden element — silently skips', async ({ steps }) => {
@@ -331,12 +331,18 @@ test.describe('steps.expect() × every field matcher (top-level)', () => {
         await steps.expect('primaryButton', 'ButtonsPage').css('cursor').toMatch(/pointer|default|auto/);
     });
 
-    test('predicate overload — positive', async ({ steps }) => {
-        await steps.expect('primaryButton', 'ButtonsPage', el => el.text === 'Primary');
+    test('.toBe(predicate) positive', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').toBe(el => el.text === 'Primary');
     });
 
-    test('predicate overload — with message', async ({ steps }) => {
-        await steps.expect('primaryButton', 'ButtonsPage', el => el.visible && el.enabled, 'must be visible and enabled');
+    test('.toBe(predicate).throws(message) sets custom message', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage')
+            .toBe(el => el.visible && el.enabled)
+            .throws('must be visible and enabled');
+    });
+
+    test('.not.toBe(predicate) flips outcome', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').not.toBe(el => el.text === 'Wrong');
     });
 });
 

--- a/tests/expect-matchers.spec.ts
+++ b/tests/expect-matchers.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from './fixture/StepFixture';
 import { ElementAction, ElementInteractions } from '../src';
+import { gotoButtons } from './fixture/pageHelpers';
 
 /**
  * Covers the expect matcher tree on both:
@@ -13,12 +14,6 @@ import { ElementAction, ElementInteractions } from '../src';
  */
 
 const FAST_TIMEOUT = 500;
-
-async function gotoButtons(steps: any) {
-    await steps.navigateTo('/');
-    await steps.click('buttonsLink', 'SidebarNav');
-    await steps.verifyUrlContains('/buttons');
-}
 
 test.describe('Expect matcher tree — text', () => {
     test.beforeEach(async ({ steps }) => {
@@ -233,6 +228,14 @@ test.describe('Expect matcher tree — predicate escape hatch', () => {
         // Build the assertion without awaiting, then await later — must succeed.
         const pending = steps.on('primaryButton', 'ButtonsPage').toBe(el => el.visible);
         await pending;
+    });
+
+    test('builder.then() is callable directly (PromiseLike contract)', async ({ steps }) => {
+        // Covers ExpectBuilder.then explicitly — this is what `await` triggers under the hood.
+        const builder = steps.on('primaryButton', 'ButtonsPage').text.toBe('Primary');
+        await new Promise<void>((resolve, reject) => {
+            builder.then(() => resolve(), reject);
+        });
     });
 });
 

--- a/tests/expect-matchers.spec.ts
+++ b/tests/expect-matchers.spec.ts
@@ -202,31 +202,37 @@ test.describe('Expect matcher tree — predicate escape hatch', () => {
     });
 
     test('fluent predicate passes when true', async ({ steps }) => {
-        await steps.on('primaryButton', 'ButtonsPage').expect(el => el.text === 'Primary');
+        await steps.on('primaryButton', 'ButtonsPage').toBe(el => el.text === 'Primary');
     });
 
     test('top-level predicate passes when true', async ({ steps }) => {
-        await steps.expect('primaryButton', 'ButtonsPage', el => el.text === 'Primary');
+        await steps.expect('primaryButton', 'ButtonsPage').toBe(el => el.text === 'Primary');
     });
 
     test('predicate reads multiple snapshot fields', async ({ steps }) => {
-        await steps.on('primaryButton', 'ButtonsPage').expect(
+        await steps.on('primaryButton', 'ButtonsPage').toBe(
             el => el.visible && el.enabled && el.text === 'Primary' && el.attributes['data-testid'] === 'btn-primary',
         );
     });
 
-    test('predicate failure surfaces custom message', async ({ page, repo }) => {
+    test('.throws(message) surfaces custom failure message', async ({ page, repo }) => {
         const fast = new ElementInteractions(page, { timeout: FAST_TIMEOUT });
         const action = new ElementAction(repo, 'primaryButton', 'ButtonsPage', fast, FAST_TIMEOUT);
         await expect(
-            action.expect(el => el.text === 'NotThere', 'primary must say NotThere'),
+            action.toBe(el => el.text === 'NotThere').throws('primary must say NotThere'),
         ).rejects.toThrow(/primary must say NotThere/);
     });
 
-    test('predicate failure includes snapshot JSON', async ({ page, repo }) => {
+    test('default failure includes snapshot JSON', async ({ page, repo }) => {
         const fast = new ElementInteractions(page, { timeout: FAST_TIMEOUT });
         const action = new ElementAction(repo, 'primaryButton', 'ButtonsPage', fast, FAST_TIMEOUT);
-        await expect(action.expect(el => el.text === 'Nope')).rejects.toThrow(/snapshot at timeout/);
+        await expect(action.toBe(el => el.text === 'Nope')).rejects.toThrow(/snapshot at timeout/);
+    });
+
+    test('chain is synchronous before await (thenable semantics)', async ({ steps }) => {
+        // Build the assertion without awaiting, then await later — must succeed.
+        const pending = steps.on('primaryButton', 'ButtonsPage').toBe(el => el.visible);
+        await pending;
     });
 });
 
@@ -255,6 +261,6 @@ test.describe('Expect matcher tree — ifVisible composition', () => {
     });
 
     test('ifVisible() + predicate silently skips when element is hidden', async ({ steps }) => {
-        await steps.on('noSuchElement', 'ButtonsPage').ifVisible(200).expect(el => el.text === 'x');
+        await steps.on('noSuchElement', 'ButtonsPage').ifVisible(200).toBe(el => el.text === 'x');
     });
 });

--- a/tests/expect-matchers.spec.ts
+++ b/tests/expect-matchers.spec.ts
@@ -1,0 +1,260 @@
+import { test, expect } from './fixture/StepFixture';
+import { ElementAction, ElementInteractions } from '../src';
+
+/**
+ * Covers the expect matcher tree on both:
+ *   - `steps.expect(el, page).<matcher>` (top-level entry)
+ *   - `steps.on(el, page).<matcher>`     (fluent builder getter)
+ *
+ * Plus the predicate escape hatch in both shapes and `.not` negation.
+ *
+ * Negative-path tests construct ElementAction directly with a short timeout
+ * so failing retries resolve quickly.
+ */
+
+const FAST_TIMEOUT = 500;
+
+async function gotoButtons(steps: any) {
+    await steps.navigateTo('/');
+    await steps.click('buttonsLink', 'SidebarNav');
+    await steps.verifyUrlContains('/buttons');
+}
+
+test.describe('Expect matcher tree — text', () => {
+    test.beforeEach(async ({ steps }) => {
+        await gotoButtons(steps);
+    });
+
+    test('top-level .text.toBe passes on exact match', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').text.toBe('Primary');
+    });
+
+    test('fluent .text.toBe passes on exact match', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').text.toBe('Primary');
+    });
+
+    test('.text.toContain passes on substring', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').text.toContain('rim');
+    });
+
+    test('.text.toMatch passes on regex', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').text.toMatch(/^Prim/);
+    });
+
+    test('.text.toStartWith passes on prefix', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').text.toStartWith('Prim');
+    });
+
+    test('.text.toEndWith passes on suffix', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').text.toEndWith('mary');
+    });
+
+    test('.not.text.toBe flips outcome', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').not.text.toBe('Secondary');
+    });
+
+    test('.text.not.toContain flips outcome', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').text.not.toContain('Secondary');
+    });
+
+    test('top-level .not.text.toContain flips outcome', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').not.text.toContain('Secondary');
+    });
+
+    test('.text.toBe throws on mismatch', async ({ page, repo }) => {
+        const fast = new ElementInteractions(page, { timeout: FAST_TIMEOUT });
+        const action = new ElementAction(repo, 'primaryButton', 'ButtonsPage', fast, FAST_TIMEOUT);
+        await expect(action.text.toBe('Nope')).rejects.toThrow(/text to be "Nope"/);
+    });
+
+    test('.text.not.toBe throws when values match', async ({ page, repo }) => {
+        const fast = new ElementInteractions(page, { timeout: FAST_TIMEOUT });
+        const action = new ElementAction(repo, 'primaryButton', 'ButtonsPage', fast, FAST_TIMEOUT);
+        await expect(action.text.not.toBe('Primary')).rejects.toThrow(/text not to be/);
+    });
+});
+
+test.describe('Expect matcher tree — value (input fields)', () => {
+    test.beforeEach(async ({ steps }) => {
+        await steps.navigateTo('/');
+        await steps.click('textInputsLink', 'SidebarNav');
+    });
+
+    test('.value.toBe passes on typed input', async ({ steps }) => {
+        await steps.fill('textInput', 'TextInputsPage', 'Alice');
+        await steps.on('textInput', 'TextInputsPage').value.toBe('Alice');
+    });
+
+    test('.value.toContain, .toMatch, .toStartWith, .toEndWith', async ({ steps }) => {
+        await steps.fill('textInput', 'TextInputsPage', 'Alice Example');
+        await steps.on('textInput', 'TextInputsPage').value.toContain('lice');
+        await steps.on('textInput', 'TextInputsPage').value.toMatch(/^Alice/);
+        await steps.on('textInput', 'TextInputsPage').value.toStartWith('Alice');
+        await steps.on('textInput', 'TextInputsPage').value.toEndWith('Example');
+    });
+
+    test('.value.not.toBe flips outcome', async ({ steps }) => {
+        await steps.fill('textInput', 'TextInputsPage', 'Alice');
+        await steps.on('textInput', 'TextInputsPage').value.not.toBe('Bob');
+    });
+});
+
+test.describe('Expect matcher tree — count', () => {
+    test.beforeEach(async ({ steps }) => {
+        await gotoButtons(steps);
+    });
+
+    test('.count.toBe passes on exact match', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').count.toBe(1);
+    });
+
+    test('.count.toBeGreaterThan / toBeLessThan', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').count.toBeGreaterThan(0);
+        await steps.on('primaryButton', 'ButtonsPage').count.toBeLessThan(10);
+    });
+
+    test('.count.toBeGreaterThanOrEqual / toBeLessThanOrEqual', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').count.toBeGreaterThanOrEqual(1);
+        await steps.on('primaryButton', 'ButtonsPage').count.toBeLessThanOrEqual(1);
+    });
+
+    test('.count.not.toBe', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').count.not.toBe(5);
+    });
+});
+
+test.describe('Expect matcher tree — visible / enabled', () => {
+    test.beforeEach(async ({ steps }) => {
+        await gotoButtons(steps);
+    });
+
+    test('.visible.toBeTrue passes for visible element', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').visible.toBeTrue();
+    });
+
+    test('.visible.toBe(true) passes for visible element', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').visible.toBe(true);
+    });
+
+    test('.enabled.toBeTrue passes for enabled element', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').enabled.toBeTrue();
+    });
+
+    test('.enabled.toBeFalse passes for disabled element', async ({ steps }) => {
+        await steps.on('disabledButton', 'ButtonsPage').enabled.toBeFalse();
+    });
+
+    test('.not.enabled.toBeTrue flips for disabled element', async ({ steps }) => {
+        await steps.on('disabledButton', 'ButtonsPage').not.enabled.toBeTrue();
+    });
+});
+
+test.describe('Expect matcher tree — attributes', () => {
+    test.beforeEach(async ({ steps }) => {
+        await gotoButtons(steps);
+    });
+
+    test('.attributes.get(name).toBe passes', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').attributes.get('data-testid').toBe('btn-primary');
+    });
+
+    test('.attributes.get(name).toContain / toMatch', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').attributes.get('data-testid').toContain('primary');
+        await steps.on('primaryButton', 'ButtonsPage').attributes.get('data-testid').toMatch(/^btn-/);
+    });
+
+    test('.attributes.toHaveKey passes', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').attributes.toHaveKey('data-testid');
+    });
+
+    test('.attributes.not.toHaveKey flips', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').attributes.not.toHaveKey('nonexistent-attr');
+    });
+
+    test('.attributes.get(name).not.toBe flips', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').attributes.get('data-testid').not.toBe('btn-secondary');
+    });
+});
+
+test.describe('Expect matcher tree — css', () => {
+    test.beforeEach(async ({ steps }) => {
+        await gotoButtons(steps);
+    });
+
+    test('.css(property).toBe passes', async ({ steps }) => {
+        // `cursor` should resolve to a concrete value on buttons regardless of styling
+        await steps.on('primaryButton', 'ButtonsPage').css('cursor').toMatch(/pointer|default|auto/);
+    });
+
+    test('.css(property).toContain / toMatch', async ({ steps }) => {
+        const color = await steps.getCssProperty('primaryButton', 'ButtonsPage', 'color');
+        await steps.on('primaryButton', 'ButtonsPage').css('color').toBe(color);
+    });
+
+    test('top-level .css(property).toMatch', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').css('cursor').toMatch(/pointer|default|auto/);
+    });
+});
+
+test.describe('Expect matcher tree — predicate escape hatch', () => {
+    test.beforeEach(async ({ steps }) => {
+        await gotoButtons(steps);
+    });
+
+    test('fluent predicate passes when true', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').expect(el => el.text === 'Primary');
+    });
+
+    test('top-level predicate passes when true', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage', el => el.text === 'Primary');
+    });
+
+    test('predicate reads multiple snapshot fields', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').expect(
+            el => el.visible && el.enabled && el.text === 'Primary' && el.attributes['data-testid'] === 'btn-primary',
+        );
+    });
+
+    test('predicate failure surfaces custom message', async ({ page, repo }) => {
+        const fast = new ElementInteractions(page, { timeout: FAST_TIMEOUT });
+        const action = new ElementAction(repo, 'primaryButton', 'ButtonsPage', fast, FAST_TIMEOUT);
+        await expect(
+            action.expect(el => el.text === 'NotThere', 'primary must say NotThere'),
+        ).rejects.toThrow(/primary must say NotThere/);
+    });
+
+    test('predicate failure includes snapshot JSON', async ({ page, repo }) => {
+        const fast = new ElementInteractions(page, { timeout: FAST_TIMEOUT });
+        const action = new ElementAction(repo, 'primaryButton', 'ButtonsPage', fast, FAST_TIMEOUT);
+        await expect(action.expect(el => el.text === 'Nope')).rejects.toThrow(/snapshot at timeout/);
+    });
+});
+
+test.describe('Expect matcher tree — strategy selector composition', () => {
+    test.beforeEach(async ({ steps }) => {
+        await gotoButtons(steps);
+    });
+
+    test('.first() + .text.toBe', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').first().text.toBe('Primary');
+    });
+
+    test('.nth(0) + .text.toContain', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').nth(0).text.toContain('rim');
+    });
+});
+
+test.describe('Expect matcher tree — ifVisible composition', () => {
+    test.beforeEach(async ({ steps }) => {
+        await gotoButtons(steps);
+    });
+
+    test('ifVisible() silently skips when element is hidden', async ({ steps }) => {
+        // No banner on this page — matcher should NOT throw, it should just skip
+        await steps.on('noSuchElement', 'ButtonsPage').ifVisible(200).text.toBe('anything');
+    });
+
+    test('ifVisible() + predicate silently skips when element is hidden', async ({ steps }) => {
+        await steps.on('noSuchElement', 'ButtonsPage').ifVisible(200).expect(el => el.text === 'x');
+    });
+});

--- a/tests/expect-timeout.spec.ts
+++ b/tests/expect-timeout.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from './fixture/StepFixture';
+
+/**
+ * Validates `.timeout(ms)` as a chainable override that composes at every
+ * level: on `steps.on()` (ElementAction), on `steps.expect()` (ExpectBuilder),
+ * on individual matchers (TextMatcher/CountMatcher/etc.), on `.not` chains,
+ * on ifVisible chains, and on `.toBe(predicate)` (PredicateAssertion).
+ *
+ * Negative-path tests pass a short timeout and assert the failure bubbles
+ * within a bounded window — proof that the override is actually honored
+ * rather than silently falling back to the default Steps timeout.
+ */
+
+async function gotoButtons(steps: any) {
+    await steps.navigateTo('/');
+    await steps.click('buttonsLink', 'SidebarNav');
+    await steps.verifyUrlContains('/buttons');
+}
+
+test.describe('timeout() — positive override (long timeout tolerated)', () => {
+    test.beforeEach(async ({ steps }) => { await gotoButtons(steps); });
+
+    test('on ElementAction — .timeout() before matcher', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').timeout(5000).text.toBe('Primary');
+    });
+
+    test('on ExpectBuilder — steps.expect().timeout()', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').timeout(5000).text.toBe('Primary');
+    });
+
+    test('on TextMatcher — .text.timeout()', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').text.timeout(5000).toBe('Primary');
+    });
+
+    test('on CountMatcher — .count.timeout()', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').count.timeout(5000).toBe(1);
+    });
+
+    test('on BooleanMatcher — .visible.timeout()', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').visible.timeout(5000).toBeTrue();
+    });
+
+    test('on AttributesMatcher — .attributes.timeout()', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').attributes.timeout(5000).toHaveKey('data-testid');
+    });
+
+    test('on AttributeMatcher — .attributes.get().timeout()', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').attributes.get('data-testid').timeout(5000).toBe('btn-primary');
+    });
+
+    test('on CssMatcher — .css().timeout()', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').css('cursor').timeout(5000).toMatch(/pointer|default|auto/);
+    });
+
+    test('on PredicateAssertion — .toBe(pred).timeout()', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').toBe(el => el.text === 'Primary').timeout(5000);
+    });
+
+    test('composes with .not — .timeout().not.text.toBe', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').timeout(5000).not.text.toBe('Nope');
+    });
+
+    test('composes with .not — .not.timeout().text.toBe', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage').not.timeout(5000).text.toBe('Nope');
+    });
+
+    test('composes with strategy selectors — .nth().timeout()', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').nth(0).timeout(5000).text.toBe('Primary');
+    });
+
+    test('composes with ifVisible — .ifVisible().timeout()', async ({ steps }) => {
+        await steps.on('primaryButton', 'ButtonsPage').ifVisible().timeout(5000).text.toBe('Primary');
+    });
+
+    test('composes with .toBe(pred).throws() — .toBe(pred).throws().timeout()', async ({ steps }) => {
+        await steps.expect('primaryButton', 'ButtonsPage')
+            .toBe(el => el.visible)
+            .throws('must be visible')
+            .timeout(5000);
+    });
+});
+
+test.describe('timeout() — negative override (short timeout fails fast)', () => {
+    test.beforeEach(async ({ steps }) => { await gotoButtons(steps); });
+
+    test('fails within the override window on TextMatcher', async ({ steps }) => {
+        const start = Date.now();
+        await expect(
+            steps.expect('primaryButton', 'ButtonsPage').text.timeout(500).toBe('WRONG'),
+        ).rejects.toThrow(/text to be/);
+        const elapsed = Date.now() - start;
+        expect(elapsed).toBeLessThan(2000);
+    });
+
+    test('fails within the override window on ExpectBuilder', async ({ steps }) => {
+        const start = Date.now();
+        await expect(
+            steps.expect('primaryButton', 'ButtonsPage').timeout(500).text.toBe('WRONG'),
+        ).rejects.toThrow(/text to be/);
+        const elapsed = Date.now() - start;
+        expect(elapsed).toBeLessThan(2000);
+    });
+
+    test('fails within the override window on ElementAction', async ({ steps }) => {
+        const start = Date.now();
+        await expect(
+            steps.on('primaryButton', 'ButtonsPage').timeout(500).text.toBe('WRONG'),
+        ).rejects.toThrow(/text to be/);
+        const elapsed = Date.now() - start;
+        expect(elapsed).toBeLessThan(2000);
+    });
+
+    test('fails within the override window on PredicateAssertion', async ({ steps }) => {
+        const start = Date.now();
+        await expect(
+            steps.expect('primaryButton', 'ButtonsPage').toBe(el => el.text === 'WRONG').timeout(500),
+        ).rejects.toThrow(/snapshot at timeout/);
+        const elapsed = Date.now() - start;
+        expect(elapsed).toBeLessThan(2000);
+    });
+
+    test('timeout() overrides survive through .throws(message)', async ({ steps }) => {
+        const start = Date.now();
+        await expect(
+            steps.expect('primaryButton', 'ButtonsPage')
+                .toBe(el => el.text === 'WRONG')
+                .timeout(500)
+                .throws('domain message'),
+        ).rejects.toThrow(/domain message/);
+        const elapsed = Date.now() - start;
+        expect(elapsed).toBeLessThan(2000);
+    });
+
+    test('timeout() order does not matter: .throws().timeout() and .timeout().throws() both honored', async ({ steps }) => {
+        // throws first, then timeout
+        await expect(
+            steps.expect('primaryButton', 'ButtonsPage')
+                .toBe(el => el.text === 'WRONG')
+                .throws('msg A')
+                .timeout(500),
+        ).rejects.toThrow(/msg A/);
+
+        // timeout first, then throws
+        await expect(
+            steps.expect('primaryButton', 'ButtonsPage')
+                .toBe(el => el.text === 'WRONG')
+                .timeout(500)
+                .throws('msg B'),
+        ).rejects.toThrow(/msg B/);
+    });
+});

--- a/tests/fixture/pageHelpers.ts
+++ b/tests/fixture/pageHelpers.ts
@@ -1,0 +1,14 @@
+import { Steps } from '../../src';
+
+/** Navigate to the Buttons demo page used by most matcher tests. */
+export async function gotoButtons(steps: Steps): Promise<void> {
+    await steps.navigateTo('/');
+    await steps.click('buttonsLink', 'SidebarNav');
+    await steps.verifyUrlContains('/buttons');
+}
+
+/** Navigate to the Text Inputs demo page used by value-matcher tests. */
+export async function gotoTextInputs(steps: Steps): Promise<void> {
+    await steps.navigateTo('/');
+    await steps.click('textInputsLink', 'SidebarNav');
+}

--- a/tests/negative.spec.ts
+++ b/tests/negative.spec.ts
@@ -117,16 +117,8 @@ test.describe('Negative Tests', () => {
     log('TC_086 Negative getByText strict — passed');
   });
 
-  test('TC_088: expectValue throws on mismatch and throws on match when { not: true }', async ({ page, steps }) => {
+  test('TC_088: Verifications.expectEqual/expectNotEqual throw on mismatch and match respectively', async ({ page }) => {
     const fast = new ElementInteractions(page, { timeout: NEGATIVE_TIMEOUT });
-
-    expect(() => {
-      steps.expect('hello', 'world');
-    }).toThrow();
-
-    expect(() => {
-      steps.expect('hello', 'hello', { not: true });
-    }).toThrow();
 
     expect(() => {
       fast.verify.expectEqual('hello', 'world');
@@ -136,6 +128,6 @@ test.describe('Negative Tests', () => {
       fast.verify.expectNotEqual('hello', 'hello');
     }).toThrow();
 
-    log('TC_088 Negative expectValue — passed');
+    log('TC_088 Negative expectEqual/expectNotEqual — passed');
   });
 });

--- a/tests/steps-api.spec.ts
+++ b/tests/steps-api.spec.ts
@@ -275,8 +275,15 @@ test.describe('TC_087: Steps - expect matcher tree (top-level)', () => {
       await steps.expect('primaryButton', 'ButtonsPage').not.text.toBe('Nope');
     });
 
-    await test.step('predicate form — positive case', async () => {
-      await steps.expect('primaryButton', 'ButtonsPage', el => el.text === 'Primary' && el.visible);
+    await test.step('.toBe(predicate) — positive case', async () => {
+      await steps.expect('primaryButton', 'ButtonsPage').toBe(el => el.text === 'Primary' && el.visible);
+    });
+
+    await test.step('.toBe(predicate).throws(message) — custom failure message', async () => {
+      // positive path: predicate passes, throws() never triggers
+      await steps.expect('primaryButton', 'ButtonsPage')
+        .toBe(el => el.enabled)
+        .throws('should be enabled');
     });
 
     log('TC_087 expect matcher tree — passed');

--- a/tests/steps-api.spec.ts
+++ b/tests/steps-api.spec.ts
@@ -252,27 +252,34 @@ test.describe('TC_047: Steps - isPresent boolean visibility check', () => {
   });
 });
 
-test.describe('TC_087: Steps - expectValue', () => {
+test.describe('TC_087: Steps - expect matcher tree (top-level)', () => {
 
-  test('expectValue passes for equal values and for differing values with { not: true }', async ({ steps }) => {
+  test('top-level steps.expect(el, page) exposes the matcher tree', async ({ steps }) => {
+    await steps.navigateTo('/');
+    await steps.click('buttonsLink', 'SidebarNav');
+    await steps.verifyUrlContains('/buttons');
 
-    await test.step('expectValue passes when values are identical', () => {
-      steps.expect('$5.99', '$5.99');
+    await test.step('text.toBe passes on exact match', async () => {
+      await steps.expect('primaryButton', 'ButtonsPage').text.toBe('Primary');
     });
 
-    await test.step('expectValue passes when both values are null', () => {
-      steps.expect(null, null);
+    await test.step('text.toMatch passes on regex', async () => {
+      await steps.expect('primaryButton', 'ButtonsPage').text.toMatch(/^Prim/);
     });
 
-    await test.step('expectValue with { not: true } passes when values differ', () => {
-      steps.expect('$5.99', '$9.99', { not: true });
+    await test.step('count.toBeGreaterThan works', async () => {
+      await steps.expect('primaryButton', 'ButtonsPage').count.toBeGreaterThan(0);
     });
 
-    await test.step('expectValue with { not: true } passes when actual is null and expected is a string', () => {
-      steps.expect(null, 'some value', { not: true });
+    await test.step('.not flips outcome', async () => {
+      await steps.expect('primaryButton', 'ButtonsPage').not.text.toBe('Nope');
     });
 
-    log('TC_087 expectValue — passed');
+    await test.step('predicate form — positive case', async () => {
+      await steps.expect('primaryButton', 'ButtonsPage', el => el.text === 'Primary' && el.visible);
+    });
+
+    log('TC_087 expect matcher tree — passed');
   });
 });
 


### PR DESCRIPTION
## Summary

Replaces the current `Steps.expect(actual, expected, options?)` and `ElementAction.expect(expected, options?)` surfaces with a chain-style matcher tree that covers every common assertion, carries `.not` negation uniformly, and exposes a snapshot-based predicate escape hatch for everything else.

## What's new

**Top-level matcher tree:**

```ts
await steps.expect('price', 'ProductPage').text.toBe('$19.99');
await steps.expect('price', 'ProductPage').text.toMatch(/^\$/);
await steps.expect('link', 'NavPage').attributes.get('href').toBe('/dashboard');
await steps.expect('items', 'ListPage').count.toBeGreaterThan(3);
await steps.expect('btn', 'Page').visible.toBeTrue();
await steps.expect('banner', 'Page').css('color').toBe('rgb(255, 0, 0)');
```

**Fluent matchers on `steps.on()`** — compose naturally after strategy selectors / `ifVisible`:

```ts
await steps.on('row', 'TablePage').nth(2).attributes.get('data-id').toBe('42');
await steps.on('cards', 'ListPage').random().text.toMatch(/\$\d+/);
await steps.on('banner', 'Page').ifVisible().text.toContain('Promo');
```

**`.not` composes anywhere in the chain:**

```ts
await steps.expect('error', 'Page').not.text.toContain('Crash');
await steps.expect('error', 'Page').text.not.toContain('Crash');
await steps.on('submitBtn', 'Page').attributes.not.toHaveKey('disabled');
```

**Predicate escape hatch** for multi-field / parsed / regex-combined assertions:

```ts
await steps.expect(
  'price', 'ProductPage',
  el => parseFloat(el.text.slice(1)) > 10,
  'price must be above $10',
);

await steps.on('card', 'Page').expect(
  el => el.visible && el.attributes['data-status'] === 'ready' && el.count > 0,
);
```

Predicates receive a plain-data `ElementSnapshot` (`text`, `value`, `attributes`, `visible`, `enabled`, `count`). On timeout, the error includes the full snapshot pretty-printed so you can see exactly why it failed.

## Why this design

- **Chain consistency.** Every assertion looks like `.field.matcher(value)`. Learning one matcher teaches all of them.
- **LLM-friendly.** `toBe / toContain / toMatch / toBeGreaterThan / toBeTrue` are saturating patterns in Jest/Playwright training data. Completions land right the first time — no bikeshed between `textContains` vs `hasPartialText` vs `containsText`.
- **Negation without method sprawl.** `.not` composes at any level instead of requiring `notText`, `notPartialText`, `notTextMatches`…
- **No pw `expect` leaking into tests.** The matcher tree is self-contained; users never reach for `@playwright/test`'s `expect` in user code.
- **One escape hatch.** When the tree doesn't cover an assertion, one predicate form handles everything — no per-field custom-matcher surface.

## Breaking change

`Steps.expect` and `ElementAction.expect` signatures change:

| Before | After |
|---|---|
| `steps.expect(actual, expected, { not: true })` | `steps.on('el', 'Page').text.not.toBe(expected)` (if comparing live element value) |
| `steps.on('el', 'Page').expect('x')` | `steps.on('el', 'Page').text.toBe('x')` |
| `steps.on('el', 'Page').expect('x', { attribute: 'href' })` | `steps.on('el', 'Page').attributes.get('href').toBe('x')` |
| `steps.on('el', 'Page').expect('x', { inputValue: true })` | `steps.on('el', 'Page').value.toBe('x')` |
| `steps.on('el', 'Page').expect('x', { cssProperty: 'color' })` | `steps.on('el', 'Page').css('color').toBe('x')` |

Internal utilities `Verifications.expectEqual` / `Verifications.expectNotEqual` remain unchanged. Existing `verify*` methods remain untouched and continue to work — users can migrate incrementally.

## Test coverage

- New file `tests/expect-matchers.spec.ts` — 40 tests covering every matcher variant, negation, predicate form, strategy-selector composition, and `ifVisible` silent-skip.
- Rewrote `TC_087` (steps-api.spec.ts) and `TC_088` (negative.spec.ts) to target the new API.
- Full suite: **271/271 passing**.
- API coverage tool: **100%**.

## Files touched

- `src/steps/ExpectMatchers.ts` (new) — matcher classes + `ElementSnapshot`.
- `src/steps/ElementAction.ts` — replaces `expect(expected, options?)`, adds `captureSnapshot`, matcher getters, and `expect(predicate, message?)`.
- `src/steps/CommonSteps.ts` — replaces `expect(actual, expected, options?)` with `expect(el, page)` + predicate overload.
- `src/index.ts` — exports `ElementSnapshot`, `ExpectBuilder`, and matcher classes.
- `skills/element-interactions/references/api-reference.md` — new "Expect Matcher Tree" section.
- `package.json` / `package-lock.json` — version bump to 0.2.5.

## Test plan

- [x] `npm run test` — 271/271 pass locally
- [x] `npx test-coverage` — 100% API coverage
- [ ] CI coverage check green
- [ ] CI test job green