### PR TITLE
chore: bump element-repository to ^0.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civitas-cerebrum/element-interactions",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@civitas-cerebrum/context-store": "^0.0.2",
-        "@civitas-cerebrum/element-repository": "^0.1.6",
+        "@civitas-cerebrum/element-repository": "^0.1.8",
         "@civitas-cerebrum/email-client": "^0.0.7",
         "debug": "^4.4.3",
         "dotenv": "^17.3.1"
@@ -34,9 +34,9 @@
       "license": "MIT"
     },
     "node_modules/@civitas-cerebrum/element-repository": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/element-repository/-/element-repository-0.1.6.tgz",
-      "integrity": "sha512-TXGEJPX2ZfV2SQsF3ULfEj2TO44QiOhajFQjekFFMB5J6fFioreYemCRoMv7LfOm50WLAw8b7r0cK24MR+6U9w==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/element-repository/-/element-repository-0.1.8.tgz",
+      "integrity": "sha512-mWNjvjBJ6wEyLsViH2h4sdwooiE5zqOyv7MVjE4hjYBxQRP2l40XY92orCHPdSjOAdR+dT54mtbn91tGf5z+Zg==",
       "license": "MIT",
       "dependencies": {
         "@civitas-cerebrum/test-coverage": "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "A robust, readable interaction and assertion Facade for Playwright. Abstract away boilerplate into semantic, English-like methods, making your test automation framework cleaner, easier to maintain, and accessible to non-developers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -55,7 +55,7 @@
   "license": "MIT",
   "dependencies": {
     "@civitas-cerebrum/context-store": "^0.0.2",
-    "@civitas-cerebrum/element-repository": "^0.1.6",
+    "@civitas-cerebrum/element-repository": "^0.1.8",
     "@civitas-cerebrum/email-client": "^0.0.7",
     "debug": "^4.4.3",
     "dotenv": "^17.3.1"


### PR DESCRIPTION
## Summary
- Bump `@civitas-cerebrum/element-repository` from `^0.1.6` to `^0.1.8`.
- 0.1.7 added per-call `attachTimeout` override on `ElementResolutionOptions`; 0.1.8 added a `scrollIntoView` direction option and a new `swipe()` primitive. Both releases are additive.
- No facade changes in this PR — pick up the new primitives here in follow-ups when we decide which to surface.
- Bumps package to 0.2.9 (may need a follow-up bump depending on merge order with #92).

## Test plan
- [x] `npm run build` passes.
- [ ] Confirm consumer repos still install cleanly after publish.

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>