### PR TITLE
Listed-element regex + withDescendant filters

### DIFF
--- a/src/enum/Options.ts
+++ b/src/enum/Options.ts
@@ -81,15 +81,54 @@ export interface DragAndDropOptions {
 }
 
 /**
+ * A match value for listed-element filters.
+ *
+ * - A plain `string` matches as a substring (existing semantics — kept for
+ *   backwards compatibility with every pre-0.2.6 call site).
+ * - A `{ regex, flags? }` object is compiled into a `RegExp` and used to
+ *   match via Playwright's filter APIs. Use this for multi-language text
+ *   matching and any pattern-based narrowing (e.g. list items whose label
+ *   matches `/delivery fee|entrega|Liefergebühr/i`).
+ *
+ * @example
+ * { regex: 'Sandycove|Burgatia|Owenahincha', flags: 'i' }
+ */
+export type TextMatcher = string | { regex: string; flags?: string };
+
+/**
  * Core match criteria for locating a specific element within a list.
- * Provide either `text` (visible text match) or `attribute` (HTML attribute match).
- * Optionally drill into a child element with `child`.
+ *
+ * The listed element is identified by EITHER `text` (visible text match) OR
+ * `attribute` (HTML attribute name-value match). Both can be combined with
+ * `withDescendant` to additionally filter by the presence or text of a
+ * descendant element — useful when the list item itself doesn't carry the
+ * distinguishing signal but one of its children does.
+ *
+ * `child` drills into a descendant AFTER the item is matched (for assertion
+ * or extraction downstream), where `withDescendant` narrows WHICH item is
+ * matched in the first place.
  */
 export interface ListedElementMatch {
-    /** Match the listed element by its visible text content. */
-    text?: string;
-    /** Match the listed element by an HTML attribute name-value pair. */
-    attribute?: { name: string; value: string };
+    /** Match the listed element by its visible text content. String = substring, object = regex. */
+    text?: TextMatcher;
+    /** Match the listed element by an HTML attribute. String value = substring, object = regex. */
+    attribute?: { name: string; value: TextMatcher };
+    /**
+     * Filter list items that contain a descendant matching this criterion.
+     * Composes with `text` / `attribute` (AND logic — the item must satisfy
+     * both the top-level match and the descendant filter).
+     *
+     * @example
+     * // "find the orderSummaryRow whose `amount` child reads /delivery/i"
+     * { withDescendant: { child: { pageName: 'CheckoutPage', elementName: 'amount' },
+     *                     text: { regex: 'delivery', flags: 'i' } } }
+     */
+    withDescendant?: {
+        /** The descendant to look for — CSS selector or page-repository reference. */
+        child: string | { pageName: string; elementName: string };
+        /** Optional text match on the descendant. When omitted, only presence is required. */
+        text?: TextMatcher;
+    };
     /** Target a child within the matched element — a CSS selector or a page-repository reference. */
     child?: string | { pageName: string; elementName: string };
 }
@@ -104,8 +143,8 @@ export interface ListedElementMatch {
 export interface VerifyListedOptions extends ListedElementMatch {
     /** Assert that the resolved element's text matches this value. */
     expectedText?: string;
-    /** Assert that the resolved element has this attribute name-value pair. */
-    expected?: { name: string; value: string };
+    /** Assert that the resolved element has this attribute name-value pair. `value` can be a string (exact match) or regex. */
+    expected?: { name: string; value: TextMatcher };
 }
 
 /**

--- a/src/interactions/Interaction.ts
+++ b/src/interactions/Interaction.ts
@@ -1,7 +1,30 @@
 import { Page } from '@playwright/test';
-import { ClickOptions, DropdownSelectOptions, DropdownSelectType, DragAndDropOptions, ListedElementMatch, ActionTimeoutOptions } from '../enum/Options';
+import { ClickOptions, DropdownSelectOptions, DropdownSelectType, DragAndDropOptions, ListedElementMatch, ActionTimeoutOptions, TextMatcher } from '../enum/Options';
 import { Utils } from '../utils/ElementUtilities';
 import { Element, WebElement } from '@civitas-cerebrum/element-repository';
+
+/**
+ * Normalizes a `TextMatcher` into a string (for substring matching) or
+ * RegExp (for pattern matching). `undefined` passes through so callers can
+ * easily check "was a matcher provided?".
+ */
+function compileTextMatcher(matcher: TextMatcher): string | RegExp;
+function compileTextMatcher(matcher: TextMatcher | undefined): string | RegExp | undefined;
+function compileTextMatcher(matcher: TextMatcher | undefined): string | RegExp | undefined {
+    if (matcher === undefined) return undefined;
+    if (typeof matcher === 'string') return matcher;
+    return new RegExp(matcher.regex, matcher.flags);
+}
+
+/**
+ * Escapes regex metacharacters in a string so it can be embedded as a literal
+ * pattern. Used for the case-insensitive fallback when a plain `text: string`
+ * matcher needs to be re-tried as a regex.
+ */
+function escapeRegex(input: string): string {
+    return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 
 /**
  * The `Interactions` class provides a robust set of methods for interacting
@@ -308,30 +331,83 @@ export class Interactions {
         options: ListedElementMatch,
         repo?: { getSelector(elementName: string, pageName: string): string },
     ): Promise<Element> {
-        let matched: Element;
-
-        if (options.text) {
-            const caseSensitive = base.filter({ hasText: options.text }).first();
-            if ((await caseSensitive.count()) > 0) {
-                matched = caseSensitive;
-            } else {
-                const escaped = options.text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-                matched = base.filter({ hasText: new RegExp(escaped, 'i') }).first();
-            }
-        } else if (options.attribute) {
-            // Locator.and() composition has no Element equivalent today — drop to Locator internally.
-            const baseLocator = (base as WebElement).locator;
-            matched = new WebElement(
-                baseLocator
-                    .and(this.page.locator(`[${options.attribute.name}="${options.attribute.value}"]`))
-                    .first(),
-            );
-        } else {
-            throw new Error('ListedElementOptions requires either "text" or "attribute" to identify the element.');
+        if (!options.text && !options.attribute && !options.withDescendant) {
+            throw new Error('ListedElementOptions requires "text", "attribute", or "withDescendant" to identify the element.');
         }
+
+        // Stage 1 — narrow by `text` OR `attribute` (whichever is provided).
+        // A regex `text` matches directly; a plain string retries case-insensitively
+        // if the exact substring misses (back-compat with v0.2.5 behavior).
+        let narrowed: Element = base;
+
+        if (options.text !== undefined) {
+            const compiled = compileTextMatcher(options.text);
+            if (compiled instanceof RegExp) {
+                narrowed = narrowed.filter({ hasText: compiled });
+            } else {
+                const caseSensitive = narrowed.filter({ hasText: compiled });
+                if ((await caseSensitive.count()) > 0) {
+                    narrowed = caseSensitive;
+                } else {
+                    narrowed = narrowed.filter({ hasText: new RegExp(escapeRegex(compiled), 'i') });
+                }
+            }
+        }
+
+        if (options.attribute !== undefined) {
+            const { name, value } = options.attribute;
+            // `locator.and()` composes attribute narrowing on the base locator.
+            // No Element equivalent today — drop to Locator internally.
+            const current = (narrowed as WebElement).locator;
+
+            if (typeof value === 'string') {
+                // Exact-string attribute match via CSS selector composition.
+                narrowed = new WebElement(current.and(this.page.locator(`[${name}="${value}"]`)));
+            } else {
+                // Regex attribute match — CSS attribute selectors don't express regex,
+                // so narrow to candidates with the attribute present, then test each
+                // attribute value against the pattern in JS.
+                const pattern = compileTextMatcher(value) as RegExp;
+                const candidates = current.and(this.page.locator(`[${name}]`));
+                const all = await candidates.all();
+                let picked: (typeof all)[number] | null = null;
+                for (const candidate of all) {
+                    const actual = await candidate.getAttribute(name);
+                    if (actual !== null && pattern.test(actual)) {
+                        picked = candidate;
+                        break;
+                    }
+                }
+                if (!picked) {
+                    throw new Error(`No listed element found with attribute "${name}" matching ${pattern}.`);
+                }
+                narrowed = new WebElement(picked);
+            }
+        }
+
+        // Stage 2 — optionally filter further by descendant presence / text.
+        if (options.withDescendant) {
+            const desc = options.withDescendant;
+            const childSelector = typeof desc.child === 'string'
+                ? desc.child
+                : (repo
+                    ? repo.getSelector(desc.child.elementName, desc.child.pageName)
+                    : (() => { throw new Error('An ElementRepository instance is required when `withDescendant.child` is a page-repository reference.'); })());
+            const current = (narrowed as WebElement).locator;
+            const descendantLocator = this.page.locator(childSelector);
+            const textMatcher = compileTextMatcher(desc.text);
+            const filterOpts = textMatcher !== undefined
+                ? { has: descendantLocator.filter({ hasText: textMatcher }) }
+                : { has: descendantLocator };
+            narrowed = new WebElement(current.filter(filterOpts));
+        }
+
+        // Always take the first match after all filters compose.
+        const matched: Element = narrowed.first();
 
         await this.utils.waitForState(matched, 'visible');
 
+        // Stage 3 — optionally drill into a child for the returned locator.
         if (!options.child) {
             return matched;
         }

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -903,7 +903,12 @@ export class Steps {
         }
 
         if (options.expected) {
-            await this.verify.attribute(target, options.expected.name, options.expected.value);
+            const { name, value } = options.expected;
+            if (typeof value === 'string') {
+                await this.verify.attribute(target, name, value);
+            } else {
+                await this.verify.attributeMatches(target, name, new RegExp(value.regex, value.flags));
+            }
             return;
         }
 

--- a/tests/listed-elements.spec.ts
+++ b/tests/listed-elements.spec.ts
@@ -236,11 +236,122 @@ test.describe('TC_054: getListedElement (raw) — child variants and error cases
         await interactions.interact.getListedElement(baseElement(), {}, repo);
       } catch (e: unknown) {
         errorThrown = true;
-        expect((e as Error).message).toContain('requires either "text" or "attribute"');
+        expect((e as Error).message).toContain('requires "text", "attribute", or "withDescendant"');
       }
       expect(errorThrown).toBe(true);
     });
 
     log('TC_054 Raw getListedElement — passed');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TC_089: Listed-element regex + descendant filter (#69)
+// ──────────────────────────────────────────────────────────────────────────────
+
+test.describe('TC_089: ListedElementMatch — regex + withDescendant', () => {
+
+  test('regex text match picks any of several candidates', async ({ steps }) => {
+    await test.step('clickListedElement with regex alternation navigates to one of the matched categories', async () => {
+      // HomePage has Forms / Buttons / Text Inputs / etc. as category cards. Regex alternation
+      // must match ONE of them and click it, navigating away from home. If the regex didn't
+      // resolve to a real element, `verifyAbsence` below would fail (categories would still be
+      // visible on home).
+      await steps.navigateTo('/');
+      await steps.clickListedElement( 'categories','HomePage', {
+        text: { regex: 'Forms|Text Inputs|Buttons', flags: 'i' },
+      });
+      await steps.verifyAbsence( 'categories','HomePage');
+    });
+
+    await test.step('getListedElementData with regex text returns the matched row text', async () => {
+      // getListedElementData proves the regex path extracts the right element's text.
+      await steps.navigateTo('/');
+      await steps.click( 'tableLink','SidebarNav');
+      await steps.verifyUrlContains('/table');
+      const cellText = await steps.getListedElementData( 'rows','TablePage', {
+        text: { regex: 'Alice|Bob', flags: 'i' },
+        child: 'td:nth-child(2)',
+      });
+      expect(cellText).toMatch(/Alice|Bob/i);
+    });
+  });
+
+  test('regex attribute match narrows by attribute value pattern', async ({ steps }) => {
+    await test.step('Navigate to Table page', async () => {
+      await steps.navigateTo('/');
+      await steps.click( 'tableLink','SidebarNav');
+      await steps.verifyUrlContains('/table');
+    });
+
+    await test.step('verifyListedElement with regex attribute value', async () => {
+      // Table rows carry data-testid="table-row-N" — match any row by /^table-row-/.
+      await steps.verifyListedElement( 'rows','TablePage', {
+        attribute: { name: 'data-testid', value: { regex: '^table-row-\\d+$' } },
+      });
+    });
+  });
+
+  test('withDescendant filters items by a child repo reference', async ({ steps }) => {
+    await test.step('Navigate to Table page', async () => {
+      await steps.navigateTo('/');
+      await steps.click( 'tableLink','SidebarNav');
+      await steps.verifyUrlContains('/table');
+    });
+
+    await test.step('Pick the row whose nameCell text matches "Alice"', async () => {
+      // The outer listed element is `rows`; we want "the row whose nameCell descendant
+      // contains Alice". Previously this required a manual page.locator().filter() call.
+      const cellText = await steps.getListedElementData( 'rows','TablePage', {
+        withDescendant: {
+          child: { pageName: 'TablePage', elementName: 'nameCell' },
+          text: { regex: 'Alice', flags: 'i' },
+        },
+        child: 'td:nth-child(2)',
+      });
+      expect(cellText).toBe('Alice Martin');
+    });
+  });
+
+  test('withDescendant without `text` filters items that merely HAVE the descendant', async ({ steps }) => {
+    await test.step('Navigate to Table page', async () => {
+      await steps.navigateTo('/');
+      await steps.click( 'tableLink','SidebarNav');
+      await steps.verifyUrlContains('/table');
+    });
+
+    await test.step('verifyListedElement — rows that have a nameCell descendant', async () => {
+      await steps.verifyListedElement( 'rows','TablePage', {
+        withDescendant: { child: { pageName: 'TablePage', elementName: 'nameCell' } },
+      });
+    });
+  });
+
+  test('throws when no matching criterion is provided', async ({ page, repo, interactions }) => {
+    await interactions.navigate.toUrl('/table');
+    const base = new WebElement(page.locator(repo.getSelector('rows', 'TablePage')));
+    let errorThrown = false;
+    try {
+      await interactions.interact.getListedElement(base, {}, repo);
+    } catch (e: unknown) {
+      errorThrown = true;
+      expect((e as Error).message).toContain('requires "text", "attribute", or "withDescendant"');
+    }
+    expect(errorThrown).toBe(true);
+  });
+
+  test('regex attribute match throws when no candidate matches the pattern', async ({ page, repo, interactions }) => {
+    await interactions.navigate.toUrl('/table');
+    const base = new WebElement(page.locator(repo.getSelector('rows', 'TablePage')));
+    let errorThrown = false;
+    try {
+      await interactions.interact.getListedElement(base, {
+        attribute: { name: 'data-testid', value: { regex: '^nonexistent-row-pattern-' } },
+      }, repo);
+    } catch (e: unknown) {
+      errorThrown = true;
+      expect((e as Error).message).toContain('No listed element found with attribute');
+    }
+    expect(errorThrown).toBe(true);
   });
 });

--- a/tests/negative.spec.ts
+++ b/tests/negative.spec.ts
@@ -93,7 +93,7 @@ test.describe('Negative Tests', () => {
     const rows = page.locator('[data-testid^="table-row-"]');
     await expect(async () => {
       await fast.interact.getListedElement(rows, {} as any);
-    }).rejects.toThrow('requires either "text" or "attribute"');
+    }).rejects.toThrow('requires "text", "attribute", or "withDescendant"');
     log('TC_084 Negative getListedElement missing criteria — passed');
   });
 


### PR DESCRIPTION
Fixes #69.

## Summary

`clickListedElement`, `verifyListedElement`, and `getListedElementData` gain three new matcher shapes via a shared `TextMatcher` type (`string | { regex: string; flags?: string }`):

1. **Regex text match** — pick any item whose visible text matches a pattern (e.g. multi-language option pickers):
   ```ts
   await steps.clickListedElement('locationOption', 'LocationPickerDialog', {
     text: { regex: 'Sandycove|Burgatia|Owenahincha', flags: 'i' },
   });
   ```

2. **Regex attribute match** — narrow by an attribute value pattern when an exact string isn't enough:
   ```ts
   await steps.verifyListedElement('rows', 'TablePage', {
     attribute: { name: 'data-testid', value: { regex: '^table-row-\\d+$' } },
   });
   ```

3. **Descendant filter (`withDescendant`)** — match list items by a descendant element's presence or text, and still drill into `child` afterwards:
   ```ts
   const fee = await steps.getListedElementData('orderSummaryRow', 'CheckoutPage', {
     withDescendant: {
       child: { pageName: 'CheckoutPage', elementName: 'amount' },
       text: { regex: 'delivery|entrega|Liefergebühr', flags: 'i' },
     },
     child: { pageName: 'CheckoutPage', elementName: 'amount' },
   });
   ```

## Backwards compatibility

Additive — `text: string` and `attribute.value: string` keep their existing substring-match semantics. Every pre-0.2.6 call site continues to work unchanged.

## Implementation notes

- `TextMatcher` is compiled via `compileTextMatcher(matcher)` → `string | RegExp` at the top of `getListedElement`. Plain strings keep their v0.2.5 case-insensitive fallback.
- Regex **attribute** matching can't be expressed as a CSS selector, so the implementation narrows to candidates with the attribute present (`locator.and(this.page.locator('[name]'))`) and then iterates with `getAttribute` to find the first whose value matches the pattern. Throws a clear error when no candidate matches.
- `withDescendant` composes via Playwright's `locator.filter({ has })` so it stacks with `text` / `attribute` as AND logic. Omitting the descendant's `text` matches purely on presence.
- `VerifyListedOptions.expected.value` is also widened so attribute verification can assert regex values.

## Naming

The issue uses `hasText`; we kept our existing `text` field (per the design chat — no Playwright convention adoption).

## Test plan

- [x] `tests/listed-elements.spec.ts` TC_089 — 6 new tests covering regex text, regex attribute, `withDescendant` with and without `text`, plus two error paths.
- [x] `tests/negative.spec.ts` TC_084 — updated for the new error message.
- [x] Full suite: 422 pass, 17 pre-existing skipped.
- [x] `npx tsc --noEmit` clean.

## Version

No version bump — lands under 0.2.6 per the current release train.

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>