### PR TITLE
Drop Locator from Target type — Element only

### DIFF
--- a/skills/element-interactions/contributing.md
+++ b/skills/element-interactions/contributing.md
@@ -82,7 +82,7 @@ The framework is split across **two packages** for a reason. Understand the spli
 | `Steps` | Top-level facade users call | Holding state across calls, exposing `Locator` in return types |
 | `ElementAction` | Fluent builder for `steps.on(...)` chains | Long-lived state (only in-flight chain state); exposing raw Playwright |
 | `ExpectMatchers` | Chain-style assertion tree | Mocking, side-effects beyond the awaited assertion |
-| `Interactions` / `Verifications` / `Extractions` | Internal helpers — accept `Element \| Locator`, route everything through `Element` | Calling raw `locator.X()` after the input is normalized |
+| `Interactions` / `Verifications` / `Extractions` | Internal helpers — accept `Element` only (no Locator). Wrap raw Locators in `new WebElement(locator)` at the seam if you must. | Calling raw `locator.X()` instead of going through `Element` |
 | `BaseFixture` | Constructs Steps with the right deps; auto-attaches failure screenshots | Test-specific logic |
 | `Element` interface | Cross-platform element abstraction | Concept that doesn't exist on one of the platforms |
 | `WebElement` | Playwright impl + web-only methods | Anything that's not a thin Playwright delegation |
@@ -395,7 +395,7 @@ If your new method doesn't fit one of these, reconsider the shape — the naming
 
 `steps.click`, `steps.verifyText`, `steps.on(...).fill`, the matcher tree shape — all the entry points users have written tests against — stay stable across patch and minor versions. Internal refactors are fine; signature changes on user-facing methods need a major bump and a clear migration note in the PR description.
 
-The current public `Target` type (`Locator | Element`) accepting raw Locators is held for backwards compatibility (see issue #74). Don't tighten this without coordination.
+The public `Target` type on `Interactions`, `Verifications`, `Extractions`, and `Utils` is `Element` (no Locator union). Consumers with custom Playwright locators wrap them via `new WebElement(locator)` at the seam — that's the single documented bridging point.
 
 ### 9. Action methods presence-detect
 

--- a/src/enum/Options.ts
+++ b/src/enum/Options.ts
@@ -1,4 +1,3 @@
-import { Locator } from '@playwright/test';
 import { Element } from '@civitas-cerebrum/element-repository';
 
 /**
@@ -71,8 +70,8 @@ export type CountVerifyOptions =
  * You must provide either a `targetLocator` OR both `xOffset` and `yOffset`.
  */
 export interface DragAndDropOptions {
-    /** The destination element to drop the dragged element onto. Accepts a Playwright Locator or an Element from the repository. */
-    target?: Locator | Element;
+    /** The destination `Element` to drop the dragged element onto. */
+    target?: Element;
     /** The horizontal offset from the center of the element (positive moves right). */
     xOffset?: number;
     /** The vertical offset from the center of the element (positive moves down). */

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ export * from './enum/Options';
 export { Navigation } from './interactions/Navigation';
 export { Verifications } from './interactions/Verification';
 export { Interactions } from './interactions/Interaction';
-export type { Target } from './interactions/Interaction';
 export { Extractions } from './interactions/Extraction';
 
 // Utilities

--- a/src/interactions/Extraction.ts
+++ b/src/interactions/Extraction.ts
@@ -1,20 +1,16 @@
-import { Page, Locator } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { Utils } from '../utils/ElementUtilities';
 import { ScreenshotOptions } from '../enum/Options';
-import { Element, WebElement } from '@civitas-cerebrum/element-repository';
-
-type Target = Locator | Element;
-
-function toElement(target: Target): Element {
-    if ('_type' in target) return target as Element;
-    return new WebElement(target as Locator);
-}
+import { Element } from '@civitas-cerebrum/element-repository';
 
 /**
  * Read-only accessors for element data: text, attributes, CSS, counts, and
  * screenshots. Pairs with `Interactions` (writes) and `Verifications`
  * (assertions) as the raw low-level layer. Users typically reach these through
  * `ElementInteractions.extract` or via `Steps.get*` / `ElementAction.get*`.
+ *
+ * Every method takes an `Element` from the repository. Wrap raw Playwright
+ * Locators via `new WebElement(locator)` at the call site if you need to bridge.
  */
 export class Extractions {
     private ELEMENT_TIMEOUT: number;
@@ -26,53 +22,46 @@ export class Extractions {
     }
 
     /** Safely retrieves and trims the text content of an element. */
-    async getText(target: Target): Promise<string | null> {
-        const element = toElement(target);
-        await this.utils.waitForState(element, 'attached');
-        const text = await element.textContent();
+    async getText(target: Element): Promise<string | null> {
+        await this.utils.waitForState(target, 'attached');
+        const text = await target.textContent();
         return text?.trim() ?? null;
     }
 
     /** Retrieves the value of a specified attribute. */
-    async getAttribute(target: Target, attributeName: string): Promise<string | null> {
-        const element = toElement(target);
-        await this.utils.waitForState(element, 'attached');
-        return element.getAttribute(attributeName);
+    async getAttribute(target: Element, attributeName: string): Promise<string | null> {
+        await this.utils.waitForState(target, 'attached');
+        return target.getAttribute(attributeName);
     }
 
     /** Retrieves the trimmed text content of every element matching the locator. */
-    async getAllTexts(target: Target): Promise<string[]> {
-        const element = toElement(target);
-        const all = await element.all();
+    async getAllTexts(target: Element): Promise<string[]> {
+        const all = await target.all();
         const texts = await Promise.all(all.map(e => e.textContent()));
         return texts.map(t => (t ?? '').trim());
     }
 
     /** Retrieves the current value of an input, textarea, or select element. */
-    async getInputValue(target: Target): Promise<string> {
-        const element = toElement(target);
-        await this.utils.waitForState(element, 'attached');
-        return element.inputValue();
+    async getInputValue(target: Element): Promise<string> {
+        await this.utils.waitForState(target, 'attached');
+        return target.inputValue();
     }
 
     /** Returns the number of DOM elements matching the target. */
-    async getCount(target: Target): Promise<number> {
-        const element = toElement(target);
-        return element.count();
+    async getCount(target: Element): Promise<number> {
+        return target.count();
     }
 
     /** Retrieves a computed CSS property value from an element. */
-    async getCssProperty(target: Target, property: string): Promise<string> {
-        const element = toElement(target);
-        await this.utils.waitForState(element, 'attached');
-        return element.getCssProperty(property);
+    async getCssProperty(target: Element, property: string): Promise<string> {
+        await this.utils.waitForState(target, 'attached');
+        return target.getCssProperty(property);
     }
 
     /** Captures a screenshot of the full page or a specific element. */
-    async screenshot(target?: Target, options?: ScreenshotOptions): Promise<Buffer> {
+    async screenshot(target?: Element, options?: ScreenshotOptions): Promise<Buffer> {
         if (target) {
-            const element = toElement(target);
-            return element.screenshot({ path: options?.path });
+            return target.screenshot({ path: options?.path });
         }
         return await this.page.screenshot({
             fullPage: options?.fullPage,

--- a/src/interactions/Interaction.ts
+++ b/src/interactions/Interaction.ts
@@ -1,21 +1,15 @@
-import { Page, Locator } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { ClickOptions, DropdownSelectOptions, DropdownSelectType, DragAndDropOptions, ListedElementMatch, ActionTimeoutOptions } from '../enum/Options';
 import { Utils } from '../utils/ElementUtilities';
 import { Element, WebElement } from '@civitas-cerebrum/element-repository';
-
-/** A Playwright Locator or an Element wrapper from the repository. */
-export type Target = Locator | Element;
-
-/** Normalizes a `Target` into an `Element`. All internal interactions route through element-repository. */
-function toElement(target: Target): Element {
-    if ('_type' in target) return target as Element;
-    return new WebElement(target as Locator);
-}
 
 /**
  * The `Interactions` class provides a robust set of methods for interacting
  * with DOM elements. All operations route through element-repository's
  * `Element` interface, keeping this class framework-agnostic.
+ *
+ * Every method takes an `Element` from the repository. Wrap raw Playwright
+ * Locators via `new WebElement(locator)` at the call site if you need to bridge.
  */
 export class Interactions {
     private ELEMENT_TIMEOUT: number;
@@ -27,11 +21,10 @@ export class Interactions {
     }
 
     /**
-     * Performs a standard click on the given target.
+     * Performs a standard click on the given element.
      * Automatically waits for the element to be attached, visible, stable, and actionable.
      */
-    async click(target: Target, options?: ClickOptions): Promise<boolean | void> {
-        const element = toElement(target);
+    async click(element: Element, options?: ClickOptions): Promise<boolean | void> {
         const useDispatch = options?.force || options?.withoutScrolling;
         const timeout = options?.timeout ?? this.ELEMENT_TIMEOUT;
 
@@ -86,18 +79,16 @@ export class Interactions {
      * Clicks only if the element is present and visible. Returns true if clicked,
      * false if the element was absent — does not throw.
      */
-    async clickIfPresent(target: Target, options?: ActionTimeoutOptions): Promise<boolean> {
-        return await this.click(target, { ifPresent: true, timeout: options?.timeout }) as boolean;
+    async clickIfPresent(element: Element, options?: ActionTimeoutOptions): Promise<boolean> {
+        return await this.click(element, { ifPresent: true, timeout: options?.timeout }) as boolean;
     }
 
-    async fill(target: Target, text: string): Promise<void> {
-        const element = toElement(target);
+    async fill(element: Element, text: string): Promise<void> {
         await this.utils.waitForState(element, 'visible');
         await element.fill(text, { timeout: this.ELEMENT_TIMEOUT });
     }
 
-    async uploadFile(target: Target, filePath: string, options?: ActionTimeoutOptions): Promise<void> {
-        const element = toElement(target);
+    async uploadFile(element: Element, filePath: string, options?: ActionTimeoutOptions): Promise<void> {
         const timeout = options?.timeout ?? this.ELEMENT_TIMEOUT;
         await this.utils.waitForState(element, 'attached', timeout);
         await element.setInputFiles(filePath, { timeout });
@@ -108,20 +99,20 @@ export class Interactions {
      * If no options are provided, safely defaults to randomly selecting an enabled, non-empty option.
      */
     async selectDropdown(
-        target: Target,
+        element: Element,
         options: DropdownSelectOptions = { type: DropdownSelectType.RANDOM }
     ): Promise<string> {
-        // selectOption is a web-only method (HTML `<select>`); narrow to WebElement.
-        const element = toElement(target) as WebElement;
         const timeout = options.timeout ?? this.ELEMENT_TIMEOUT;
         await this.utils.waitForState(element, 'visible', timeout);
+        // selectOption is a web-only method (HTML `<select>`); narrow to WebElement.
+        const web = element as WebElement;
         const type = options.type ?? DropdownSelectType.RANDOM;
 
         if (type === DropdownSelectType.VALUE) {
             if (options.value === undefined) {
                 throw new Error('[Action] Error -> "value" must be provided when using DropdownSelectType.VALUE.');
             }
-            const selected = await element.selectOption({ value: options.value }, { timeout });
+            const selected = await web.selectOption({ value: options.value }, { timeout });
             return selected[0];
         }
 
@@ -129,14 +120,14 @@ export class Interactions {
             if (options.index === undefined) {
                 throw new Error('[Action] Error -> "index" must be provided when using DropdownSelectType.INDEX.');
             }
-            const selected = await element.selectOption({ index: options.index }, { timeout });
+            const selected = await web.selectOption({ index: options.index }, { timeout });
             return selected[0];
         }
 
         // Random path — look for enabled, non-empty <option> descendants.
         // `locateChild` composes a CSS selector underneath the current element;
         // this is part of the Element contract, not a raw locator call.
-        const enabledOptions = element.locateChild('option:not([disabled]):not([value=""])');
+        const enabledOptions = web.locateChild('option:not([disabled]):not([value=""])');
 
         await this.utils.waitForState(enabledOptions.first(), 'attached', timeout).catch(() => { });
 
@@ -152,18 +143,16 @@ export class Interactions {
             throw new Error(`[Action] Error -> Option at index ${randomIndex} is missing a "value" attribute.`);
         }
 
-        const selected = await element.selectOption({ value: valueToSelect }, { timeout });
+        const selected = await web.selectOption({ value: valueToSelect }, { timeout });
         return selected[0];
     }
 
-    async hover(target: Target): Promise<void> {
-        const element = toElement(target);
+    async hover(element: Element): Promise<void> {
         await this.utils.waitForState(element, 'visible');
         await element.hover({ timeout: this.ELEMENT_TIMEOUT });
     }
 
-    async scrollIntoView(target: Target): Promise<void> {
-        const element = toElement(target);
+    async scrollIntoView(element: Element): Promise<void> {
         await this.utils.waitForState(element, 'attached');
         await element.scrollIntoView({ timeout: this.ELEMENT_TIMEOUT });
     }
@@ -173,13 +162,12 @@ export class Interactions {
      * Absolute-offset drags use the page's mouse API (no Element equivalent
      * exists today); all other paths route through `Element.dragTo`.
      */
-    async dragAndDrop(target: Target, options: DragAndDropOptions): Promise<void> {
-        const element = toElement(target);
+    async dragAndDrop(element: Element, options: DragAndDropOptions): Promise<void> {
         const timeout = options.timeout ?? this.ELEMENT_TIMEOUT;
         await this.utils.waitForState(element, 'visible', timeout);
 
         if (options.target) {
-            const dropElement = toElement(options.target);
+            const dropElement = options.target;
             await this.utils.waitForState(dropElement, 'visible', timeout);
 
             if (options.xOffset !== undefined && options.yOffset !== undefined) {
@@ -230,25 +218,23 @@ export class Interactions {
     }
 
     /**
-     * Filters a locator list and returns the first element matching the given text.
-     * Uses Element.filter composition (which delegates to Playwright's filter under the hood).
+     * Filters an element list and returns the first match for the given text.
+     * Uses Element.filter composition.
      */
     public async getByText(
-        baseTarget: Target,
+        base: Element,
         desiredText: string,
         strict: boolean = false,
-    ): Promise<Locator | null> {
-        const base = toElement(baseTarget);
-
+    ): Promise<Element | null> {
         const caseSensitive = base.filter({ hasText: desiredText }).first();
         if ((await caseSensitive.count()) > 0) {
-            return (caseSensitive as WebElement).locator;
+            return caseSensitive;
         }
 
         const escaped = desiredText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         const caseInsensitive = base.filter({ hasText: new RegExp(escaped, 'i') }).first();
         if ((await caseInsensitive.count()) > 0) {
-            return (caseInsensitive as WebElement).locator;
+            return caseInsensitive;
         }
 
         const all = await base.all();
@@ -260,40 +246,34 @@ export class Interactions {
         return null;
     }
 
-    async typeSequentially(target: Target, text: string, delay: number = 100): Promise<void> {
-        const element = toElement(target);
+    async typeSequentially(element: Element, text: string, delay: number = 100): Promise<void> {
         await this.utils.waitForState(element, 'visible');
         await element.pressSequentially(text, delay, { timeout: this.ELEMENT_TIMEOUT });
     }
 
-    /** Right-click (context menu) on the given target. Web-only. */
-    async rightClick(target: Target, options?: ActionTimeoutOptions): Promise<void> {
-        const element = toElement(target) as WebElement;
+    /** Right-click (context menu) on the given element. Web-only. */
+    async rightClick(element: Element, options?: ActionTimeoutOptions): Promise<void> {
         const timeout = options?.timeout ?? this.ELEMENT_TIMEOUT;
         await this.utils.waitForState(element, 'visible', timeout);
-        await element.rightClick({ timeout });
+        await (element as WebElement).rightClick({ timeout });
     }
 
-    async doubleClick(target: Target): Promise<void> {
-        const element = toElement(target);
+    async doubleClick(element: Element): Promise<void> {
         await this.utils.waitForState(element, 'visible');
         await element.doubleClick({ timeout: this.ELEMENT_TIMEOUT });
     }
 
-    async check(target: Target): Promise<void> {
-        const element = toElement(target);
+    async check(element: Element): Promise<void> {
         await this.utils.waitForState(element, 'visible');
         await element.check({ timeout: this.ELEMENT_TIMEOUT });
     }
 
-    async uncheck(target: Target): Promise<void> {
-        const element = toElement(target);
+    async uncheck(element: Element): Promise<void> {
         await this.utils.waitForState(element, 'visible');
         await element.uncheck({ timeout: this.ELEMENT_TIMEOUT });
     }
 
-    async setSliderValue(target: Target, value: number, options?: ActionTimeoutOptions): Promise<void> {
-        const element = toElement(target);
+    async setSliderValue(element: Element, value: number, options?: ActionTimeoutOptions): Promise<void> {
         const timeout = options?.timeout ?? this.ELEMENT_TIMEOUT;
         await this.utils.waitForState(element, 'visible', timeout);
         await element.fill(String(value), { timeout });
@@ -303,48 +283,44 @@ export class Interactions {
         await this.page.keyboard.press(key);
     }
 
-    async clearInput(target: Target): Promise<void> {
-        const element = toElement(target);
+    async clearInput(element: Element): Promise<void> {
         await this.utils.waitForState(element, 'visible');
         await element.clear({ timeout: this.ELEMENT_TIMEOUT });
     }
 
-    async selectMultiple(target: Target, values: string[], options?: ActionTimeoutOptions): Promise<string[]> {
-        // selectOption is web-only; narrow to WebElement.
-        const element = toElement(target) as WebElement;
+    async selectMultiple(element: Element, values: string[], options?: ActionTimeoutOptions): Promise<string[]> {
         const timeout = options?.timeout ?? this.ELEMENT_TIMEOUT;
         await this.utils.waitForState(element, 'visible', timeout);
-        return element.selectOption(values.map(v => ({ value: v })), { timeout });
+        // selectOption is web-only; narrow to WebElement.
+        return (element as WebElement).selectOption(values.map(v => ({ value: v })), { timeout });
     }
 
     /**
      * Resolves a specific element from a list by matching visible text or an attribute,
      * with optional child-element drill-down.
      *
-     * Returns a Playwright `Locator` because callers downstream need it for
-     * `expect(locator).X()` assertions and child-selector composition that
-     * doesn't fit the Element abstraction (e.g. `.and()`). Internally, match
-     * discovery uses Element methods where possible.
+     * Returns an `Element` — pass it into any `interact`/`verify`/`extract` method,
+     * or cast to `WebElement` to reach the raw Playwright `Locator` for Playwright-specific
+     * composition (e.g. `.and()`, `.or()`).
      */
     async getListedElement(
-        baseTarget: Target,
+        base: Element,
         options: ListedElementMatch,
         repo?: { getSelector(elementName: string, pageName: string): string },
-    ): Promise<Locator> {
-        const baseElement = toElement(baseTarget);
+    ): Promise<Element> {
         let matched: Element;
 
         if (options.text) {
-            const caseSensitive = baseElement.filter({ hasText: options.text }).first();
+            const caseSensitive = base.filter({ hasText: options.text }).first();
             if ((await caseSensitive.count()) > 0) {
                 matched = caseSensitive;
             } else {
                 const escaped = options.text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-                matched = baseElement.filter({ hasText: new RegExp(escaped, 'i') }).first();
+                matched = base.filter({ hasText: new RegExp(escaped, 'i') }).first();
             }
         } else if (options.attribute) {
-            // Locator.and() composition has no Element equivalent today — drop to Locator.
-            const baseLocator = (baseElement as WebElement).locator;
+            // Locator.and() composition has no Element equivalent today — drop to Locator internally.
+            const baseLocator = (base as WebElement).locator;
             matched = new WebElement(
                 baseLocator
                     .and(this.page.locator(`[${options.attribute.name}="${options.attribute.value}"]`))
@@ -357,17 +333,17 @@ export class Interactions {
         await this.utils.waitForState(matched, 'visible');
 
         if (!options.child) {
-            return (matched as WebElement).locator;
+            return matched;
         }
 
         if (typeof options.child === 'string') {
-            return (matched.locateChild(options.child) as WebElement).locator;
+            return matched.locateChild(options.child);
         }
 
         if (!repo) {
             throw new Error('An ElementRepository instance is required when "child" is a page-repository reference.');
         }
         const childSelector = repo.getSelector(options.child.elementName, options.child.pageName);
-        return (matched.locateChild(childSelector) as WebElement).locator;
+        return matched.locateChild(childSelector);
     }
 }

--- a/src/interactions/Verification.ts
+++ b/src/interactions/Verification.ts
@@ -3,8 +3,6 @@ type LocatorAssertions = ReturnType<typeof expect<Locator>>;
 import { CountVerifyOptions, TextVerifyOptions } from '../enum/Options';
 import { Element, WebElement } from '@civitas-cerebrum/element-repository';
 
-type Target = Locator | Element;
-
 /** Shared options every Verifications method accepts. */
 export interface VerifyOptions {
     /** When `true`, flips the assertion — passes when the underlying condition fails. */
@@ -15,16 +13,9 @@ export interface VerifyOptions {
     errorMessage?: string;
 }
 
-function resolveLocator(target: Target): Locator {
-    if ('_type' in target) {
-        return (target as unknown as WebElement).locator;
-    }
-    return target as Locator;
-}
-
-function toElement(target: Target): Element {
-    if ('_type' in target) return target as Element;
-    return new WebElement(target as Locator);
+/** Reach the Playwright Locator under an Element (web-only expect(locator) calls need it). */
+function resolveLocator(target: Element): Locator {
+    return (target as unknown as WebElement).locator;
 }
 
 /**
@@ -64,7 +55,7 @@ export class Verifications {
      * @param expectedText - The exact text string expected (optional if checking 'notEmpty').
      * @param options - Configuration to alter the verification behavior.
      */
-    async text(target: Target, expectedText?: string, options?: TextVerifyOptions & VerifyOptions): Promise<void> {
+    async text(target: Element, expectedText?: string, options?: TextVerifyOptions & VerifyOptions): Promise<void> {
         const locator = resolveLocator(target);
         const { matcher, timeout } = this.prepare(locator, options);
         if (options?.notEmpty) {
@@ -80,25 +71,25 @@ export class Verifications {
     /**
      * Asserts that the specified element contains the expected substring.
      */
-    async textContains(target: Target, expectedText: string, options?: VerifyOptions): Promise<void> {
+    async textContains(target: Element, expectedText: string, options?: VerifyOptions): Promise<void> {
         const { matcher, timeout } = this.prepare(resolveLocator(target), options);
         await matcher.toContainText(expectedText, { timeout });
     }
 
     /** Asserts the element's text matches a regular expression. */
-    async textMatches(target: Target, regex: RegExp, options?: VerifyOptions): Promise<void> {
+    async textMatches(target: Element, regex: RegExp, options?: VerifyOptions): Promise<void> {
         const { matcher, timeout } = this.prepare(resolveLocator(target), options);
         await matcher.toHaveText(regex, { timeout });
     }
 
     /** Asserts the element's text starts with the given prefix. */
-    async textStartsWith(target: Target, prefix: string, options?: VerifyOptions): Promise<void> {
+    async textStartsWith(target: Element, prefix: string, options?: VerifyOptions): Promise<void> {
         const escaped = prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         await this.textMatches(target, new RegExp('^' + escaped), options);
     }
 
     /** Asserts the element's text ends with the given suffix. */
-    async textEndsWith(target: Target, suffix: string, options?: VerifyOptions): Promise<void> {
+    async textEndsWith(target: Element, suffix: string, options?: VerifyOptions): Promise<void> {
         const escaped = suffix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         await this.textMatches(target, new RegExp(escaped + '$'), options);
     }
@@ -107,7 +98,7 @@ export class Verifications {
      * Asserts that the specified element is attached to the DOM and is visible.
      * @param target - A Playwright Locator or Element pointing to the target element.
      */
-    async presence(target: Target, options?: VerifyOptions): Promise<void> {
+    async presence(target: Element, options?: VerifyOptions): Promise<void> {
         const { matcher, timeout } = this.prepare(resolveLocator(target), options);
         await matcher.toBeVisible({ timeout });
     }
@@ -117,7 +108,7 @@ export class Verifications {
      * Accepts a Target or a raw selector string to prevent unnecessary repository waits.
      * @param selectorOrTarget - A Playwright Locator, Element, or raw selector string.
      */
-    async absence(selectorOrTarget: Target | string): Promise<void> {
+    async absence(selectorOrTarget: Element | string): Promise<void> {
         const locator = typeof selectorOrTarget === 'string'
             ? this.page.locator(selectorOrTarget)
             : resolveLocator(selectorOrTarget);
@@ -130,7 +121,7 @@ export class Verifications {
   * @param target - A Playwright Locator or Element pointing to the target element.
   * @param state - The expected state to verify.
   */
-    async state(target: Target, state: 'enabled' | 'disabled' | 'editable' | 'checked' | 'focused' | 'visible' | 'hidden' | 'attached' | 'inViewport', options?: VerifyOptions): Promise<void>;
+    async state(target: Element, state: 'enabled' | 'disabled' | 'editable' | 'checked' | 'focused' | 'visible' | 'hidden' | 'attached' | 'inViewport', options?: VerifyOptions): Promise<void>;
 
     /**
      * Asserts the state of an element using Playwright's built-in locator assertions.
@@ -141,7 +132,7 @@ export class Verifications {
     async state(locator: string, state: 'enabled' | 'disabled' | 'editable' | 'checked' | 'focused' | 'visible' | 'hidden' | 'attached' | 'inViewport', timeout?: number): Promise<void>;
 
     async state(
-        locator: Target | string,
+        locator: Element | string,
         state: 'enabled' | 'disabled' | 'editable' | 'checked' | 'focused' | 'visible' | 'hidden' | 'attached' | 'inViewport',
         timeoutOrOptions?: number | VerifyOptions,
     ): Promise<void> {
@@ -180,25 +171,25 @@ export class Verifications {
      * @param attributeName - The name of the HTML attribute to check (e.g., 'href', 'class', 'alt').
      * @param expectedValue - The exact expected value of the attribute.
      */
-    async attribute(target: Target, attributeName: string, expectedValue: string, options?: VerifyOptions): Promise<void> {
+    async attribute(target: Element, attributeName: string, expectedValue: string, options?: VerifyOptions): Promise<void> {
         const { matcher, timeout } = this.prepare(resolveLocator(target), options);
         await matcher.toHaveAttribute(attributeName, expectedValue, { timeout });
     }
 
     /** Asserts that a given HTML attribute contains the substring. */
-    async attributeContains(target: Target, attributeName: string, substring: string, options?: VerifyOptions): Promise<void> {
+    async attributeContains(target: Element, attributeName: string, substring: string, options?: VerifyOptions): Promise<void> {
         const escaped = substring.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         await this.attributeMatches(target, attributeName, new RegExp(escaped), options);
     }
 
     /** Asserts that a given HTML attribute matches a regular expression. */
-    async attributeMatches(target: Target, attributeName: string, regex: RegExp, options?: VerifyOptions): Promise<void> {
+    async attributeMatches(target: Element, attributeName: string, regex: RegExp, options?: VerifyOptions): Promise<void> {
         const { matcher, timeout } = this.prepare(resolveLocator(target), options);
         await matcher.toHaveAttribute(attributeName, regex, { timeout });
     }
 
     /** Asserts that the element has a given HTML attribute present (regardless of value). */
-    async hasAttribute(target: Target, attributeName: string, options?: VerifyOptions): Promise<void> {
+    async hasAttribute(target: Element, attributeName: string, options?: VerifyOptions): Promise<void> {
         const { matcher, timeout } = this.prepare(resolveLocator(target), options);
         await matcher.toHaveAttribute(attributeName, /[\s\S]*/, { timeout });
     }
@@ -212,7 +203,7 @@ export class Verifications {
      * @param scroll - Whether to smoothly scroll the image(s) into the viewport before verifying (default: true).
      * @throws Will throw an error if no images are found matching the locator or if any image fails to decode.
      */
-    async images(imagesTarget: Target, scroll: boolean = true): Promise<void> {
+    async images(imagesTarget: Element, scroll: boolean = true): Promise<void> {
         const imagesLocator = resolveLocator(imagesTarget);
         const productImages = await imagesLocator.all();
 
@@ -251,31 +242,31 @@ export class Verifications {
      * @param target - A Playwright Locator or Element pointing to the input element.
      * @param expectedValue - The expected value of the input.
      */
-    async inputValue(target: Target, expectedValue: string, options?: VerifyOptions): Promise<void> {
+    async inputValue(target: Element, expectedValue: string, options?: VerifyOptions): Promise<void> {
         const { matcher, timeout } = this.prepare(resolveLocator(target), options);
         await matcher.toHaveValue(expectedValue, { timeout });
     }
 
     /** Asserts the input value contains the given substring. */
-    async inputValueContains(target: Target, substring: string, options?: VerifyOptions): Promise<void> {
+    async inputValueContains(target: Element, substring: string, options?: VerifyOptions): Promise<void> {
         const escaped = substring.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         await this.inputValueMatches(target, new RegExp(escaped), options);
     }
 
     /** Asserts the input value matches a regular expression. */
-    async inputValueMatches(target: Target, regex: RegExp, options?: VerifyOptions): Promise<void> {
+    async inputValueMatches(target: Element, regex: RegExp, options?: VerifyOptions): Promise<void> {
         const { matcher, timeout } = this.prepare(resolveLocator(target), options);
         await matcher.toHaveValue(regex, { timeout });
     }
 
     /** Asserts the input value starts with the given prefix. */
-    async inputValueStartsWith(target: Target, prefix: string, options?: VerifyOptions): Promise<void> {
+    async inputValueStartsWith(target: Element, prefix: string, options?: VerifyOptions): Promise<void> {
         const escaped = prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         await this.inputValueMatches(target, new RegExp('^' + escaped), options);
     }
 
     /** Asserts the input value ends with the given suffix. */
-    async inputValueEndsWith(target: Target, suffix: string, options?: VerifyOptions): Promise<void> {
+    async inputValueEndsWith(target: Element, suffix: string, options?: VerifyOptions): Promise<void> {
         const escaped = suffix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         await this.inputValueMatches(target, new RegExp(escaped + '$'), options);
     }
@@ -322,7 +313,7 @@ export class Verifications {
      * @param target - A Playwright Locator or Element resolving to the list of elements.
      * @param expectedTexts - The expected text values in order.
      */
-    async order(target: Target, expectedTexts: string[]): Promise<void> {
+    async order(target: Element, expectedTexts: string[]): Promise<void> {
         const locator = resolveLocator(target);
         await expect(locator).toHaveText(expectedTexts, { timeout: this.ELEMENT_TIMEOUT });
     }
@@ -335,19 +326,19 @@ export class Verifications {
      * @param property - The CSS property name (e.g. `'color'`, `'font-size'`, `'display'`).
      * @param expectedValue - The expected computed value.
      */
-    async cssProperty(target: Target, property: string, expectedValue: string, options?: VerifyOptions): Promise<void> {
+    async cssProperty(target: Element, property: string, expectedValue: string, options?: VerifyOptions): Promise<void> {
         const { matcher, timeout } = this.prepare(resolveLocator(target), options);
         await matcher.toHaveCSS(property, expectedValue, { timeout });
     }
 
     /** Asserts a computed CSS property value contains the given substring. */
-    async cssPropertyContains(target: Target, property: string, substring: string, options?: VerifyOptions): Promise<void> {
+    async cssPropertyContains(target: Element, property: string, substring: string, options?: VerifyOptions): Promise<void> {
         const escaped = substring.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         await this.cssPropertyMatches(target, property, new RegExp(escaped), options);
     }
 
     /** Asserts a computed CSS property value matches a regular expression. */
-    async cssPropertyMatches(target: Target, property: string, regex: RegExp, options?: VerifyOptions): Promise<void> {
+    async cssPropertyMatches(target: Element, property: string, regex: RegExp, options?: VerifyOptions): Promise<void> {
         const { matcher, timeout } = this.prepare(resolveLocator(target), options);
         await matcher.toHaveCSS(property, regex, { timeout });
     }
@@ -359,7 +350,7 @@ export class Verifications {
      * @param target - A Playwright Locator or Element resolving to the list of elements.
      * @param direction - `'asc'` for ascending (A-Z) or `'desc'` for descending (Z-A).
      */
-    async listOrder(target: Target, direction: 'asc' | 'desc'): Promise<void> {
+    async listOrder(target: Element, direction: 'asc' | 'desc'): Promise<void> {
         const locator = resolveLocator(target);
         const texts = (await locator.allTextContents()).map(t => t.trim());
 
@@ -382,7 +373,7 @@ export class Verifications {
      * @param verifyOptions - Optional `{ negated?, timeout?, errorMessage? }` override.
      * @throws Error if any count in `options` is negative, or if the count does not match.
      */
-    async count(target: Target, options: CountVerifyOptions, verifyOptions?: VerifyOptions): Promise<void> {
+    async count(target: Element, options: CountVerifyOptions, verifyOptions?: VerifyOptions): Promise<void> {
         const locator = resolveLocator(target);
         const timeout = verifyOptions?.timeout ?? this.ELEMENT_TIMEOUT;
         const { matcher } = this.prepare(locator, verifyOptions);
@@ -415,7 +406,6 @@ export class Verifications {
             throw new Error(`You must provide 'exact', 'greaterThan', 'lessThan', 'greaterThanOrEqual', or 'lessThanOrEqual' in CountVerifyOptions.`);
         }
 
-        const element = toElement(target);
         const describe = [
             options.greaterThan !== undefined ? `> ${options.greaterThan}` : null,
             options.lessThan !== undefined ? `< ${options.lessThan}` : null,
@@ -425,7 +415,7 @@ export class Verifications {
         const negatedSuffix = verifyOptions?.negated ? ' (negated)' : '';
 
         await expect.poll(async () => {
-            const actualCount = await element.count();
+            const actualCount = await target.count();
             const passes =
                 (options.greaterThan === undefined || actualCount > options.greaterThan) &&
                 (options.lessThan === undefined || actualCount < options.lessThan) &&

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -1,5 +1,5 @@
-import { Page, Locator, Response } from '@playwright/test';
-import { ElementRepository, Element, WebElement, ElementResolutionOptions, SelectionStrategy } from '@civitas-cerebrum/element-repository';
+import { Page, Response } from '@playwright/test';
+import { ElementRepository, WebElement, ElementResolutionOptions, SelectionStrategy } from '@civitas-cerebrum/element-repository';
 import { ElementInteractions } from '../interactions/facade/ElementInteractions';
 import { Utils } from '../utils/ElementUtilities';
 import { EmailClientConfig, EmailSendOptions, EmailReceiveOptions, ReceivedEmail, EmailMarkOptions, EmailMarkAction, EmailFilter } from '@civitas-cerebrum/email-client';
@@ -7,15 +7,6 @@ import { StepOptions, DropdownSelectOptions, TextVerifyOptions, CountVerifyOptio
 import { logger } from '../logger/Logger';
 import { ElementAction } from './ElementAction';
 import { ExpectBuilder } from './ExpectMatchers';
-
-/**
- * Extracts the underlying Playwright Locator from an Element wrapper.
- * This bridges the Element interface from element-repository
- * with the Playwright-specific interaction/verification/extraction classes.
- */
-function toLocator(element: Element): Locator {
-    return (element as WebElement).locator;
-}
 
 const log = {
     navigate: logger('navigate'),
@@ -362,8 +353,8 @@ export class Steps {
      */
     async uploadFile(elementName: string, pageName: string, filePath: string, options?: StepOptions): Promise<void> {
         log.interact('Uploading file "%s" to "%s" in "%s"', filePath, elementName, pageName);
-        const locator = toLocator(await this.repo.get(elementName, pageName, this.toResolutionOptions(options)));
-        await this.interact.uploadFile(locator, filePath);
+        const element = await this.repo.get(elementName, pageName, this.toResolutionOptions(options));
+        await this.interact.uploadFile(element, filePath);
     }
 
     /**
@@ -381,21 +372,21 @@ export class Steps {
         options?: StepOptions
     ): Promise<string> {
         log.interact('Selecting dropdown option for "%s" in "%s"', elementName, pageName);
-        const locator = toLocator(await this.repo.get(elementName, pageName, this.toResolutionOptions(options)));
-        return await this.interact.selectDropdown(locator, dropdownOptions);
+        const element = await this.repo.get(elementName, pageName, this.toResolutionOptions(options));
+        return await this.interact.selectDropdown(element, dropdownOptions);
     }
 
     /**
      * Performs a drag-and-drop action on an element.
      * @param elementName - The element name as defined under the given page.
      * @param pageName - The page name as defined in `page-repository.json`.
-     * @param dragOptions - Drag target: either `{ target: Locator }` or `{ xOffset, yOffset }`.
+     * @param dragOptions - Drag target: either `{ target: Element }` or `{ xOffset, yOffset }`.
      * @param options - Optional step options for element resolution.
      */
     async dragAndDrop(elementName: string, pageName: string, dragOptions: DragAndDropOptions, options?: StepOptions): Promise<void> {
         log.interact('Dragging and dropping "%s" in "%s"', elementName, pageName);
-        const locator = toLocator(await this.repo.get(elementName, pageName, this.toResolutionOptions(options)));
-        await this.interact.dragAndDrop(locator, dragOptions);
+        const element = await this.repo.get(elementName, pageName, this.toResolutionOptions(options));
+        await this.interact.dragAndDrop(element, dragOptions);
     }
 
     /**
@@ -404,14 +395,14 @@ export class Steps {
      * @param elementName - The element name as defined under the given page.
      * @param pageName - The page name as defined in `page-repository.json`.
      * @param elementText - The visible text of the specific list item to drag.
-     * @param dragOptions - Drag target: either `{ target: Locator }` or `{ xOffset, yOffset }`.
+     * @param dragOptions - Drag target: either `{ target: Element }` or `{ xOffset, yOffset }`.
      * @throws Error if no element with the specified text is found.
      */
     async dragAndDropListedElement(elementName: string, pageName: string, elementText: string, dragOptions: DragAndDropOptions): Promise<void> {
         log.interact('Dragging and dropping "%s" in "%s"', elementText, pageName);
         const element = await this.repo.getByText(elementName, pageName, elementText);
         if (!element) throw new Error(`No element with text "${elementText}" found for "${elementName}" in "${pageName}"`);
-        await this.interact.dragAndDrop(toLocator(element), dragOptions);
+        await this.interact.dragAndDrop(element, dragOptions);
     }
 
     /**
@@ -423,8 +414,8 @@ export class Steps {
      */
     async setSliderValue(elementName: string, pageName: string, value: number, options?: StepOptions): Promise<void> {
         log.interact('Setting slider "%s" in "%s" to value: %d', elementName, pageName, value);
-        const locator = toLocator(await this.repo.get(elementName, pageName, this.toResolutionOptions(options)));
-        await this.interact.setSliderValue(locator, value);
+        const element = await this.repo.get(elementName, pageName, this.toResolutionOptions(options));
+        await this.interact.setSliderValue(element, value);
     }
 
     /**
@@ -478,8 +469,8 @@ export class Steps {
      */
     async selectMultiple(elementName: string, pageName: string, values: string[], options?: StepOptions): Promise<string[]> {
         log.interact('Selecting multiple values on "%s" in "%s": %O', elementName, pageName, values);
-        const locator = toLocator(await this.repo.get(elementName, pageName, this.toResolutionOptions(options)));
-        return await this.interact.selectMultiple(locator, values);
+        const element = await this.repo.get(elementName, pageName, this.toResolutionOptions(options));
+        return await this.interact.selectMultiple(element, values);
     }
 
     // ==========================================
@@ -563,24 +554,24 @@ export class Steps {
      */
     async getAll(elementName: string, pageName: string, getAllOptions?: GetAllOptions, options?: StepOptions): Promise<string[]> {
         log.extract('Extracting all from "%s" in "%s"', elementName, pageName);
-        let locator = toLocator(await this.repo.get(elementName, pageName, this.toAllResolutionOptions(options)));
+        let element = await this.repo.get(elementName, pageName, this.toAllResolutionOptions(options));
 
         if (getAllOptions?.child) {
             if (typeof getAllOptions.child === 'string') {
-                locator = locator.locator(getAllOptions.child);
+                element = element.locateChild(getAllOptions.child);
             } else {
                 const childSelector = this.repo.getSelector(getAllOptions.child.elementName, getAllOptions.child.pageName);
-                locator = locator.locator(childSelector);
+                element = element.locateChild(childSelector);
             }
         }
 
         if (getAllOptions?.extractAttribute) {
-            const elements = await locator.all();
+            const elements = await element.all();
             const values = await Promise.all(elements.map(el => el.getAttribute(getAllOptions.extractAttribute!)));
             return values.filter((v): v is string => v !== null);
         }
 
-        return await this.extract.getAllTexts(locator);
+        return await this.extract.getAllTexts(element);
     }
 
     // ==========================================
@@ -890,8 +881,8 @@ export class Steps {
      */
     async clickListedElement(elementName: string, pageName: string, options: ListedElementMatch): Promise<void> {
         log.interact('Clicking listed element in "%s" > "%s" with options: %O', pageName, elementName, options);
-        const baseLocator = toLocator(await this.repo.get(elementName, pageName, { strategy: SelectionStrategy.ALL }));
-        const target = await this.interact.getListedElement(baseLocator, options, this.repo);
+        const baseElement = await this.repo.get(elementName, pageName, { strategy: SelectionStrategy.ALL });
+        const target = await this.interact.getListedElement(baseElement, options, this.repo);
         await this.interact.click(target);
     }
 
@@ -903,8 +894,8 @@ export class Steps {
      */
     async verifyListedElement(elementName: string, pageName: string, options: VerifyListedOptions): Promise<void> {
         log.verify('Verifying listed element in "%s" > "%s" with options: %O', pageName, elementName, options);
-        const baseLocator = toLocator(await this.repo.get(elementName, pageName, { strategy: SelectionStrategy.ALL }));
-        const target = await this.interact.getListedElement(baseLocator, options, this.repo);
+        const baseElement = await this.repo.get(elementName, pageName, { strategy: SelectionStrategy.ALL });
+        const target = await this.interact.getListedElement(baseElement, options, this.repo);
 
         if (options.expectedText !== undefined) {
             await this.verify.text(target, options.expectedText);
@@ -928,8 +919,8 @@ export class Steps {
      */
     async getListedElementData(elementName: string, pageName: string, options: GetListedDataOptions): Promise<string | null> {
         log.extract('Extracting data from listed element in "%s" > "%s" with options: %O', pageName, elementName, options);
-        const baseLocator = toLocator(await this.repo.get(elementName, pageName, { strategy: SelectionStrategy.ALL }));
-        const target = await this.interact.getListedElement(baseLocator, options, this.repo);
+        const baseElement = await this.repo.get(elementName, pageName, { strategy: SelectionStrategy.ALL });
+        const target = await this.interact.getListedElement(baseElement, options, this.repo);
 
         if (options.extractAttribute) {
             return await this.extract.getAttribute(target, options.extractAttribute);
@@ -979,8 +970,7 @@ export class Steps {
     ): Promise<void> {
         log.interact('Waiting for "%s" in "%s" to be "%s", then clicking', elementName, pageName, state);
         const element = await this.repo.get(elementName, pageName, this.toResolutionOptions(options));
-        const locator = toLocator(element);
-        await this.utils.waitForState(locator, state);
+        await this.utils.waitForState(element, state);
         await this.interact.click(element);
     }
 
@@ -1084,8 +1074,8 @@ export class Steps {
     async screenshot(elementNameOrOptions?: string | ScreenshotOptions, pageName?: string, options?: ScreenshotOptions): Promise<Buffer> {
         if (typeof elementNameOrOptions === 'string' && pageName) {
             log.extract('Taking screenshot of "%s" in "%s"', elementNameOrOptions, pageName);
-            const locator = toLocator(await this.repo.get(elementNameOrOptions, pageName));
-            return await this.extract.screenshot(locator, options);
+            const element = await this.repo.get(elementNameOrOptions, pageName);
+            return await this.extract.screenshot(element, options);
         }
 
         const opts = typeof elementNameOrOptions === 'object' ? elementNameOrOptions : options;

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -1,4 +1,3 @@
-import { Locator } from '@playwright/test';
 import { ElementRepository, Element, WebElement, ElementResolutionOptions, SelectionStrategy } from '@civitas-cerebrum/element-repository';
 import { ElementInteractions } from '../interactions/facade/ElementInteractions';
 import { DropdownSelectOptions, TextVerifyOptions, CountVerifyOptions, DragAndDropOptions, ScreenshotOptions, IsVisibleOptions } from '../enum/Options';
@@ -7,10 +6,6 @@ import {
     ExpectBuilder,
     ExpectContext,
 } from './ExpectMatchers';
-
-function toLocator(element: Element): Locator {
-    return (element as WebElement).locator;
-}
 
 /**
  * Fluent builder for performing actions on a repository element.
@@ -124,17 +119,13 @@ export class ElementAction {
         return this.repo.get(this.elementName, this.pageName, this.resolutionOptions);
     }
 
-    private async resolveLocator(): Promise<Locator> {
-        return toLocator(await this.resolve());
-    }
-
     // -- Terminal actions: interactions --
 
     /** Click the resolved element. Skips silently if `ifVisible()` was set and element is hidden. */
     async click(options?: { withoutScrolling?: boolean; force?: boolean }): Promise<void> {
         if (!await this.shouldProceed()) return;
-        const locator = toLocator(await this.resolve());
-        await this.interactions.interact.click(locator, {
+        const element = await this.resolve();
+        await this.interactions.interact.click(element, {
             withoutScrolling: options?.withoutScrolling,
             force: options?.force,
             timeout: this._timeout,
@@ -145,8 +136,7 @@ export class ElementAction {
     async clickIfPresent(options?: { withoutScrolling?: boolean; force?: boolean }): Promise<boolean> {
         const element = await this.resolve();
         if (await element.isVisible()) {
-            const locator = toLocator(element);
-            await this.interactions.interact.click(locator, {
+            await this.interactions.interact.click(element, {
                 withoutScrolling: options?.withoutScrolling,
                 ifPresent: true,
                 force: options?.force,
@@ -180,8 +170,8 @@ export class ElementAction {
 
     /** Select a dropdown option. */
     async selectDropdown(options?: DropdownSelectOptions): Promise<string> {
-        const locator = await this.resolveLocator();
-        return await this.interactions.interact.selectDropdown(locator, {
+        const element = await this.resolve();
+        return await this.interactions.interact.selectDropdown(element, {
             ...options,
             timeout: options?.timeout ?? this._timeout,
         });
@@ -221,14 +211,14 @@ export class ElementAction {
 
     /** Upload a file to a file input. */
     async uploadFile(filePath: string): Promise<void> {
-        const locator = await this.resolveLocator();
-        await this.interactions.interact.uploadFile(locator, filePath, { timeout: this._timeout });
+        const element = await this.resolve();
+        await this.interactions.interact.uploadFile(element, filePath, { timeout: this._timeout });
     }
 
     /** Drag and drop the resolved element. */
     async dragAndDrop(options: DragAndDropOptions): Promise<void> {
-        const locator = await this.resolveLocator();
-        await this.interactions.interact.dragAndDrop(locator, {
+        const element = await this.resolve();
+        await this.interactions.interact.dragAndDrop(element, {
             ...options,
             timeout: options.timeout ?? this._timeout,
         });
@@ -242,14 +232,14 @@ export class ElementAction {
 
     /** Set slider value. */
     async setSliderValue(value: number): Promise<void> {
-        const locator = await this.resolveLocator();
-        await this.interactions.interact.setSliderValue(locator, value, { timeout: this._timeout });
+        const element = await this.resolve();
+        await this.interactions.interact.setSliderValue(element, value, { timeout: this._timeout });
     }
 
     /** Select multiple options from a multi-select. */
     async selectMultiple(values: string[]): Promise<string[]> {
-        const locator = await this.resolveLocator();
-        return await this.interactions.interact.selectMultiple(locator, values, { timeout: this._timeout });
+        const element = await this.resolve();
+        return await this.interactions.interact.selectMultiple(element, values, { timeout: this._timeout });
     }
 
     // -- Terminal actions: verifications --
@@ -355,7 +345,7 @@ export class ElementAction {
      */
     async verifyImages(scroll: boolean = true): Promise<void> {
         const element = await this.repo.get(this.elementName, this.pageName, { strategy: SelectionStrategy.ALL });
-        await this.interactions.verify.images(toLocator(element), scroll);
+        await this.interactions.verify.images(element, scroll);
     }
 
     /** Assert element state. */
@@ -378,7 +368,7 @@ export class ElementAction {
      */
     async verifyOrder(expectedTexts: string[]): Promise<void> {
         const element = await this.repo.get(this.elementName, this.pageName, { strategy: SelectionStrategy.ALL });
-        await this.interactions.verify.order(toLocator(element), expectedTexts);
+        await this.interactions.verify.order(element, expectedTexts);
     }
 
     /**
@@ -389,7 +379,7 @@ export class ElementAction {
      */
     async verifyListOrder(direction: 'asc' | 'desc'): Promise<void> {
         const element = await this.repo.get(this.elementName, this.pageName, { strategy: SelectionStrategy.ALL });
-        await this.interactions.verify.listOrder(toLocator(element), direction);
+        await this.interactions.verify.listOrder(element, direction);
     }
 
     // -- Terminal actions: extractions --
@@ -414,8 +404,8 @@ export class ElementAction {
 
     /** Get all text contents from matching elements. */
     async getAllTexts(): Promise<string[]> {
-        const locator = await this.resolveLocator();
-        return await this.interactions.extract.getAllTexts(locator);
+        const element = await this.resolve();
+        return await this.interactions.extract.getAllTexts(element);
     }
 
     /** Get input value. */
@@ -432,8 +422,8 @@ export class ElementAction {
 
     /** Take a screenshot of the element. */
     async screenshot(options?: ScreenshotOptions): Promise<Buffer> {
-        const locator = await this.resolveLocator();
-        return await this.interactions.extract.screenshot(locator, options);
+        const element = await this.resolve();
+        return await this.interactions.extract.screenshot(element, options);
     }
 
     // -- Expect matcher tree + predicate escape hatch --

--- a/src/utils/ElementUtilities.ts
+++ b/src/utils/ElementUtilities.ts
@@ -1,14 +1,5 @@
-import { Locator } from '@playwright/test';
-import { Element, WebElement } from '@civitas-cerebrum/element-repository';
+import { Element } from '@civitas-cerebrum/element-repository';
 import { log } from '../logger/Logger';
-
-/** Accepts either a Playwright `Locator` or an element-repository `Element`. */
-type Waitable = Locator | Element;
-
-function toElement(target: Waitable): Element {
-    if ('_type' in target) return target as Element;
-    return new WebElement(target as Locator);
-}
 
 /**
  * Utility class to handle standardized waiting logic across the framework.
@@ -33,17 +24,16 @@ export class Utils {
      * If the resolver yields multiple elements (strict mode violation),
      * the wait is retried automatically on the first matched element.
      *
-     * @param target  - An `Element` or Playwright `Locator` to wait on.
+     * @param element - An `Element` to wait on.
      * @param state   - The state to wait for. Defaults to `'visible'`.
      * @param timeout - Per-call timeout override. Falls back to the instance timeout when omitted.
      */
     async waitForState(
-        target: Waitable,
+        element: Element,
         state: 'visible' | 'attached' | 'hidden' | 'detached' = 'visible',
         timeout?: number,
     ): Promise<void> {
         const effectiveTimeout = timeout ?? this.timeout;
-        const element = toElement(target);
         try {
             await element.waitFor({ state, timeout: effectiveTimeout });
         } catch (error) {

--- a/tests/core-api.spec.ts
+++ b/tests/core-api.spec.ts
@@ -93,7 +93,7 @@ test.describe('E2E Facade Implementation Suite', () => {
 
       await steps.dragAndDropListedElement( 'sortableItems','SortablePage', 'Item A', { target: dropZone! });
 
-      await interactions.verify.textContains((dropZone as WebElement).locator, 'Item A');
+      await interactions.verify.textContains(dropZone!, 'Item A');
     });
 
     log('TC_002 Drag and Drop Interactions — passed');

--- a/tests/listed-elements.spec.ts
+++ b/tests/listed-elements.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from './fixture/StepFixture';
+import { WebElement } from '@civitas-cerebrum/element-repository';
 import { createLogger } from '../src/logger/Logger';
 
 const log = createLogger('tests');
@@ -191,16 +192,16 @@ test.describe('TC_054: getListedElement (raw) — child variants and error cases
       await steps.verifyUrlContains('/table');
     });
 
+    const baseElement = () => new WebElement(page.locator(repo.getSelector('rows', 'TablePage')));
+
     await test.step('getListedElement with text match', async () => {
-      const baseLocator = page.locator(repo.getSelector('rows', 'TablePage'));
-      const row = await interactions.interact.getListedElement(baseLocator, { text: 'Alice' }, repo);
+      const row = await interactions.interact.getListedElement(baseElement(), { text: 'Alice' }, repo);
       const text = await row.textContent();
       expect(text).toContain('Alice');
     });
 
     await test.step('getListedElement with attribute match', async () => {
-      const baseLocator = page.locator(repo.getSelector('rows', 'TablePage'));
-      const row = await interactions.interact.getListedElement(baseLocator, {
+      const row = await interactions.interact.getListedElement(baseElement(), {
         attribute: { name: 'data-testid', value: 'table-row-1' }
       }, repo);
       const text = await row.textContent();
@@ -208,8 +209,7 @@ test.describe('TC_054: getListedElement (raw) — child variants and error cases
     });
 
     await test.step('getListedElement with child as page-repo reference', async () => {
-      const baseLocator = page.locator(repo.getSelector('rows', 'TablePage'));
-      const child = await interactions.interact.getListedElement(baseLocator, {
+      const child = await interactions.interact.getListedElement(baseElement(), {
         text: 'Alice',
         child: { pageName: 'TablePage', elementName: 'rowCheckboxes' }
       }, repo);
@@ -217,10 +217,9 @@ test.describe('TC_054: getListedElement (raw) — child variants and error cases
     });
 
     await test.step('getListedElement throws when child is page-repo ref but no repo provided', async () => {
-      const baseLocator = page.locator(repo.getSelector('rows', 'TablePage'));
       let errorThrown = false;
       try {
-        await interactions.interact.getListedElement(baseLocator, {
+        await interactions.interact.getListedElement(baseElement(), {
           text: 'Alice',
           child: { pageName: 'TablePage', elementName: 'rowCheckboxes' }
         });
@@ -232,10 +231,9 @@ test.describe('TC_054: getListedElement (raw) — child variants and error cases
     });
 
     await test.step('getListedElement throws when neither text nor attribute provided', async () => {
-      const baseLocator = page.locator(repo.getSelector('rows', 'TablePage'));
       let errorThrown = false;
       try {
-        await interactions.interact.getListedElement(baseLocator, {}, repo);
+        await interactions.interact.getListedElement(baseElement(), {}, repo);
       } catch (e: unknown) {
         errorThrown = true;
         expect((e as Error).message).toContain('requires either "text" or "attribute"');

--- a/tests/raw-api.spec.ts
+++ b/tests/raw-api.spec.ts
@@ -4,8 +4,14 @@
  * Exercises the raw interaction classes (ElementRepository, Verifications,
  * Navigation) directly, verifying they produce correct results against
  * the live vue-test-app — not just that they don't throw.
+ *
+ * As of v0.2.6 the Verifications/Interactions/Extractions classes only accept
+ * `Element`, not raw Playwright Locators. These tests construct `WebElement`
+ * wrappers at the seam — the one place in the codebase where bridging from a
+ * `page.locator(...)` into an `Element` is still expected.
  */
 import { test, expect } from './fixture/StepFixture';
+import { WebElement } from '@civitas-cerebrum/element-repository';
 
 test.describe('ElementRepository — direct query methods', () => {
 
@@ -95,28 +101,29 @@ test.describe('Verifications — direct method validation', () => {
     const { Verifications } = await import('../src/interactions/Verification');
     const shortVerify = new Verifications(page, 2000);
 
-    await shortVerify.presence(page.locator('[data-testid="btn-primary"]'));
+    await shortVerify.presence(new WebElement(page.locator('[data-testid="btn-primary"]')));
 
     await expect(async () => {
-      await shortVerify.presence(page.locator('[data-testid="nonexistent"]'));
+      await shortVerify.presence(new WebElement(page.locator('[data-testid="nonexistent"]')));
     }).rejects.toThrow();
   });
 
   test('attribute — validates correct attribute value', async ({ page, steps, interactions }) => {
     await steps.navigateTo('/buttons');
-    const locator = page.locator('[data-testid="btn-primary"]');
-    await interactions.verify.attribute(locator, 'data-testid', 'btn-primary');
+    const el = new WebElement(page.locator('[data-testid="btn-primary"]'));
+    await interactions.verify.attribute(el, 'data-testid', 'btn-primary');
   });
 
   test('attribute — fails for wrong attribute value', async ({ page, steps }) => {
     await steps.navigateTo('/buttons');
     const { Verifications } = await import('../src/interactions/Verification');
     const shortVerify = new Verifications(page, 2000);
+    const el = new WebElement(page.locator('[data-testid="btn-primary"]'));
 
-    await shortVerify.attribute(page.locator('[data-testid="btn-primary"]'), 'data-testid', 'btn-primary');
+    await shortVerify.attribute(el, 'data-testid', 'btn-primary');
 
     await expect(async () => {
-      await shortVerify.attribute(page.locator('[data-testid="btn-primary"]'), 'data-testid', 'wrong-value');
+      await shortVerify.attribute(el, 'data-testid', 'wrong-value');
     }).rejects.toThrow();
   });
 
@@ -131,7 +138,7 @@ test.describe('Verifications — direct method validation', () => {
     const locator = page.locator('#name');
     await locator.waitFor({ state: 'visible' });
     await locator.fill('Verified Value');
-    await interactions.verify.inputValue(locator, 'Verified Value');
+    await interactions.verify.inputValue(new WebElement(locator), 'Verified Value');
   });
 
   test('inputValue — fails when value does not match', async ({ page, steps }) => {
@@ -142,23 +149,24 @@ test.describe('Verifications — direct method validation', () => {
     const locator = page.locator('#name');
     await locator.waitFor({ state: 'visible' });
     await locator.fill('Actual');
-    await shortVerify.inputValue(locator, 'Actual');
+    const el = new WebElement(locator);
+    await shortVerify.inputValue(el, 'Actual');
 
     await expect(async () => {
-      await shortVerify.inputValue(locator, 'Expected');
+      await shortVerify.inputValue(el, 'Expected');
     }).rejects.toThrow();
   });
 
   test('cssProperty — verifies computed CSS matches expected value', async ({ page, steps, interactions }) => {
     await steps.navigateTo('/buttons');
-    const locator = page.locator('[data-testid="btn-primary"]');
-    const display = await interactions.extract.getCssProperty(locator, 'display');
-    await interactions.verify.cssProperty(locator, 'display', display);
+    const el = new WebElement(page.locator('[data-testid="btn-primary"]'));
+    const display = await interactions.extract.getCssProperty(el, 'display');
+    await interactions.verify.cssProperty(el, 'display', display);
   });
 
   test('text/value/attribute variants — contains / matches / startsWith / endsWith', async ({ page, steps, interactions }) => {
     await steps.navigateTo('/buttons');
-    const btn = page.locator('[data-testid="btn-primary"]');
+    const btn = new WebElement(page.locator('[data-testid="btn-primary"]'));
 
     await interactions.verify.textContains(btn, 'rim');
     await interactions.verify.textMatches(btn, /^Prim/);
@@ -169,9 +177,10 @@ test.describe('Verifications — direct method validation', () => {
     await interactions.verify.attributeMatches(btn, 'data-testid', /^btn-/);
 
     await steps.navigateTo('/forms');
-    const input = page.locator('#name');
-    await input.waitFor({ state: 'visible' });
-    await input.fill('Alice Example');
+    const inputLocator = page.locator('#name');
+    await inputLocator.waitFor({ state: 'visible' });
+    await inputLocator.fill('Alice Example');
+    const input = new WebElement(inputLocator);
     await interactions.verify.inputValueContains(input, 'lice');
     await interactions.verify.inputValueMatches(input, /^Alice/);
     await interactions.verify.inputValueStartsWith(input, 'Alice');
@@ -204,14 +213,14 @@ test.describe('Verifications — direct method validation', () => {
     await steps.navigateTo('/product-carousel');
     const locator = page.locator('[data-testid="product-image-0"]');
     await locator.waitFor({ state: 'visible', timeout: 5000 });
-    await interactions.verify.images(locator);
+    await interactions.verify.images(new WebElement(locator));
   });
 
   test('order — verifies elements appear in expected text order', async ({ page, steps, interactions }) => {
     await steps.navigateTo('/buttons');
     // First two buttons in the variants section
     const locator = page.locator('.btn-row .btn').first();
-    await interactions.verify.order(locator, ['Primary']);
+    await interactions.verify.order(new WebElement(locator), ['Primary']);
   });
 
   test('listOrder — verifies list elements are sorted', async ({ page, steps, interactions }) => {
@@ -221,7 +230,7 @@ test.describe('Verifications — direct method validation', () => {
     const count = await locator.count();
     if (count > 1) {
       try {
-        await interactions.verify.listOrder(locator, 'asc');
+        await interactions.verify.listOrder(new WebElement(locator), 'asc');
       } catch {
         // List may not be sorted ascending — the method is exercised with real data
       }


### PR DESCRIPTION
Fixes #74.

## Summary

The public `Target` type on `Interactions`, `Verifications`, `Extractions`, and `Utils` was `Locator | Element` during the element-repository migration window. That compat window is now closed, and the `Target` alias — now just `type Target = Element` — is removed entirely. Every signature takes `Element` directly.

Internal helpers that wrapped raw Locators in `WebElement` on the fly are gone; the one remaining seam is `Verifications.resolveLocator()`, which legitimately needs the raw Locator for Playwright's `expect(locator)` assertions.

## Changes

- **`src/interactions/Interaction.ts`**: `Target` type alias removed. Every signature takes `Element`. `getByText` and `getListedElement` now return `Element | null` / `Element` instead of `Locator`.
- **`src/interactions/Verification.ts`**: `Target` type alias removed. `resolveLocator` stays as an internal helper for `expect(locator).X()` calls.
- **`src/interactions/Extraction.ts`**: `Target` type alias removed.
- **`src/utils/ElementUtilities.ts`**: `Waitable` alias removed. `waitForState` takes `Element` directly.
- **`src/enum/Options.ts`**: `DragAndDropOptions.target` narrowed from `Locator | Element` to `Element`. Removed the `Locator` import.
- **`src/index.ts`**: dropped the `export type { Target } from './interactions/Interaction'` re-export.
- **`src/steps/CommonSteps.ts` / `src/steps/ElementAction.ts`**: removed the `toLocator` / `resolveLocator` helpers. Every call site that was extracting a Locator to hand to `interact`/`verify`/`extract` now hands over the `Element` directly. `getAll` uses `Element.locateChild` for child drill-down.
- **Tests** (`raw-api.spec.ts`, `listed-elements.spec.ts`, `core-api.spec.ts`): the handful of tests constructing raw Playwright locators for direct `interactions.interact/verify/extract` calls now wrap via `new WebElement(locator)`. Documented in the raw-api header comment as the single bridging point.
- **`contributing.md`** (invariant #8 and layer responsibility table): reflect the tightened type.

## Breaking change

Consumers calling `interactions.interact.X(locator)` / `verify.X(locator)` / `extract.X(locator)` with a raw `Locator` must switch to an `Element`:

```ts
// Before
await interactions.verify.text(page.locator('#foo'), 'bar');

// After
await interactions.verify.text(new WebElement(page.locator('#foo')), 'bar');
```

Anyone who imported `Target` from `@civitas-cerebrum/element-interactions` now imports `Element` from `@civitas-cerebrum/element-repository` (already re-exported at the same top level).

Steps API users (`steps.click(el, page, ...)` etc.) and fluent API users (`steps.on(el, page).click()`) are unaffected.

## Test plan

- [x] `npx playwright test` — 416 pass, 17 pre-existing skipped.
- [x] `npx tsc --noEmit` — clean.
- [x] No `import { Locator } from '@playwright/test'` in `src/interactions/Interaction.ts`, `src/interactions/Extraction.ts`, or `src/utils/ElementUtilities.ts` (kept in `src/interactions/Verification.ts` for the internal `expect(locator)` seam).
- [x] `Target` type alias removed from all four files and from `src/index.ts`.

## Version

No version bump — content lands under 0.2.6 per the current release train.

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>