### PR TITLE
chore: log.warn when click retries via dispatchEvent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civitas-cerebrum/element-interactions",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "A robust, readable interaction and assertion Facade for Playwright. Abstract away boilerplate into semantic, English-like methods, making your test automation framework cleaner, easier to maintain, and accessible to non-developers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/interactions/Interaction.ts
+++ b/src/interactions/Interaction.ts
@@ -2,6 +2,7 @@ import { Page } from '@playwright/test';
 import { ClickOptions, DropdownSelectOptions, DropdownSelectType, DragAndDropOptions, ListedElementMatch, ActionTimeoutOptions, TextMatcher } from '../enum/Options';
 import { Utils } from '../utils/ElementUtilities';
 import { Element, WebElement } from '@civitas-cerebrum/element-repository';
+import { log } from '../logger/Logger';
 
 /**
  * Normalizes a `TextMatcher` into a string (for substring matching) or
@@ -91,6 +92,7 @@ export class Interactions {
         } catch (error: unknown) {
             const message = error instanceof Error ? error.message : String(error);
             if (message.includes('intercepts pointer events')) {
+                log.warn('click intercepted by another element — retrying via dispatchEvent(\'click\')');
                 await element.dispatchEvent('click');
             } else {
                 await element.click({ timeout });


### PR DESCRIPTION
## Summary
When a standard click fails with \"intercepts pointer events\" and \`Interaction\` retries via \`dispatchEvent('click')\`, emit a warning under the \`tester:warn\` namespace so the fallback is visible in test output. Previously the retry was silent, which made diagnosing flakes harder.

Mirrors the matching change landing in singularity-engine PR #28. No behavioural change.

Version \`0.2.7 → 0.2.8\`.

## Test plan
- [ ] CI green.
- [ ] \`DEBUG=tester:warn npx playwright test\` surfaces the message when a click is intercepted.

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>