### PR TITLE
chore: re-export Playwright's expect from package entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civitas-cerebrum/element-interactions",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "A robust, readable interaction and assertion Facade for Playwright. Abstract away boilerplate into semantic, English-like methods, making your test automation framework cleaner, easier to maintain, and accessible to non-developers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,10 @@ export type { ElementSnapshot, ExpectContext } from './steps/ExpectMatchers';
 // Test Fixture
 export { baseFixture, BaseFixtureOptions } from './fixture/BaseFixture';
 
+// Re-export Playwright's `expect` so consumers don't need a separate
+// `@playwright/test` import alongside the package's fluent expect API.
+export { expect } from '@playwright/test';
+
 // Re-exports from @civitas-cerebrum/email-client
 export { EmailClient } from '@civitas-cerebrum/email-client';
 export type {


### PR DESCRIPTION
## Summary
- Re-export `expect` from `@playwright/test` via the package index so consumer tests don't need two imports.
- With this, `import { test, expect } from '@civitas-cerebrum/element-interactions'`-style access is possible (via fixture + package).
- Version bump `0.2.7 → 0.2.8`.

## Test plan
- [ ] `npx tsc --noEmit` passes locally.
- [ ] CI green.
- [ ] Consumer project can `import { expect } from '@civitas-cerebrum/element-interactions'` after publish.

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>