### PR TITLE
Deprecate verify* aliases that the matcher tree already covers

### DIFF
--- a/skills/element-interactions/contributing.md
+++ b/skills/element-interactions/contributing.md
@@ -276,7 +276,20 @@ Every public method that reaches the DOM/driver is `async`. No synchronous eleme
 - **Assertions** extend the matcher tree (`steps.expect(el, page).field.matcher(value)`). New assertions add to `ExpectMatchers.ts`, not new flat `verifyX` on `Steps`.
 - **Actions** stay flat on `Steps` (`steps.click`, `steps.fill`, `steps.dragAndDrop`). Composite workflows (`steps.fillForm`, `steps.retryUntil`) stay flat too.
 
-The legacy `verify*` family on `Steps` is kept for backwards compatibility — don't grow it; route new assertions through the matcher tree.
+Every element-scoped `verify*` is exposed in **two forms that share one implementation**:
+
+1. **Fluent form on `ElementAction`** — `steps.on(el, page).verifyX(...)`. This is the canonical implementation. Each method is either a thin wrapper over the matcher tree (for `verifyPresence`, `verifyText`, `verifyTextContains`, `verifyCount`, `verifyAttribute`, `verifyInputValue`, `verifyCssProperty`) or a direct call into `Verifications` where a specialized fast path is needed (`verifyAbsence` via `toBeHidden`, `verifyState`, `verifyImages`, `verifyOrder`, `verifyListOrder`).
+2. **Standalone form on `Steps`** — `steps.verifyX(el, page, ...)`. This is a thin delegate that constructs the fluent builder via `actionWithStrategy(...)` and calls the matching `ElementAction.verifyX(...)`. One implementation, two entry points.
+
+This is the invariant to preserve when adding a new verification:
+- Add the method on `ElementAction` (or grow `Verifications` first if the underlying primitive doesn't exist).
+- Add the matching standalone method on `Steps` that delegates via `this.actionWithStrategy(elementName, pageName, options).verifyX(...)`. Keep the logging on the Steps side so `tester:verify` output stays consistent.
+
+A handful of verifications only make sense as page-level or filter-then-match shapes and only exist on `Steps`:
+- **`verifyUrlContains`, `verifyTabCount`** — page-level, not element-scoped; the tree starts at an element.
+- **`verifyListedElement`** — filter-then-match; the fluent tree operates on a single resolved element.
+
+The matcher tree (`.text.toBe`, `.count.toBeGreaterThan`, etc.) remains the place to grow **new** assertion shapes — chainable negation, regex, substring, custom predicates, etc. When a matcher-tree shape lands that subsumes an existing `verify*` form, don't deprecate the `verify*`; the two coexist as equally valid entry points.
 
 ### 3a. Implementation lives in the `Interactions` / `Verifications` / `Extractions` layer. Everything else is a facade.
 

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -589,13 +589,18 @@ export class Steps {
 
     /**
      * Asserts that the element is present and visible in the DOM.
+     *
+     * Equivalent to the fluent form `steps.on(elementName, pageName).verifyPresence()` —
+     * both share the same underlying implementation (the matcher tree). Use whichever
+     * form is more readable in the call site.
+     *
      * @param elementName - The element name as defined under the given page.
      * @param pageName - The page name as defined in `page-repository.json`.
      * @param options - Optional step options for element resolution.
      */
     async verifyPresence(elementName: string, pageName: string, options?: StepOptions): Promise<void> {
         log.verify('Verifying presence of "%s" in "%s"', elementName, pageName);
-        await this.actionWithStrategy(elementName, pageName, options).visible.toBeTrue();
+        await this.actionWithStrategy(elementName, pageName, options).verifyPresence();
     }
 
     /**
@@ -657,14 +662,7 @@ export class Steps {
      */
     async verifyAbsence(elementName: string, pageName: string, options?: StepOptions): Promise<void> {
         log.verify('Verifying absence of "%s" in "%s"', elementName, pageName);
-        // Stays non-delegated: uses Playwright's `expect(locator).toBeHidden()`
-        // which is optimized for the absent case (returns quickly, no 15s repo
-        // resolution wait). The matcher tree's visible.toBeFalse() would work
-        // but pays the full repo-timeout to "fail to find" the element before
-        // even starting the polling loop.
-        void options;
-        const selector = this.repo.getSelector(elementName, pageName);
-        await this.verify.absence(selector);
+        await this.actionWithStrategy(elementName, pageName, options).verifyAbsence();
     }
 
     /**
@@ -672,6 +670,8 @@ export class Steps {
      *
      * Call with no `expectedText` to assert the element has any non-empty text:
      * `await steps.verifyText('status', 'Page');`
+     *
+     * Equivalent to the fluent form `steps.on(elementName, pageName).verifyText(expectedText)`.
      *
      * @param elementName - The element name as defined under the given page.
      * @param pageName - The page name as defined in `page-repository.json`.
@@ -684,16 +684,15 @@ export class Steps {
         if (verifyOptions?.notEmpty !== undefined) {
             log.verify('[DEPRECATED] verifyText: the `notEmpty` option is redundant — call verifyText("%s", "%s") with no expectedText to assert "not empty".', elementName, pageName);
         }
-        const notEmpty = verifyOptions?.notEmpty || expectedText === undefined;
-        const logDetail = notEmpty ? 'is not empty' : `matches: "${expectedText}"`;
-        log.verify('Verifying text of "%s" in "%s" %s', elementName, pageName, logDetail);
-        const action = this.actionWithStrategy(elementName, pageName, options);
-        if (notEmpty) await action.text.not.toBe('');
-        else await action.text.toBe(expectedText!);
+        log.verify('Verifying text of "%s" in "%s"%s', elementName, pageName, expectedText === undefined ? ' is not empty' : ` matches: "${expectedText}"`);
+        await this.actionWithStrategy(elementName, pageName, options).verifyText(expectedText, verifyOptions);
     }
 
     /**
      * Asserts the number of elements matching the locator satisfies the given condition.
+     *
+     * Equivalent to `steps.on(elementName, pageName).verifyCount(countOptions)`.
+     *
      * @param elementName - The element name as defined under the given page.
      * @param pageName - The page name as defined in `page-repository.json`.
      * @param countOptions - Count condition.
@@ -701,15 +700,14 @@ export class Steps {
      */
     async verifyCount(elementName: string, pageName: string, countOptions: CountVerifyOptions, options?: StepOptions): Promise<void> {
         log.verify('Verifying count for "%s" in "%s" with options: %O', elementName, pageName, countOptions);
-        const action = this.actionWithStrategy(elementName, pageName, options);
-        if (countOptions.exactly !== undefined) await action.count.toBe(countOptions.exactly);
-        else if (countOptions.greaterThan !== undefined) await action.count.toBeGreaterThan(countOptions.greaterThan);
-        else if (countOptions.lessThan !== undefined) await action.count.toBeLessThan(countOptions.lessThan);
-        else throw new Error("verifyCount requires 'exactly', 'greaterThan', or 'lessThan' in CountVerifyOptions.");
+        await this.actionWithStrategy(elementName, pageName, options).verifyCount(countOptions);
     }
 
     /**
      * Asserts that all image elements matching the locator have loaded successfully.
+     *
+     * Equivalent to `steps.on(elementName, pageName).verifyImages(scroll)`.
+     *
      * @param elementName - The element name as defined under the given page.
      * @param pageName - The page name as defined in `page-repository.json`.
      * @param scroll - Whether to scroll each image into view before checking. Defaults to `true`.
@@ -717,12 +715,14 @@ export class Steps {
      */
     async verifyImages(elementName: string, pageName: string, scroll: boolean = true, options?: StepOptions): Promise<void> {
         log.verify('Verifying images for "%s" in "%s" (scroll: %s)', elementName, pageName, scroll);
-        const locator = toLocator(await this.repo.get(elementName, pageName, this.toAllResolutionOptions(options)));
-        await this.verify.images(locator, scroll);
+        await this.actionWithStrategy(elementName, pageName, options).verifyImages(scroll);
     }
 
     /**
      * Asserts that an element's text content contains the specified substring.
+     *
+     * Equivalent to `steps.on(elementName, pageName).verifyTextContains(expectedText)`.
+     *
      * @param elementName - The element name as defined under the given page.
      * @param pageName - The page name as defined in `page-repository.json`.
      * @param expectedText - The substring expected to be found within the element's text.
@@ -730,15 +730,18 @@ export class Steps {
      */
     async verifyTextContains(elementName: string, pageName: string, expectedText: string, options?: StepOptions): Promise<void> {
         log.verify('Verifying "%s" in "%s" contains text: "%s"', elementName, pageName, expectedText);
-        await this.actionWithStrategy(elementName, pageName, options).text.toContain(expectedText);
+        await this.actionWithStrategy(elementName, pageName, options).verifyTextContains(expectedText);
     }
 
     /**
      * Asserts that an element is in the specified state.
+     *
+     * Equivalent to `steps.on(elementName, pageName).verifyState(state)`.
+     *
      * @param elementName - The element name as defined under the given page.
      * @param pageName - The page name as defined in `page-repository.json`.
      * @param state - The expected state.
-     * @param timeout - Optional timeout in milliseconds.
+     * @param timeout - Optional timeout in milliseconds. When omitted, the fixture default is used.
      */
     async verifyState(
         elementName: string,
@@ -747,12 +750,16 @@ export class Steps {
         timeout?: number
     ): Promise<void> {
         log.verify('Verifying "%s" in "%s" is %s', elementName, pageName, state);
-        const locatorString = this.repo.getSelector(elementName, pageName);
-        await this.verify.state(locatorString, state, timeout);
+        const action = this.on(elementName, pageName);
+        if (timeout !== undefined) action.timeout(timeout);
+        await action.verifyState(state);
     }
 
     /**
      * Asserts that an element has a specific HTML attribute with the expected value.
+     *
+     * Equivalent to `steps.on(elementName, pageName).verifyAttribute(attributeName, expectedValue)`.
+     *
      * @param elementName - The element name as defined under the given page.
      * @param pageName - The page name as defined in `page-repository.json`.
      * @param attributeName - The name of the HTML attribute to check.
@@ -761,7 +768,7 @@ export class Steps {
      */
     async verifyAttribute(elementName: string, pageName: string, attributeName: string, expectedValue: string, options?: StepOptions): Promise<void> {
         log.verify('Verifying "%s" in "%s" has attribute "%s" = "%s"', elementName, pageName, attributeName, expectedValue);
-        await this.actionWithStrategy(elementName, pageName, options).attributes.get(attributeName).toBe(expectedValue);
+        await this.actionWithStrategy(elementName, pageName, options).verifyAttribute(attributeName, expectedValue);
     }
 
     /**
@@ -775,6 +782,9 @@ export class Steps {
 
     /**
      * Asserts that an input, textarea, or select element has the expected value.
+     *
+     * Equivalent to `steps.on(elementName, pageName).verifyInputValue(expectedValue)`.
+     *
      * @param elementName - The element name as defined under the given page.
      * @param pageName - The page name as defined in `page-repository.json`.
      * @param expectedValue - The expected value of the input.
@@ -782,7 +792,7 @@ export class Steps {
      */
     async verifyInputValue(elementName: string, pageName: string, expectedValue: string, options?: StepOptions): Promise<void> {
         log.verify('Verifying input value of "%s" in "%s" matches: "%s"', elementName, pageName, expectedValue);
-        await this.actionWithStrategy(elementName, pageName, options).value.toBe(expectedValue);
+        await this.actionWithStrategy(elementName, pageName, options).verifyInputValue(expectedValue);
     }
 
     /**
@@ -823,6 +833,9 @@ export class Steps {
     /**
      * Asserts that the text contents of all elements matching the locator appear
      * in the exact order specified.
+     *
+     * Equivalent to `steps.on(elementName, pageName).verifyOrder(expectedTexts)`.
+     *
      * @param elementName - The element name as defined under the given page.
      * @param pageName - The page name as defined in `page-repository.json`.
      * @param expectedTexts - The expected text values in their expected order.
@@ -830,12 +843,14 @@ export class Steps {
      */
     async verifyOrder(elementName: string, pageName: string, expectedTexts: string[], options?: StepOptions): Promise<void> {
         log.verify('Verifying order of "%s" in "%s": %O', elementName, pageName, expectedTexts);
-        const element = await this.repo.get(elementName, pageName, this.toAllResolutionOptions(options));
-        await this.verify.order(element, expectedTexts);
+        await this.actionWithStrategy(elementName, pageName, options).verifyOrder(expectedTexts);
     }
 
     /**
      * Asserts that a computed CSS property of an element matches the expected value.
+     *
+     * Equivalent to `steps.on(elementName, pageName).verifyCssProperty(property, expectedValue)`.
+     *
      * @param elementName - The element name as defined under the given page.
      * @param pageName - The page name as defined in `page-repository.json`.
      * @param property - The CSS property name.
@@ -844,12 +859,15 @@ export class Steps {
      */
     async verifyCssProperty(elementName: string, pageName: string, property: string, expectedValue: string, options?: StepOptions): Promise<void> {
         log.verify('Verifying CSS "%s" of "%s" in "%s" = "%s"', property, elementName, pageName, expectedValue);
-        await this.actionWithStrategy(elementName, pageName, options).css(property).toBe(expectedValue);
+        await this.actionWithStrategy(elementName, pageName, options).verifyCssProperty(property, expectedValue);
     }
 
     /**
      * Asserts that the text contents of all elements matching the locator are sorted
      * in the specified direction.
+     *
+     * Equivalent to `steps.on(elementName, pageName).verifyListOrder(direction)`.
+     *
      * @param elementName - The element name as defined under the given page.
      * @param pageName - The page name as defined in `page-repository.json`.
      * @param direction - `'asc'` for ascending or `'desc'` for descending.
@@ -857,8 +875,7 @@ export class Steps {
      */
     async verifyListOrder(elementName: string, pageName: string, direction: 'asc' | 'desc', options?: StepOptions): Promise<void> {
         log.verify('Verifying "%s" in "%s" is sorted %s', elementName, pageName, direction);
-        const element = await this.repo.get(elementName, pageName, this.toAllResolutionOptions(options));
-        await this.verify.listOrder(element, direction);
+        await this.actionWithStrategy(elementName, pageName, options).verifyListOrder(direction);
     }
 
     // ==========================================

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -246,24 +246,27 @@ export class ElementAction {
 
     // -- Terminal actions: verifications --
     //
-    // These legacy `verify*` methods are thin delegations to the matcher tree.
-    // The tree is the single source of truth for assertion behavior and error
-    // formatting; `verify*` stays on the public surface for backwards compat.
+    // `verify*` is the canonical fluent form. The top-level `Steps.verifyX(el, page, ...)`
+    // methods are thin wrappers that route through these — one implementation, two
+    // entry points. Internally each delegates to the matcher tree (which is the single
+    // source of truth for retry/timeout/negation mechanics) or to the raw verification
+    // layer when a specialized fast path exists (e.g. `verifyAbsence` via `toBeHidden`).
 
-    /** Assert the element is visible. */
+    /** Assert the element is visible. Delegates to the matcher tree's `.visible.toBeTrue()`. */
     async verifyPresence(): Promise<void> {
         await this.expectBuilder().visible.toBeTrue();
     }
 
     /**
-     * Assert the element is hidden or detached. Stays non-delegated — uses
-     * Playwright's `expect(locator).toBeHidden()` which is optimized for the
-     * absent case and returns quickly, unlike the matcher tree's
-     * `visible.toBeFalse()` which pays the full repo resolution timeout.
+     * Assert the element is hidden or detached. Uses Playwright's
+     * `expect(locator).toBeHidden()` on the raw selector — never calls
+     * `repo.get(...)` because that would pay the 15s repo-resolution wait
+     * waiting for the element to become attached, which is the opposite of
+     * what we want when asserting absence.
      */
     async verifyAbsence(): Promise<void> {
-        const element = await this.resolve();
-        await element.action(this._timeout).verifyAbsence();
+        const selector = this.repo.getSelector(this.elementName, this.pageName);
+        await this.interactions.verify.absence(selector);
     }
 
     /**
@@ -284,12 +287,12 @@ export class ElementAction {
         else await builder.text.toBe(expected!);
     }
 
-    /** Assert text contains a substring. */
+    /** Assert text contains a substring. Delegates to the matcher tree's `.text.toContain(...)`. */
     async verifyTextContains(expected: string): Promise<void> {
         await this.expectBuilder().text.toContain(expected);
     }
 
-    /** Assert the element count. */
+    /** Assert the element count. Delegates to the matcher tree's count matchers. */
     async verifyCount(options: CountVerifyOptions): Promise<void> {
         const builder = this.expectBuilder();
         if (options.exactly !== undefined) await builder.count.toBe(options.exactly);
@@ -327,20 +330,24 @@ export class ElementAction {
         }
     }
 
-    /** Assert an attribute value. */
+    /** Assert an attribute value. Delegates to the matcher tree's `.attributes.get(name).toBe(value)`. */
     async verifyAttribute(attributeName: string, expectedValue: string): Promise<void> {
         await this.expectBuilder().attributes.get(attributeName).toBe(expectedValue);
     }
 
-    /** Assert input value. */
+    /** Assert input value. Delegates to the matcher tree's `.value.toBe(expectedValue)`. */
     async verifyInputValue(expectedValue: string): Promise<void> {
         await this.expectBuilder().value.toBe(expectedValue);
     }
 
-    /** Verify images loaded correctly. */
+    /**
+     * Assert every matched image has a real `src`, non-zero `naturalWidth`, and
+     * decodes successfully. Collection-level — resolves with
+     * `SelectionStrategy.ALL` regardless of any strategy selector.
+     */
     async verifyImages(scroll: boolean = true): Promise<void> {
-        const locator = await this.resolveLocator();
-        await this.interactions.verify.images(locator, scroll);
+        const element = await this.repo.get(this.elementName, this.pageName, { strategy: SelectionStrategy.ALL });
+        await this.interactions.verify.images(toLocator(element), scroll);
     }
 
     /** Assert element state. */
@@ -349,21 +356,32 @@ export class ElementAction {
         await this.interactions.verify.state(selector, state);
     }
 
-    /** Assert CSS property value. */
+    /** Assert CSS property value. Delegates to the matcher tree's `.css(property).toBe(value)`. */
     async verifyCssProperty(property: string, expectedValue: string): Promise<void> {
         await this.expectBuilder().css(property).toBe(expectedValue);
     }
 
-    /** Assert elements are in the expected text order. */
+    /**
+     * Assert all matched elements appear in the exact text order specified.
+     *
+     * Collection-level — ignores any `.first()` / `.nth()` / `.random()` strategy
+     * on the chain and resolves with `SelectionStrategy.ALL` so the full list is
+     * compared against `expectedTexts`.
+     */
     async verifyOrder(expectedTexts: string[]): Promise<void> {
-        const locator = await this.resolveLocator();
-        await this.interactions.verify.order(locator, expectedTexts);
+        const element = await this.repo.get(this.elementName, this.pageName, { strategy: SelectionStrategy.ALL });
+        await this.interactions.verify.order(toLocator(element), expectedTexts);
     }
 
-    /** Assert list is sorted. */
+    /**
+     * Assert all matched elements are sorted in the given direction.
+     *
+     * Collection-level — resolves with `SelectionStrategy.ALL` regardless of any
+     * strategy selector on the chain.
+     */
     async verifyListOrder(direction: 'asc' | 'desc'): Promise<void> {
-        const locator = await this.resolveLocator();
-        await this.interactions.verify.listOrder(locator, direction);
+        const element = await this.repo.get(this.elementName, this.pageName, { strategy: SelectionStrategy.ALL });
+        await this.interactions.verify.listOrder(toLocator(element), direction);
     }
 
     // -- Terminal actions: extractions --


### PR DESCRIPTION
Addresses #77.

## Summary

Every element-scoped `verify*` is now exposed in **two forms that share one implementation**:

1. **Fluent form on `ElementAction`** — `steps.on(el, page).verifyX(...)`. The canonical implementation. Each method is either a thin wrapper over the matcher tree (for `verifyPresence`, `verifyText`, `verifyTextContains`, `verifyCount`, `verifyAttribute`, `verifyInputValue`, `verifyCssProperty`) or a direct call into `Verifications` where a specialized fast path is needed (`verifyAbsence` via `toBeHidden`, `verifyState`, `verifyImages`, `verifyOrder`, `verifyListOrder`).
2. **Standalone form on `Steps`** — `steps.verifyX(el, page, ...)`. A thin delegate that constructs the fluent builder via `actionWithStrategy(...)` and calls the matching `ElementAction.verifyX(...)`.

**Earlier iterations of this PR marked the seven matcher-tree-backed `verify*` methods as `@deprecated`.** That was a wrong call — standalone `verify*` remains a first-class entry point, not something slated for removal. All `@deprecated` tags on `verify*` methods are gone; both forms are permanent.

## What changed

- `src/steps/CommonSteps.ts` — 12 element-scoped `verifyX(...)` methods rewritten as thin delegates through `this.actionWithStrategy(elementName, pageName, options).verifyX(...)`. One implementation per verification, two entry points.
- `src/steps/ElementAction.ts` — `@deprecated` tags removed from the seven matcher-tree-backed methods. `verifyAbsence` takes the selector-string fast path (`interactions.verify.absence(selector)`) to avoid the 15s repo-resolution wait. `verifyOrder`, `verifyListOrder`, `verifyImages` now force `SelectionStrategy.ALL` on resolution (they're collection-level) regardless of any `.first()` / `.nth()` selector on the chain.
- `skills/element-interactions/contributing.md` — section 3 reworked. Documents the "one implementation, two entry points" invariant: when adding a new verification, grow `ElementAction` + add a delegating wrapper on `Steps`. The matcher tree remains where NEW assertion shapes go (regex, negation, chained multi-assertions, custom predicates), but existing `verify*` forms aren't on a deprecation path.

### `TextVerifyOptions.notEmpty` still deprecated

Unchanged from the original PR — the flag is redundant because `verifyText()` with no `expectedText` already asserts "not empty". JSDoc `@deprecated` tag + runtime warning on both `Steps.verifyText` and `ElementAction.verifyText` stay.

## Test plan

- [x] `npx playwright test` — 416 pass, 17 pre-existing skipped.
- [x] `npx tsc --noEmit` — clean.
- [x] Hot spots verified after the delegation shift:
  - `verifyAbsence` returns in ms (selector-string fast path preserved).
  - `verifyOrder` / `verifyListOrder` / `verifyImages` resolve with `ALL` strategy.

## Version

No version bump — content lands under 0.2.6 per the current release train.

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>