### PR TITLE
Thread ElementAction.timeout() through Interactions-routed actions

### DIFF
--- a/skills/element-interactions/contributing.md
+++ b/skills/element-interactions/contributing.md
@@ -340,16 +340,16 @@ Steps.timeout (fixture) → ElementAction._timeout → ExpectContext.timeout →
 - `ExpectBuilder.timeout(ms)` mutates `ctx.timeout` and retroactively patches the last queued assertion (so `.satisfy(pred).timeout(500)` applies 500ms to that predicate).
 - Matcher `.timeout(ms)` (e.g. `.text.timeout(500)`) mutates its own ctx AND propagates to the builder for subsequent matchers — but does NOT retroactively patch a prior matcher's queued entry.
 
-**Scope — what `.timeout(ms)` currently affects:**
+**Scope — what `.timeout(ms)` affects:**
 1. Every verification/matcher (`.text.toBe`, `.count.toBeGreaterThan`, `.satisfy(pred)`, `.verifyText`, `.verifyCount`, etc.).
 2. Element-routed actions that go through `element.action(this._timeout).X()` on `ElementAction` — `hover`, `fill`, `check`, `uncheck`, `doubleClick`, `typeSequentially`, `clearInput`, `scrollIntoView`, `getText`, `getAttribute`, `getCount`, `getInputValue`.
+3. Interactions-routed actions — `click`, `clickIfPresent`, `rightClick`, `uploadFile`, `dragAndDrop`, `selectDropdown`, `setSliderValue`, `selectMultiple`. `ElementAction` passes `this._timeout` through the option bag of each `interactions.interact.*` call, which then uses it for both the pre-action `Utils.waitForState(...)` and the Playwright primitive (`element.click({ timeout })`, etc.).
 
-**What it does NOT currently affect** (open issue — Interactions-routed actions use the fixture-level timeout):
-- `click`, `clickIfPresent`, `rightClick`, `uploadFile`, `dragAndDrop`, `selectDropdown`, `setSliderValue`, `selectMultiple`.
+When adding a new Interactions-routed action, extend its option bag with `timeout?: number` (or accept an `ActionTimeoutOptions` parameter for modifier-free methods) and plumb it to the same two places — pre-wait and primitive. The `ElementAction` call site passes `{ timeout: this._timeout }` into the bag.
 
-These flow through `this.interactions.interact.*` where `ElementInteractions.interact`'s internal `ELEMENT_TIMEOUT` is set once at construction and never mutated by `ElementAction.timeout()`. Wiring this through requires threading `timeout` into every `Interactions.*` signature — tracked as a follow-up.
+**Repo resolution has its own timeout.** `repo.get(...)` pays `ElementRepository.defaultTimeout` (configured by `repoTimeout` on the fixture, 15000ms default) waiting for the element to reach `attached`. This is upstream of `ElementAction._timeout` — the chain-level `.timeout(ms)` only governs action + verification, not resolution. If you need to bound resolution too, use `repo.setDefaultTimeout(ms)` on the fixture or in a `beforeEach`.
 
-**Visibility probe is another deliberate exception.** `ifVisible(ms?)` has its own short `visibilityTimeout` (default 2000ms) because its whole purpose is fast-skip: a hidden element should abort the action in ~2s, not 30s. Do not unify it into the main timeout.
+**Visibility probe is a deliberate exception.** `ifVisible(ms?)` has its own short `visibilityTimeout` (default 2000ms) because its whole purpose is fast-skip: a hidden element should abort the action in ~2s, not 30s. Do not unify it into the main timeout.
 
 Other builder state (queue, pendingNot) also mutates, but stays scoped: each `.expect()` / `.on()` call returns a fresh builder, so mutation doesn't leak across chains. `.not` is one-shot — it flips the next matcher only, then resets.
 

--- a/src/enum/Options.ts
+++ b/src/enum/Options.ts
@@ -23,6 +23,19 @@ export interface DropdownSelectOptions {
     value?: string;
     /** The index of the option to select (Required if type is INDEX). */
     index?: number;
+    /** Per-call timeout override in milliseconds. Falls back to the Interactions default when omitted. */
+    timeout?: number;
+}
+
+/**
+ * Minimal options for action methods that only need a per-call timeout
+ * (`rightClick`, `uploadFile`, `setSliderValue`, `selectMultiple`).
+ * Use the dedicated option bags (`ClickOptions`, `DropdownSelectOptions`,
+ * `DragAndDropOptions`) when there are other modifiers.
+ */
+export interface ActionTimeoutOptions {
+    /** Per-call timeout override in milliseconds. Falls back to the Interactions default when omitted. */
+    timeout?: number;
 }
 
 /**
@@ -64,6 +77,8 @@ export interface DragAndDropOptions {
     xOffset?: number;
     /** The vertical offset from the center of the element (positive moves down). */
     yOffset?: number;
+    /** Per-call timeout override in milliseconds. Falls back to the Interactions default when omitted. */
+    timeout?: number;
 }
 
 /**
@@ -165,6 +180,8 @@ export interface ClickOptions {
     ifPresent?: boolean;
     /** Force the click, bypassing Playwright's pointer-interception checks. Useful for elements obscured by parent overlays. */
     force?: boolean;
+    /** Per-call timeout override in milliseconds. Falls back to the Interactions default when omitted. */
+    timeout?: number;
 }
 
 /**

--- a/src/interactions/Interaction.ts
+++ b/src/interactions/Interaction.ts
@@ -1,5 +1,5 @@
 import { Page, Locator } from '@playwright/test';
-import { ClickOptions, DropdownSelectOptions, DropdownSelectType, DragAndDropOptions, ListedElementMatch } from '../enum/Options';
+import { ClickOptions, DropdownSelectOptions, DropdownSelectType, DragAndDropOptions, ListedElementMatch, ActionTimeoutOptions } from '../enum/Options';
 import { Utils } from '../utils/ElementUtilities';
 import { Element, WebElement } from '@civitas-cerebrum/element-repository';
 
@@ -33,13 +33,14 @@ export class Interactions {
     async click(target: Target, options?: ClickOptions): Promise<boolean | void> {
         const element = toElement(target);
         const useDispatch = options?.force || options?.withoutScrolling;
+        const timeout = options?.timeout ?? this.ELEMENT_TIMEOUT;
 
         if (options?.ifPresent) {
             if (await element.isVisible()) {
                 if (useDispatch) {
-                    await this.dispatchClick(element);
+                    await this.dispatchClick(element, timeout);
                 } else {
-                    await this.clickWithInterceptionRetry(element);
+                    await this.clickWithInterceptionRetry(element, timeout);
                 }
                 return true;
             }
@@ -47,20 +48,20 @@ export class Interactions {
         }
 
         if (useDispatch) {
-            await this.dispatchClick(element);
+            await this.dispatchClick(element, timeout);
             return;
         }
 
-        await this.utils.waitForState(element, 'visible');
-        await this.clickWithInterceptionRetry(element);
+        await this.utils.waitForState(element, 'visible', timeout);
+        await this.clickWithInterceptionRetry(element, timeout);
     }
 
     /**
      * Dispatches a native 'click' event directly on the element, bypassing
      * actionability checks. Used for both `force` and `withoutScrolling`.
      */
-    private async dispatchClick(element: Element): Promise<void> {
-        await this.utils.waitForState(element, 'attached');
+    private async dispatchClick(element: Element, timeout: number): Promise<void> {
+        await this.utils.waitForState(element, 'attached', timeout);
         await element.dispatchEvent('click');
     }
 
@@ -68,15 +69,15 @@ export class Interactions {
      * Attempts a standard click. If interception is reported, retries by
      * dispatching a native click event on the element instead.
      */
-    private async clickWithInterceptionRetry(element: Element): Promise<void> {
+    private async clickWithInterceptionRetry(element: Element, timeout: number): Promise<void> {
         try {
-            await element.click({ timeout: Math.min(this.ELEMENT_TIMEOUT, 5000) });
+            await element.click({ timeout: Math.min(timeout, 5000) });
         } catch (error: unknown) {
             const message = error instanceof Error ? error.message : String(error);
             if (message.includes('intercepts pointer events')) {
                 await element.dispatchEvent('click');
             } else {
-                await element.click({ timeout: this.ELEMENT_TIMEOUT });
+                await element.click({ timeout });
             }
         }
     }
@@ -85,8 +86,8 @@ export class Interactions {
      * Clicks only if the element is present and visible. Returns true if clicked,
      * false if the element was absent — does not throw.
      */
-    async clickIfPresent(target: Target): Promise<boolean> {
-        return await this.click(target, { ifPresent: true }) as boolean;
+    async clickIfPresent(target: Target, options?: ActionTimeoutOptions): Promise<boolean> {
+        return await this.click(target, { ifPresent: true, timeout: options?.timeout }) as boolean;
     }
 
     async fill(target: Target, text: string): Promise<void> {
@@ -95,10 +96,11 @@ export class Interactions {
         await element.fill(text, { timeout: this.ELEMENT_TIMEOUT });
     }
 
-    async uploadFile(target: Target, filePath: string): Promise<void> {
+    async uploadFile(target: Target, filePath: string, options?: ActionTimeoutOptions): Promise<void> {
         const element = toElement(target);
-        await this.utils.waitForState(element, 'attached');
-        await element.setInputFiles(filePath, { timeout: this.ELEMENT_TIMEOUT });
+        const timeout = options?.timeout ?? this.ELEMENT_TIMEOUT;
+        await this.utils.waitForState(element, 'attached', timeout);
+        await element.setInputFiles(filePath, { timeout });
     }
 
     /**
@@ -111,14 +113,15 @@ export class Interactions {
     ): Promise<string> {
         // selectOption is a web-only method (HTML `<select>`); narrow to WebElement.
         const element = toElement(target) as WebElement;
-        await this.utils.waitForState(element, 'visible');
+        const timeout = options.timeout ?? this.ELEMENT_TIMEOUT;
+        await this.utils.waitForState(element, 'visible', timeout);
         const type = options.type ?? DropdownSelectType.RANDOM;
 
         if (type === DropdownSelectType.VALUE) {
             if (options.value === undefined) {
                 throw new Error('[Action] Error -> "value" must be provided when using DropdownSelectType.VALUE.');
             }
-            const selected = await element.selectOption({ value: options.value }, { timeout: this.ELEMENT_TIMEOUT });
+            const selected = await element.selectOption({ value: options.value }, { timeout });
             return selected[0];
         }
 
@@ -126,7 +129,7 @@ export class Interactions {
             if (options.index === undefined) {
                 throw new Error('[Action] Error -> "index" must be provided when using DropdownSelectType.INDEX.');
             }
-            const selected = await element.selectOption({ index: options.index }, { timeout: this.ELEMENT_TIMEOUT });
+            const selected = await element.selectOption({ index: options.index }, { timeout });
             return selected[0];
         }
 
@@ -135,7 +138,7 @@ export class Interactions {
         // this is part of the Element contract, not a raw locator call.
         const enabledOptions = element.locateChild('option:not([disabled]):not([value=""])');
 
-        await this.utils.waitForState(enabledOptions.first(), 'attached').catch(() => { });
+        await this.utils.waitForState(enabledOptions.first(), 'attached', timeout).catch(() => { });
 
         const count = await enabledOptions.count();
         if (count === 0) {
@@ -149,7 +152,7 @@ export class Interactions {
             throw new Error(`[Action] Error -> Option at index ${randomIndex} is missing a "value" attribute.`);
         }
 
-        const selected = await element.selectOption({ value: valueToSelect }, { timeout: this.ELEMENT_TIMEOUT });
+        const selected = await element.selectOption({ value: valueToSelect }, { timeout });
         return selected[0];
     }
 
@@ -172,11 +175,12 @@ export class Interactions {
      */
     async dragAndDrop(target: Target, options: DragAndDropOptions): Promise<void> {
         const element = toElement(target);
-        await this.utils.waitForState(element, 'visible');
+        const timeout = options.timeout ?? this.ELEMENT_TIMEOUT;
+        await this.utils.waitForState(element, 'visible', timeout);
 
         if (options.target) {
             const dropElement = toElement(options.target);
-            await this.utils.waitForState(dropElement, 'visible');
+            await this.utils.waitForState(dropElement, 'visible', timeout);
 
             if (options.xOffset !== undefined && options.yOffset !== undefined) {
                 const targetBox = await dropElement.boundingBox();
@@ -191,16 +195,21 @@ export class Interactions {
 
                 await element.dragTo(dropElement, {
                     targetPosition,
-                    timeout: this.ELEMENT_TIMEOUT,
+                    timeout,
                 });
                 return;
             }
 
-            await element.dragTo(dropElement, { timeout: this.ELEMENT_TIMEOUT });
+            await element.dragTo(dropElement, { timeout });
             return;
         }
 
         if (options.xOffset !== undefined && options.yOffset !== undefined) {
+            // The mouse-drag path has no action method with a built-in timeout,
+            // so enforce `timeout` here by requiring the element to actually be
+            // visible before reading its bounding box. `Utils.waitForState` only
+            // log-warns; this throws, keeping elapsed time bounded.
+            await element.waitFor({ state: 'visible', timeout });
             const box = await element.boundingBox();
             if (!box) {
                 throw new Error('[Action] Error -> Unable to get bounding box for element to perform drag action.');
@@ -258,10 +267,11 @@ export class Interactions {
     }
 
     /** Right-click (context menu) on the given target. Web-only. */
-    async rightClick(target: Target): Promise<void> {
+    async rightClick(target: Target, options?: ActionTimeoutOptions): Promise<void> {
         const element = toElement(target) as WebElement;
-        await this.utils.waitForState(element, 'visible');
-        await element.rightClick({ timeout: this.ELEMENT_TIMEOUT });
+        const timeout = options?.timeout ?? this.ELEMENT_TIMEOUT;
+        await this.utils.waitForState(element, 'visible', timeout);
+        await element.rightClick({ timeout });
     }
 
     async doubleClick(target: Target): Promise<void> {
@@ -282,10 +292,11 @@ export class Interactions {
         await element.uncheck({ timeout: this.ELEMENT_TIMEOUT });
     }
 
-    async setSliderValue(target: Target, value: number): Promise<void> {
+    async setSliderValue(target: Target, value: number, options?: ActionTimeoutOptions): Promise<void> {
         const element = toElement(target);
-        await this.utils.waitForState(element, 'visible');
-        await element.fill(String(value), { timeout: this.ELEMENT_TIMEOUT });
+        const timeout = options?.timeout ?? this.ELEMENT_TIMEOUT;
+        await this.utils.waitForState(element, 'visible', timeout);
+        await element.fill(String(value), { timeout });
     }
 
     async pressKey(key: string): Promise<void> {
@@ -298,11 +309,12 @@ export class Interactions {
         await element.clear({ timeout: this.ELEMENT_TIMEOUT });
     }
 
-    async selectMultiple(target: Target, values: string[]): Promise<string[]> {
+    async selectMultiple(target: Target, values: string[], options?: ActionTimeoutOptions): Promise<string[]> {
         // selectOption is web-only; narrow to WebElement.
         const element = toElement(target) as WebElement;
-        await this.utils.waitForState(element, 'visible');
-        return element.selectOption(values.map(v => ({ value: v })), { timeout: this.ELEMENT_TIMEOUT });
+        const timeout = options?.timeout ?? this.ELEMENT_TIMEOUT;
+        await this.utils.waitForState(element, 'visible', timeout);
+        return element.selectOption(values.map(v => ({ value: v })), { timeout });
     }
 
     /**

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -137,6 +137,7 @@ export class ElementAction {
         await this.interactions.interact.click(locator, {
             withoutScrolling: options?.withoutScrolling,
             force: options?.force,
+            timeout: this._timeout,
         });
     }
 
@@ -149,6 +150,7 @@ export class ElementAction {
                 withoutScrolling: options?.withoutScrolling,
                 ifPresent: true,
                 force: options?.force,
+                timeout: this._timeout,
             });
             return true;
         }
@@ -179,7 +181,10 @@ export class ElementAction {
     /** Select a dropdown option. */
     async selectDropdown(options?: DropdownSelectOptions): Promise<string> {
         const locator = await this.resolveLocator();
-        return await this.interactions.interact.selectDropdown(locator, options);
+        return await this.interactions.interact.selectDropdown(locator, {
+            ...options,
+            timeout: options?.timeout ?? this._timeout,
+        });
     }
 
     /** Check a checkbox or radio button. Skips silently if `ifVisible()` was set and element is hidden. */
@@ -205,7 +210,7 @@ export class ElementAction {
     /** Right-click the resolved element. */
     async rightClick(): Promise<void> {
         const element = await this.resolve();
-        await this.interactions.interact.rightClick(element);
+        await this.interactions.interact.rightClick(element, { timeout: this._timeout });
     }
 
     /** Type text character by character. */
@@ -217,13 +222,16 @@ export class ElementAction {
     /** Upload a file to a file input. */
     async uploadFile(filePath: string): Promise<void> {
         const locator = await this.resolveLocator();
-        await this.interactions.interact.uploadFile(locator, filePath);
+        await this.interactions.interact.uploadFile(locator, filePath, { timeout: this._timeout });
     }
 
     /** Drag and drop the resolved element. */
     async dragAndDrop(options: DragAndDropOptions): Promise<void> {
         const locator = await this.resolveLocator();
-        await this.interactions.interact.dragAndDrop(locator, options);
+        await this.interactions.interact.dragAndDrop(locator, {
+            ...options,
+            timeout: options.timeout ?? this._timeout,
+        });
     }
 
     /** Clear the input value. */
@@ -235,13 +243,13 @@ export class ElementAction {
     /** Set slider value. */
     async setSliderValue(value: number): Promise<void> {
         const locator = await this.resolveLocator();
-        await this.interactions.interact.setSliderValue(locator, value);
+        await this.interactions.interact.setSliderValue(locator, value, { timeout: this._timeout });
     }
 
     /** Select multiple options from a multi-select. */
     async selectMultiple(values: string[]): Promise<string[]> {
         const locator = await this.resolveLocator();
-        return await this.interactions.interact.selectMultiple(locator, values);
+        return await this.interactions.interact.selectMultiple(locator, values, { timeout: this._timeout });
     }
 
     // -- Terminal actions: verifications --

--- a/src/utils/ElementUtilities.ts
+++ b/src/utils/ElementUtilities.ts
@@ -33,30 +33,33 @@ export class Utils {
      * If the resolver yields multiple elements (strict mode violation),
      * the wait is retried automatically on the first matched element.
      *
-     * @param target - An `Element` or Playwright `Locator` to wait on.
-     * @param state  - The state to wait for. Defaults to `'visible'`.
+     * @param target  - An `Element` or Playwright `Locator` to wait on.
+     * @param state   - The state to wait for. Defaults to `'visible'`.
+     * @param timeout - Per-call timeout override. Falls back to the instance timeout when omitted.
      */
     async waitForState(
         target: Waitable,
         state: 'visible' | 'attached' | 'hidden' | 'detached' = 'visible',
+        timeout?: number,
     ): Promise<void> {
+        const effectiveTimeout = timeout ?? this.timeout;
         const element = toElement(target);
         try {
-            await element.waitFor({ state, timeout: this.timeout });
+            await element.waitFor({ state, timeout: effectiveTimeout });
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
 
             if (message.includes('strict mode violation')) {
                 console.warn('Locator resolved to multiple elements. Waiting on first element instead.');
                 try {
-                    await element.first().waitFor({ state, timeout: this.timeout });
+                    await element.first().waitFor({ state, timeout: effectiveTimeout });
                 } catch {
-                    log.warn(`First element failed to reach state '${state}' within ${this.timeout}ms...`);
+                    log.warn(`First element failed to reach state '${state}' within ${effectiveTimeout}ms...`);
                 }
                 return;
             }
 
-            log.warn(`Element failed to reach state '${state}' within ${this.timeout}ms...`);
+            log.warn(`Element failed to reach state '${state}' within ${effectiveTimeout}ms...`);
         }
     }
 }

--- a/tests/expect-timeout.spec.ts
+++ b/tests/expect-timeout.spec.ts
@@ -172,3 +172,100 @@ test.describe('timeout() — negative override (short timeout fails fast)', () =
         ).rejects.toThrow(/msg B/);
     });
 });
+
+/**
+ * Issue #76 — `ElementAction.timeout()` now threads through Interactions-routed
+ * actions (click, clickIfPresent, rightClick, uploadFile, dragAndDrop,
+ * selectDropdown, setSliderValue, selectMultiple).
+ *
+ * Each test below targets an element that exists in the page-repository but is
+ * NOT attached to the DOM of the current page (we stay on `/` and use elements
+ * from other pages). The pre-action `waitForState('visible')` inside
+ * `Interactions` will time out; we assert the failure bubbles within the
+ * override window rather than the fixture default (30_000ms).
+ *
+ * Without the fix, each of these would take ~30s; with it, each times out in ~500ms.
+ */
+test.describe('ElementAction.timeout() — Interactions-routed actions', () => {
+    const TIMEOUT = 500;
+    // Tight bound: distinguishes the fixed behavior (~500ms action + fast repo
+    // resolution ≈ under 3s) from the pre-fix behavior (~30s default action
+    // timeout regardless of the chain override).
+    const UPPER_BOUND = 5000;
+
+    test.beforeEach(async ({ steps, repo }) => {
+        // Shorten repo resolution timeout so the action-side timeout dominates
+        // elapsed time. Without this, each test would wait the full 15s default
+        // inside StrategyResolver before the action-level timeout kicks in.
+        repo.setDefaultTimeout(1000);
+        // Land on home. The elements targeted below are from other pages —
+        // their selectors won't resolve to attached DOM nodes here.
+        await steps.navigateTo('/');
+    });
+
+    test('click() honors the chain timeout', async ({ steps }) => {
+        const start = Date.now();
+        await expect(
+            steps.on('primaryButton', 'ButtonsPage').timeout(TIMEOUT).click(),
+        ).rejects.toThrow();
+        expect(Date.now() - start).toBeLessThan(UPPER_BOUND);
+    });
+
+    test('clickIfPresent() returns false quickly regardless of chain timeout', async ({ steps }) => {
+        // clickIfPresent short-circuits when the element isn't visible. The
+        // timeout doesn't extend that path — we just assert the signature
+        // accepts a chain timeout and the call resolves without throwing.
+        const start = Date.now();
+        const result = await steps.on('primaryButton', 'ButtonsPage').timeout(TIMEOUT).clickIfPresent();
+        expect(result).toBe(false);
+        expect(Date.now() - start).toBeLessThan(UPPER_BOUND);
+    });
+
+    test('rightClick() honors the chain timeout', async ({ steps }) => {
+        const start = Date.now();
+        await expect(
+            steps.on('primaryButton', 'ButtonsPage').timeout(TIMEOUT).rightClick(),
+        ).rejects.toThrow();
+        expect(Date.now() - start).toBeLessThan(UPPER_BOUND);
+    });
+
+    test('uploadFile() honors the chain timeout', async ({ steps }) => {
+        const start = Date.now();
+        await expect(
+            steps.on('singleFileInput', 'FileUploadPage').timeout(TIMEOUT).uploadFile('tests/test-files/test-upload.txt'),
+        ).rejects.toThrow();
+        expect(Date.now() - start).toBeLessThan(UPPER_BOUND);
+    });
+
+    test('dragAndDrop() honors the chain timeout', async ({ steps }) => {
+        const start = Date.now();
+        await expect(
+            steps.on('item1', 'DraggablePage').timeout(TIMEOUT).dragAndDrop({ xOffset: 10, yOffset: 10 }),
+        ).rejects.toThrow();
+        expect(Date.now() - start).toBeLessThan(UPPER_BOUND);
+    });
+
+    test('selectDropdown() honors the chain timeout', async ({ steps }) => {
+        const start = Date.now();
+        await expect(
+            steps.on('singleSelect', 'DropdownSelectPage').timeout(TIMEOUT).selectDropdown(),
+        ).rejects.toThrow();
+        expect(Date.now() - start).toBeLessThan(UPPER_BOUND);
+    });
+
+    test('setSliderValue() honors the chain timeout', async ({ steps }) => {
+        const start = Date.now();
+        await expect(
+            steps.on('basicSlider', 'SlidersPage').timeout(TIMEOUT).setSliderValue(50),
+        ).rejects.toThrow();
+        expect(Date.now() - start).toBeLessThan(UPPER_BOUND);
+    });
+
+    test('selectMultiple() honors the chain timeout', async ({ steps }) => {
+        const start = Date.now();
+        await expect(
+            steps.on('multiSelect', 'DropdownSelectPage').timeout(TIMEOUT).selectMultiple(['Australia']),
+        ).rejects.toThrow();
+        expect(Date.now() - start).toBeLessThan(UPPER_BOUND);
+    });
+});


### PR DESCRIPTION
Fixes #76.

## Summary

`ElementAction.timeout(ms)` is the documented chain-level timeout override, but until now it only governed Element-routed actions (`hover`, `fill`, matchers, …). Calls that went through `Interactions.interact.*` — `click`, `clickIfPresent`, `rightClick`, `uploadFile`, `dragAndDrop`, `selectDropdown`, `setSliderValue`, `selectMultiple` — kept using the fixture-level default because `Interactions.ELEMENT_TIMEOUT` was set once at construction and never mutated.

This PR threads the per-chain timeout through all eight methods:

- `ClickOptions` / `DropdownSelectOptions` / `DragAndDropOptions` gain `timeout?: number`.
- `ActionTimeoutOptions` (new) covers the four methods that previously took no options.
- Every `Interactions` method reads `options?.timeout ?? this.ELEMENT_TIMEOUT` and uses it for both the pre-action `Utils.waitForState` and the Playwright primitive.
- `Utils.waitForState` now accepts an optional per-call timeout override.
- `ElementAction` call sites pass `{ timeout: this._timeout }` (merged with caller options where applicable).
- `dragAndDrop`'s mouse-path (no-target + xOffset/yOffset) gains a throwing `waitFor({state:'visible', timeout})` so `boundingBox()` can't silently eat the Playwright default.

## Docs

`contributing.md` invariant #5 — drop the "what it does NOT affect" caveat and call out that repo resolution (`ElementRepository.defaultTimeout` / `repoTimeout`) is a separately-bounded concern upstream of this chain timeout.

## Test plan

- [x] `npx playwright test` — 424 pass, 17 pre-existing skipped.
- [x] New `tests/expect-timeout.spec.ts` block: eight timing assertions that shorten `repo.setDefaultTimeout(1000)` per-test and check each action fails within 5000ms (vs ~35s before the fix).
- [x] `npx tsc --noEmit` — clean.

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>