### PR TITLE
refactor: formalize VisibleChain contract, consolidate step loggers

### DIFF
--- a/src/logger/Logger.ts
+++ b/src/logger/Logger.ts
@@ -152,3 +152,24 @@ export const log = {
    */
   important: logger('important'),
 };
+
+/**
+ * Domain-sliced loggers for the Steps API. Each key corresponds to a
+ * conceptual area — importers should pick the one that matches what they're
+ * reporting. Centralized here so splits of `Steps` into semantic facades don't
+ * each redeclare the same namespaces.
+ *
+ * @example
+ * ```ts
+ * import { stepLog } from '../logger/Logger';
+ * stepLog.interact('Clicking on "%s" in "%s"', elementName, pageName);
+ * ```
+ */
+export const stepLog = {
+  navigate: logger('navigate'),
+  interact: logger('interact'),
+  extract: logger('extract'),
+  verify: logger('verify'),
+  email: logger('email'),
+  wait: logger('wait'),
+};

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -4,18 +4,9 @@ import { ElementInteractions } from '../interactions/facade/ElementInteractions'
 import { Utils } from '../utils/ElementUtilities';
 import { EmailClientConfig, EmailSendOptions, EmailReceiveOptions, ReceivedEmail, EmailMarkOptions, EmailMarkAction, EmailFilter } from '@civitas-cerebrum/email-client';
 import { StepOptions, DropdownSelectOptions, TextVerifyOptions, CountVerifyOptions, DragAndDropOptions, ListedElementOptions, ListedElementMatch, VerifyListedOptions, GetListedDataOptions, FillFormValue, GetAllOptions, ScreenshotOptions, IsVisibleOptions } from '../enum/Options';
-import { logger } from '../logger/Logger';
+import { stepLog as log } from '../logger/Logger';
 import { ElementAction } from './ElementAction';
 import { ExpectBuilder } from './ExpectMatchers';
-
-const log = {
-    navigate: logger('navigate'),
-    interact: logger('interact'),
-    extract: logger('extract'),
-    verify: logger('verify'),
-    email: logger('email'),
-    wait: logger('wait'),
-};
 
 /**
  * The `Steps` class serves as a unified Facade for test orchestration.

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -25,14 +25,23 @@ export class ElementAction {
     private visibilityTimeout: number = 2000;
 
     constructor(
-        private repo: ElementRepository,
-        private elementName: string,
-        private pageName: string,
+        private _repo: ElementRepository,
+        private _elementName: string,
+        private _pageName: string,
         private interactions: ElementInteractions,
         private timeoutMs?: number,
     ) {
         this._timeout = timeoutMs ?? 30000;
     }
+
+    /** Repository this chain resolves elements against. Readonly — set at construction. */
+    get repo(): ElementRepository { return this._repo; }
+
+    /** Element name on the target page. Readonly — set at construction. */
+    get elementName(): string { return this._elementName; }
+
+    /** Page name in the repository. Readonly — set at construction. */
+    get pageName(): string { return this._pageName; }
 
     /**
      * Override the retry timeout for any subsequent matcher or predicate call

--- a/src/steps/VisibleChain.ts
+++ b/src/steps/VisibleChain.ts
@@ -66,9 +66,7 @@ export class VisibleChain implements PromiseLike<boolean> {
      * repository-resolution default that `repo.get(...)` would impose.
      */
     private async probe(): Promise<boolean> {
-        const el = this.action['elementName'] as string;
-        const pg = this.action['pageName'] as string;
-        const repo = this.action['repo'] as { getSelector: (e: string, p: string) => string; driver: { locator: (s: string) => { first: () => import('@playwright/test').Locator } } };
+        const { elementName: el, pageName: pg, repo } = this.action;
         const timeout = this.options.timeout ?? 2000;
         const containsText = this.options.containsText;
         try {
@@ -199,8 +197,7 @@ export class VisibleChain implements PromiseLike<boolean> {
     // ──────────────────────────────────────────────────────────────────────
 
     private async gate(name: string, exec: () => Promise<unknown>): Promise<void> {
-        const el = this.action['elementName'] as string;
-        const pg = this.action['pageName'] as string;
+        const { elementName: el, pageName: pg } = this.action;
         if (!(await this.probe())) {
             log('[gate] skipping %s() on "%s" @ "%s" — not visible', name, el, pg);
             return;
@@ -210,8 +207,7 @@ export class VisibleChain implements PromiseLike<boolean> {
     }
 
     private async gateReturning<T>(name: string, fallback: T, exec: () => Promise<T>): Promise<T> {
-        const el = this.action['elementName'] as string;
-        const pg = this.action['pageName'] as string;
+        const { elementName: el, pageName: pg } = this.action;
         if (!(await this.probe())) {
             log('[gate] skipping %s() on "%s" @ "%s" — not visible (returning fallback)', name, el, pg);
             return fallback;


### PR DESCRIPTION
## Summary

Two internal cleanups from the 0.2.6 audit. **Zero API changes** — all public signatures, return types, and behaviors preserved.

### 1. ElementAction → VisibleChain contract

\`VisibleChain\` was reaching into \`ElementAction\`'s private fields via bracket-access casts:

\`\`\`ts
const el = this.action['elementName'] as string;
const pg = this.action['pageName'] as string;
const repo = this.action['repo'] as { getSelector: ...; driver: ... };
\`\`\`

Replaced with readonly getters on \`ElementAction\`. Underlying fields are renamed with a \`_\` prefix; the contract is now declared, typed, and documented. VisibleChain destructures the exposed getters instead of casting through brackets.

### 2. Step loggers consolidated

CommonSteps redeclared the six domain loggers (\`navigate\`, \`interact\`, \`extract\`, \`verify\`, \`email\`, \`wait\`) inline. Moved the declaration to \`src/logger/Logger.ts\` as \`stepLog\` so any module that needs the same palette can import it without re-instantiating.

### Skipped from audit

The audit also flagged splitting CommonSteps.ts (1185 lines, 62 methods) into 7 domain facades. Skipped — a close reading showed the methods are already a well-grouped Facade layer (2-4 line delegates over \`ElementInteractions\`), and a full split would add a new delegation layer and ~200 lines of overhead without cleaning any real entanglement.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx playwright test tests/enhanced-selectors.spec.ts -g \"#70\"\` — all 11 VisibleChain tests pass after the getter rewiring

## Version

No bump — lands under 0.2.6 per the current release train.

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>