### PR TITLE
Unify isVisible() + ifVisible() into a single dual-behavior method

### DIFF
--- a/skills/element-interactions/contributing.md
+++ b/skills/element-interactions/contributing.md
@@ -362,7 +362,9 @@ When adding a new Interactions-routed action, extend its option bag with `timeou
 
 **Repo resolution has its own timeout.** `repo.get(...)` pays `ElementRepository.defaultTimeout` (configured by `repoTimeout` on the fixture, 15000ms default) waiting for the element to reach `attached`. This is upstream of `ElementAction._timeout` — the chain-level `.timeout(ms)` only governs action + verification, not resolution. If you need to bound resolution too, use `repo.setDefaultTimeout(ms)` on the fixture or in a `beforeEach`.
 
-**Visibility probe is a deliberate exception.** `ifVisible(ms?)` has its own short `visibilityTimeout` (default 2000ms) because its whole purpose is fast-skip: a hidden element should abort the action in ~2s, not 30s. Do not unify it into the main timeout.
+**Visibility probe/gate is another deliberate exception.** `isVisible(options?)` (the unified replacement for the old `ifVisible()` / boolean `isVisible()` pair) and its older aliases use a short `visibilityTimeout` (default 2000ms) because their whole purpose is fast-skip: a hidden element should abort the action in ~2s, not 30s. Do not unify it into the main timeout.
+
+`isVisible(options?)` returns a `VisibleChain` that is both awaitable (`Promise<boolean>`) and chainable (`.click()`, `.text.toBe(...)`, etc.). The probe constructs a `WebElement` directly from `repo.getSelector(...)` rather than going through `repo.get(...)` — otherwise the 15s repository-resolution wait would swallow the caller's short timeout. Every probe and gate decision is logged under `tester:visible` with a `[probe]` or `[gate]` tag.
 
 Other builder state (queue, pendingNot) also mutates, but stays scoped: each `.expect()` / `.on()` call returns a fresh builder, so mutation doesn't leak across chains. `.not` is one-shot — it flips the next matcher only, then resets.
 

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -613,36 +613,41 @@ export class Steps {
     }
 
     /**
-     * Non-throwing visibility probe. Returns `true` if the element is visible
-     * within the given timeout, `false` otherwise. Optionally filters by text content.
+     * Unified visibility entry point. Returns a `VisibleChain` that is both:
      *
-     * Unlike `isPresent`, this method supports a custom timeout (default 2000ms)
-     * and an optional `containsText` filter that requires the element's text to
-     * include the given substring.
+     * - **awaitable as `Promise<boolean>`** — the probe, never throws. Backwards
+     *   compatible with the old `isVisible(): Promise<boolean>` signature —
+     *   `await steps.isVisible('banner', 'Page', { timeout: 500 })` still
+     *   resolves to a boolean at runtime.
+     * - **chainable with action methods and the matcher tree** — the gate,
+     *   silently skips when the element is hidden. Replaces `steps.on(...).ifVisible()`.
+     *
+     * Every probe and gate decision is logged under `tester:visible` with a
+     * `[probe]` or `[gate]` tag so silently-skipped actions stay debuggable.
      *
      * @param elementName - The element name as defined under the given page.
      * @param pageName - The page name as defined in `page-repository.json`.
-     * @param options - Optional probe settings.
-     * @returns `true` if the element is visible (and matches text, if specified), `false` otherwise.
+     * @param options - `{ timeout?: 2000, containsText?: string }`.
+     *
+     * @example
+     * ```ts
+     * // Probe — returns boolean
+     * const ok = await steps.isVisible('banner', 'Page', { timeout: 500 });
+     *
+     * // Gate — skips when hidden
+     * await steps.isVisible('cookieBanner', 'Page').click();
+     *
+     * // Gate + containsText
+     * await steps.isVisible('promo', 'Page', { containsText: '50% off' }).click();
+     *
+     * // Matcher tree — silently skipped when hidden
+     * await steps.isVisible('banner', 'Page').text.toBe('Hello');
+     * ```
      */
-    async isVisible(elementName: string, pageName: string, options?: IsVisibleOptions): Promise<boolean> {
+    isVisible(elementName: string, pageName: string, options?: IsVisibleOptions) {
         const timeout = options?.timeout ?? 2000;
         log.verify('Probing visibility of "%s" in "%s" (timeout: %dms)', elementName, pageName, timeout);
-        try {
-            // Use getSelector + construct a WebElement directly so the caller-supplied
-            // timeout is the only wait in play — repo.get() would block on its own
-            // repository resolution timeout (15s default) before our waitFor runs.
-            const selector = this.repo.getSelector(elementName, pageName);
-            const element = new WebElement(this.page.locator(selector).first());
-            await element.waitFor({ state: 'visible', timeout });
-            if (options?.containsText) {
-                const text = await element.textContent().catch(() => null);
-                return text !== null && text.includes(options.containsText);
-            }
-            return true;
-        } catch {
-            return false;
-        }
+        return this.on(elementName, pageName).isVisible(options);
     }
 
     /**

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -6,6 +6,7 @@ import {
     ExpectBuilder,
     ExpectContext,
 } from './ExpectMatchers';
+import { VisibleChain } from './VisibleChain';
 
 /**
  * Fluent builder for performing actions on a repository element.
@@ -91,6 +92,10 @@ export class ElementAction {
      * await steps.on('cookieBanner', 'Page').ifVisible().click();
      * await steps.on('promoPopup', 'Page').ifVisible(500).click();
      * ```
+     *
+     * @deprecated Prefer `await steps.on(el, page).isVisible({ timeout }).click()`.
+     * `isVisible()` is the unified replacement for both `ifVisible()` (modifier)
+     * and the old boolean `isVisible()` probe. Will be removed in a future major release.
      */
     ifVisible(timeout?: number): this {
         this.conditionalVisible = true;
@@ -310,22 +315,36 @@ export class ElementAction {
     }
 
     /**
-     * Non-throwing visibility probe with optional text filtering and custom timeout.
-     * Returns `true` if the element is visible (and matches text if specified), `false` otherwise.
+     * Unified visibility entry point. Returns a `VisibleChain` that is both:
+     *
+     * - **awaitable as `Promise<boolean>`** — the probe, never throws. Backwards
+     *   compatible with the old `isVisible(): Promise<boolean>` signature —
+     *   `await steps.on(el, page).isVisible({ timeout: 500 })` still resolves
+     *   to a boolean at runtime.
+     * - **chainable with action methods and the matcher tree** — the gate,
+     *   silently skips when the element is hidden. Replaces `ifVisible()`.
+     *
+     * Every probe and gate decision is logged under `tester:visible` with a
+     * `[probe]` or `[gate]` tag so silently-skipped actions stay debuggable.
+     *
+     * @param options - `{ timeout?: 2000, containsText?: string }`. When
+     *   `containsText` is provided, the probe is `true` only if the element is
+     *   visible AND its text contains the given substring. Note: matcher-tree
+     *   gates (`.isVisible().text.toBe(...)`) only honor the visibility check —
+     *   `containsText` applies to probe + action-gate paths.
+     *
+     * @example
+     * ```ts
+     * // Probe
+     * if (await steps.on('banner', 'Page').isVisible({ timeout: 500 })) { … }
+     *
+     * // Gate
+     * await steps.on('cookieBanner', 'Page').isVisible().click();
+     * await steps.on('promo', 'Page').isVisible({ timeout: 500 }).text.toBe('Promo');
+     * ```
      */
-    async isVisible(options?: IsVisibleOptions): Promise<boolean> {
-        const timeout = options?.timeout ?? 2000;
-        try {
-            const element = await this.resolve();
-            await element.waitFor({ state: 'visible', timeout });
-            if (options?.containsText) {
-                const text = await element.textContent().catch(() => null);
-                return text !== null && text.includes(options.containsText);
-            }
-            return true;
-        } catch {
-            return false;
-        }
+    isVisible(options?: IsVisibleOptions): VisibleChain {
+        return new VisibleChain(this, options);
     }
 
     /** Assert an attribute value. Delegates to the matcher tree's `.attributes.get(name).toBe(value)`. */

--- a/src/steps/VisibleChain.ts
+++ b/src/steps/VisibleChain.ts
@@ -1,0 +1,222 @@
+import { WebElement } from '@civitas-cerebrum/element-repository';
+import { ElementAction } from './ElementAction';
+import { IsVisibleOptions, ClickOptions, DropdownSelectOptions, DragAndDropOptions } from '../enum/Options';
+import { createLogger } from '../logger/Logger';
+
+const log = createLogger('visible');
+
+/**
+ * Dual-behavior chain returned by `steps.on(el, page).visible(options?)` and
+ * `steps.visible(el, page, options?)`. Consolidates the old `isVisible()`
+ * probe and `ifVisible()` modifier into one entry point.
+ *
+ * Two modes of use:
+ *
+ * **1. Probe (`await chain`)** — resolves to `boolean`, never throws.
+ *    Replaces the deprecated `isVisible(...)` probe.
+ *
+ *    ```ts
+ *    const ok = await steps.on('banner', 'Page').visible({ timeout: 500 });
+ *    if (ok) { … }
+ *    ```
+ *
+ * **2. Gate (`chain.click()` / `.fill(...)` / matcher tree)** — runs the same
+ *    probe, then either executes the action or silently skips it. Replaces
+ *    the deprecated `ifVisible(...)` modifier.
+ *
+ *    ```ts
+ *    await steps.on('cookieBanner', 'Page').visible().click();
+ *    await steps.on('promo', 'Page').visible({ timeout: 500 }).text.toBe('Promo');
+ *    ```
+ *
+ * Every probe and gate decision is logged under `tester:visible` with a
+ * `[probe]` or `[gate]` tag so test failures that end in a silently-skipped
+ * action remain traceable without sprinkling `console.log` through user code:
+ *
+ *    tester:visible [probe] "banner" @ "HomePage" (timeout=500ms) → true
+ *    tester:visible [gate] skipping click() on "cookieBanner" @ "HomePage" — not visible
+ *    tester:visible [gate] executing fill() on "searchInput" @ "SearchPage" — visible
+ */
+export class VisibleChain implements PromiseLike<boolean> {
+    constructor(
+        private action: ElementAction,
+        private options: IsVisibleOptions = {},
+    ) {
+        // Wire the `ifVisible()` gate on the underlying ElementAction so the
+        // matcher-tree access (`.visible().text.toBe(...)`) inherits the skip
+        // semantics for free via `ExpectContext.conditionalVisible`.
+        this.action.ifVisible(options.timeout);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Probe path — `await chain` resolves to boolean.
+    // ──────────────────────────────────────────────────────────────────────
+
+    then<TResult1 = boolean, TResult2 = never>(
+        onfulfilled?: ((value: boolean) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+    ): Promise<TResult1 | TResult2> {
+        return this.probe().then(onfulfilled as any, onrejected as any);
+    }
+
+    /**
+     * Runs the visibility check (and optional `containsText` filter) without
+     * throwing. Constructs a `WebElement` directly from the raw selector so
+     * the caller-supplied `timeout` is the only wait — avoids the 15s
+     * repository-resolution default that `repo.get(...)` would impose.
+     */
+    private async probe(): Promise<boolean> {
+        const el = this.action['elementName'] as string;
+        const pg = this.action['pageName'] as string;
+        const repo = this.action['repo'] as { getSelector: (e: string, p: string) => string; driver: { locator: (s: string) => { first: () => import('@playwright/test').Locator } } };
+        const timeout = this.options.timeout ?? 2000;
+        const containsText = this.options.containsText;
+        try {
+            const selector = repo.getSelector(el, pg);
+            const element = new WebElement(repo.driver.locator(selector).first());
+            await element.waitFor({ state: 'visible', timeout });
+            if (containsText) {
+                const text = await element.textContent().catch(() => null);
+                const ok = text !== null && text.includes(containsText);
+                log('[probe] "%s" @ "%s" (timeout=%dms, containsText="%s") → %s', el, pg, timeout, containsText, ok);
+                return ok;
+            }
+            log('[probe] "%s" @ "%s" (timeout=%dms) → true', el, pg, timeout);
+            return true;
+        } catch {
+            log('[probe] "%s" @ "%s" (timeout=%dms) → false', el, pg, timeout);
+            return false;
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Gate path — action methods probe first, then execute or skip.
+    // ──────────────────────────────────────────────────────────────────────
+
+    /** Click — gated on visibility. Silently skips if hidden. */
+    async click(options?: ClickOptions): Promise<void> {
+        await this.gate('click', () => this.action.click(options));
+    }
+
+    /** `clickIfPresent` gated on visibility. Returns `false` when the gate skips. */
+    async clickIfPresent(options?: ClickOptions): Promise<boolean> {
+        return this.gateReturning('clickIfPresent', false, () => this.action.clickIfPresent(options));
+    }
+
+    /** Hover — gated. */
+    async hover(): Promise<void> {
+        await this.gate('hover', () => this.action.hover());
+    }
+
+    /** Fill — gated. */
+    async fill(text: string): Promise<void> {
+        await this.gate('fill', () => this.action.fill(text));
+    }
+
+    /** Scroll into view — gated. */
+    async scrollIntoView(): Promise<void> {
+        await this.gate('scrollIntoView', () => this.action.scrollIntoView());
+    }
+
+    /** Check — gated. */
+    async check(): Promise<void> {
+        await this.gate('check', () => this.action.check());
+    }
+
+    /** Uncheck — gated. */
+    async uncheck(): Promise<void> {
+        await this.gate('uncheck', () => this.action.uncheck());
+    }
+
+    /** Double-click — gated. */
+    async doubleClick(): Promise<void> {
+        await this.gate('doubleClick', () => this.action.doubleClick());
+    }
+
+    /** Right-click — gated. */
+    async rightClick(): Promise<void> {
+        await this.gate('rightClick', () => this.action.rightClick());
+    }
+
+    /** Type sequentially — gated. */
+    async typeSequentially(text: string, delay?: number): Promise<void> {
+        await this.gate('typeSequentially', () => this.action.typeSequentially(text, delay));
+    }
+
+    /** Upload file — gated. */
+    async uploadFile(filePath: string): Promise<void> {
+        await this.gate('uploadFile', () => this.action.uploadFile(filePath));
+    }
+
+    /** Clear input — gated. */
+    async clearInput(): Promise<void> {
+        await this.gate('clearInput', () => this.action.clearInput());
+    }
+
+    /** Select dropdown — gated. Returns the selected value, or empty string when skipped. */
+    async selectDropdown(options?: DropdownSelectOptions): Promise<string> {
+        return this.gateReturning('selectDropdown', '', () => this.action.selectDropdown(options));
+    }
+
+    /** Set slider value — gated. */
+    async setSliderValue(value: number): Promise<void> {
+        await this.gate('setSliderValue', () => this.action.setSliderValue(value));
+    }
+
+    /** Select multiple — gated. Returns the selected values, or empty array when skipped. */
+    async selectMultiple(values: string[]): Promise<string[]> {
+        return this.gateReturning('selectMultiple', [] as string[], () => this.action.selectMultiple(values));
+    }
+
+    /** Drag and drop — gated. */
+    async dragAndDrop(options: DragAndDropOptions): Promise<void> {
+        await this.gate('dragAndDrop', () => this.action.dragAndDrop(options));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Matcher tree — gated via `ExpectContext.conditionalVisible`.
+    //
+    // The matcher tree accessors forward to the underlying ElementAction.
+    // `ifVisible()` was already invoked in the constructor, so a hidden
+    // element short-circuits the matcher without throwing. The
+    // `containsText` filter is NOT honored by matcher-tree gates — it only
+    // applies to probe + action-gate paths. For content-filtered assertions,
+    // use `.text.toContain(...)` directly or combine with `satisfy(...)`.
+    // ──────────────────────────────────────────────────────────────────────
+
+    get text() { return this.action.text; }
+    get value() { return this.action.value; }
+    get count() { return this.action.count; }
+    get enabled() { return this.action.enabled; }
+    get visible() { return this.action.visible; }
+    get attributes() { return this.action.attributes; }
+    css(property: string) { return this.action.css(property); }
+    satisfy(predicate: Parameters<ElementAction['satisfy']>[0]) { return this.action.satisfy(predicate); }
+    get not() { return this.action.not; }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Internal helpers
+    // ──────────────────────────────────────────────────────────────────────
+
+    private async gate(name: string, exec: () => Promise<unknown>): Promise<void> {
+        const el = this.action['elementName'] as string;
+        const pg = this.action['pageName'] as string;
+        if (!(await this.probe())) {
+            log('[gate] skipping %s() on "%s" @ "%s" — not visible', name, el, pg);
+            return;
+        }
+        log('[gate] executing %s() on "%s" @ "%s" — visible', name, el, pg);
+        await exec();
+    }
+
+    private async gateReturning<T>(name: string, fallback: T, exec: () => Promise<T>): Promise<T> {
+        const el = this.action['elementName'] as string;
+        const pg = this.action['pageName'] as string;
+        if (!(await this.probe())) {
+            log('[gate] skipping %s() on "%s" @ "%s" — not visible (returning fallback)', name, el, pg);
+            return fallback;
+        }
+        log('[gate] executing %s() on "%s" @ "%s" — visible', name, el, pg);
+        return exec();
+    }
+}

--- a/tests/enhanced-selectors.spec.ts
+++ b/tests/enhanced-selectors.spec.ts
@@ -219,6 +219,59 @@ test.describe('Enhanced Selectors — Issue Fixes #61-#65', () => {
   });
 
   // ============================================================
+  // #70 — Unified isVisible() dual-behavior (probe + gate)
+  // ============================================================
+
+  test('#70: isVisible — probe mode via top-level Steps API (backwards compat with old boolean return)', async ({ steps }) => {
+    // `await steps.isVisible(...)` still resolves to boolean at runtime.
+    const ok: boolean = await steps.isVisible('promoBanner', 'EnhancedSelectorsPage');
+    expect(ok).toBe(true);
+
+    const hidden: boolean = await steps.isVisible('alwaysHidden', 'EnhancedSelectorsPage', { timeout: 500 });
+    expect(hidden).toBe(false);
+  });
+
+  test('#70: isVisible — probe via fluent API also resolves to boolean', async ({ steps }) => {
+    const ok: boolean = await steps.on('promoBanner', 'EnhancedSelectorsPage').isVisible();
+    expect(ok).toBe(true);
+  });
+
+  test('#70: isVisible — gate path skips click on hidden element silently', async ({ steps }) => {
+    await test.step('Gate on hidden element — click is skipped', async () => {
+      await steps.isVisible('alwaysHidden', 'EnhancedSelectorsPage', { timeout: 500 }).click();
+      // No error — click was gated.
+    });
+
+    await test.step('Gate on visible element — click executes', async () => {
+      await steps.isVisible('toggleBannerBtn', 'EnhancedSelectorsPage').click();
+    });
+
+    await test.step('Banner toggled off after the gate-passed click', async () => {
+      const stillVisible = await steps.isVisible('promoBanner', 'EnhancedSelectorsPage', { timeout: 500 });
+      expect(stillVisible).toBe(false);
+    });
+  });
+
+  test('#70: isVisible — containsText filter applies to both probe and action gate', async ({ steps }) => {
+    await test.step('Probe — containsText matches', async () => {
+      const match = await steps.isVisible('promoBanner', 'EnhancedSelectorsPage', { containsText: '50% off' });
+      expect(match).toBe(true);
+    });
+
+    await test.step('Probe — containsText does not match', async () => {
+      const noMatch = await steps.isVisible('promoBanner', 'EnhancedSelectorsPage', { containsText: 'nonexistent-copy' });
+      expect(noMatch).toBe(false);
+    });
+  });
+
+  test('#70: isVisible — matcher tree (fluent) silently skips when hidden', async ({ steps }) => {
+    // Hidden element — the matcher tree assertion should NOT throw because the
+    // visibility gate inherited from the chain makes the assertion skip.
+    await steps.on('alwaysHidden', 'EnhancedSelectorsPage').isVisible({ timeout: 500 }).text.toBe('anything');
+  });
+
+
+  // ============================================================
   // #62 — Iframe / Cross-Frame Scope
   // ============================================================
 

--- a/tests/enhanced-selectors.spec.ts
+++ b/tests/enhanced-selectors.spec.ts
@@ -270,6 +270,56 @@ test.describe('Enhanced Selectors — Issue Fixes #61-#65', () => {
     await steps.on('alwaysHidden', 'EnhancedSelectorsPage').isVisible({ timeout: 500 }).text.toBe('anything');
   });
 
+  test('#70: isVisible — containsText filter gates the action (not just the probe)', async ({ steps }) => {
+    // clickIfPresent has an observable return value (true when executed, fallback
+    // false when the gate skips) that distinguishes "action ran" from "action
+    // skipped" without relying on DOM side effects. Proves containsText drives
+    // the gate decision, not just the boolean probe.
+    await test.step('containsText matches → gate executes, clickIfPresent returns true', async () => {
+      const ran = await steps
+        .isVisible('promoBanner', 'EnhancedSelectorsPage', { containsText: '50% off' })
+        .clickIfPresent();
+      expect(ran).toBe(true);
+    });
+
+    await test.step('containsText does not match → gate skips, clickIfPresent returns false', async () => {
+      const skipped = await steps
+        .isVisible('promoBanner', 'EnhancedSelectorsPage', { containsText: 'nonexistent-copy' })
+        .clickIfPresent();
+      expect(skipped).toBe(false);
+    });
+  });
+
+  test('#70: isVisible — fluent probe honors containsText filter', async ({ steps }) => {
+    // Probe coverage so far only exercises containsText via the top-level
+    // `steps.isVisible(...)`. Verify the fluent `steps.on(...).isVisible(opts)`
+    // entry point applies the same filter — symmetry matters because the two
+    // entry points share implementation but wire the options differently.
+    const match = await steps
+      .on('promoBanner', 'EnhancedSelectorsPage')
+      .isVisible({ containsText: '50% off' });
+    expect(match).toBe(true);
+
+    const noMatch = await steps
+      .on('promoBanner', 'EnhancedSelectorsPage')
+      .isVisible({ containsText: 'nonexistent-copy' });
+    expect(noMatch).toBe(false);
+  });
+
+  test('#70: isVisible — probe on hidden element respects caller timeout (no 15s repo wait)', async ({ steps }) => {
+    // VisibleChain.probe() constructs a WebElement directly from
+    // `repo.getSelector(...)` to avoid the 15s repository-resolution default
+    // that `repo.get(...)` would otherwise impose. Without this fast path, a
+    // `{ timeout: 500 }` probe on a hidden element would still pay the full
+    // 15s wait. Lock the invariant with a wall-clock assertion: the probe
+    // should resolve within a small multiple of its requested timeout.
+    const start = Date.now();
+    const result = await steps.isVisible('alwaysHidden', 'EnhancedSelectorsPage', { timeout: 500 });
+    const elapsed = Date.now() - start;
+    expect(result).toBe(false);
+    expect(elapsed).toBeLessThan(3000);
+  });
+
 
   // ============================================================
   // #62 — Iframe / Cross-Frame Scope

--- a/tests/enhanced-selectors.spec.ts
+++ b/tests/enhanced-selectors.spec.ts
@@ -346,6 +346,27 @@ test.describe('Enhanced Selectors — Issue Fixes #61-#65', () => {
     expect(values).toEqual([]);
   });
 
+  test('#70: isVisible — remaining action-method and matcher-tree proxies skip cleanly on hidden element', async ({ steps }) => {
+    // Sweep every VisibleChain entry point that the #70 block has not
+    // individually exercised. A hidden element must make all of them no-op
+    // without throwing — if any proxy were wired incorrectly (wrong signature,
+    // missing await, forwarding to the underlying action outside the gate),
+    // the call would throw against `alwaysHidden` instead of returning silently.
+    const chain = () => steps.isVisible('alwaysHidden', 'EnhancedSelectorsPage', { timeout: 500 });
+
+    // void action-method proxies
+    await chain().clearInput();
+    await chain().dragAndDrop({ target: { x: 0, y: 0 } });
+    await chain().setSliderValue(50);
+    await chain().typeSequentially('ignored', 10);
+    await chain().uploadFile('/tmp/ignored.txt');
+
+    // matcher-tree proxies — gated via conditionalVisible, so the assertion
+    // short-circuits on hidden.
+    await chain().css('display').toBe('impossible-value');
+    await chain().satisfy(() => false);
+  });
+
 
   // ============================================================
   // #62 — Iframe / Cross-Frame Scope

--- a/tests/enhanced-selectors.spec.ts
+++ b/tests/enhanced-selectors.spec.ts
@@ -320,6 +320,32 @@ test.describe('Enhanced Selectors — Issue Fixes #61-#65', () => {
     expect(elapsed).toBeLessThan(3000);
   });
 
+  test('#70: isVisible — matcher tree .count proxy silently skips when hidden', async ({ steps }) => {
+    // Extends matcher-tree coverage beyond `.text` — `.count` is a numeric
+    // assertion proxy, a distinct code path from string comparators. A hidden
+    // element should short-circuit the assertion without throwing, same as
+    // `.text.toBe(...)` does.
+    await steps.on('alwaysHidden', 'EnhancedSelectorsPage').isVisible({ timeout: 500 }).count.toBe(999);
+  });
+
+  test('#70: isVisible — gateReturning fallbacks for selectDropdown and selectMultiple', async ({ steps }) => {
+    // Three action methods go through `gateReturning()` with a non-boolean
+    // fallback — clickIfPresent → false is covered above. The other two
+    // (selectDropdown → '', selectMultiple → []) share the same helper but
+    // different fallback types. Calling them on a hidden non-dropdown element
+    // also doubles as proof that the gate skips BEFORE the underlying action
+    // executes — otherwise selectDropdown on a hidden <div> would throw.
+    const value = await steps
+      .isVisible('alwaysHidden', 'EnhancedSelectorsPage', { timeout: 500 })
+      .selectDropdown();
+    expect(value).toBe('');
+
+    const values = await steps
+      .isVisible('alwaysHidden', 'EnhancedSelectorsPage', { timeout: 500 })
+      .selectMultiple(['anything']);
+    expect(values).toEqual([]);
+  });
+
 
   // ============================================================
   // #62 — Iframe / Cross-Frame Scope


### PR DESCRIPTION
Addresses #70.

## Summary

`steps.isVisible(el, page, options?)` and `steps.on(el, page).isVisible(options?)` now return a `VisibleChain` that is both:

1. **Awaitable as `Promise<boolean>`** — the probe, never throws. Backwards compatible: `await steps.isVisible(...)` still resolves to a boolean at runtime with the same timeout / `containsText` semantics.
2. **Chainable with action methods and the matcher tree** — the gate, silently skips when hidden. Replaces `ifVisible()`:

```ts
// Before
await steps.on('cookie', 'Page').ifVisible().click();

// After
await steps.on('cookie', 'Page').isVisible().click();
await steps.isVisible('cookie', 'Page').click();   // top-level too

// containsText filter applies to probe + action gate
await steps.isVisible('promo', 'Page', { containsText: '50% off' }).click();

// Matcher tree silently skips hidden elements (inherited from ifVisible plumbing)
await steps.on('banner', 'Page').isVisible({ timeout: 500 }).text.toBe('Hi');
```

## Debuggability

Every probe and gate decision is logged under a new `tester:visible` channel with a `[probe]` or `[gate]` tag so silently-skipped actions stay debuggable:

```
tester:visible [probe] "banner" @ "HomePage" (timeout=500ms) → true
tester:visible [gate] skipping click() on "cookieBanner" @ "HomePage" — not visible
tester:visible [gate] executing fill() on "searchInput" @ "SearchPage" — visible
```

## Naming

The issue title proposed `visible()` as the merged name; the matcher tree already exposes `.visible.toBeTrue()` on `ElementAction`, which would collide with a same-named method. The merged API keeps the name `isVisible()`:
- preserves `.visible.toBeTrue()` unchanged
- keeps `await steps.isVisible(...)` runtime-compatible with every pre-0.2.6 call site

## Implementation

- **`src/steps/VisibleChain.ts`** (new): implements `PromiseLike<boolean>` plus proxies for 15 action methods, the matcher tree (`.text`, `.value`, `.count`, `.enabled`, `.visible`, `.attributes`, `.css`, `.satisfy`, `.not`), and logging on every probe + gate decision.
- Probe path constructs a `WebElement` directly from `repo.getSelector(...)` rather than going through `repo.get(...)` — otherwise the 15s repository-resolution wait would swallow the caller's short timeout.
- Matcher-tree gating reuses the existing `conditionalVisible` plumbing via `this.action.ifVisible(timeout)` on the wrapped `ElementAction`.
- `ifVisible()` stays on `ElementAction` as a `@deprecated` alias. The old boolean `isVisible()` is now the probe face of the unified method.
- `contributing.md` invariant #5 updated to document the unified method and the fast-path probe rationale.

## Test plan

- [x] `tests/enhanced-selectors.spec.ts` — 5 new tests (`#70: …`) covering probe, gate, `containsText` filter, and matcher-tree gating.
- [x] Existing `#63` tests for the boolean probe continue to pass unchanged (VisibleChain is `PromiseLike<boolean>`).
- [x] Full suite: 421 pass, 17 pre-existing skipped.
- [x] `npx tsc --noEmit` — clean.

## Version

No bump — lands under 0.2.6 per the current release train.

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>