### PR TITLE
feat: add onboarding companion skill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civitas-cerebrum/element-interactions",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "A robust, readable interaction and assertion Facade for Playwright. Abstract away boilerplate into semantic, English-like methods, making your test automation framework cleaner, easier to maintain, and accessible to non-developers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/skills/bug-discovery/SKILL.md
+++ b/skills/bug-discovery/SKILL.md
@@ -356,3 +356,17 @@ After generating the report, ask:
 > "Bug discovery report written to `docs/e2e/bug-discovery-report.md`. Would you also like me to create GitHub issues for the confirmed bugs?"
 
 If the user agrees, create one issue per confirmed bug with the same structure as the report entry, labeled `bug` and `bug-discovery`.
+
+---
+
+## Invocation options
+
+bug-discovery accepts one optional parameter via `args`.
+
+| Mode | Behaviour |
+|---|---|
+| `phase: 'full'` (default) | Run Phase 1a (Element Probing), Phase 1b (Flow Probing), and everything downstream as documented above. |
+| `phase: '1a-element-probing'` | Run Phase 1a only. Write findings to `onboarding-report.md` (or the default bug report file). Do not run Phase 1b. |
+| `phase: '1b-flow-probing'` | Run Phase 1b only. Require that Phase 1a has already been run in a prior session (findings file exists). Use those findings to prioritise flow probes. |
+
+Parameter parsing: recognise the literal substrings `1a-element-probing`, `1b-flow-probing`, or `full` in `args`. Default to `full`.

--- a/skills/element-interactions/SKILL.md
+++ b/skills/element-interactions/SKILL.md
@@ -287,6 +287,7 @@ When the skill activates, **read the user's message first**. If they have alread
 Only show the greeting menu if the user's message is vague or just says something like "help me with Playwright tests":
 
 > "How can I help you today? I can:
+> - **Onboard a fresh project** — detect what's missing and run the full pipeline autonomously (scaffold → happy path → journey mapping → coverage expansion → bug hunts → summary)
 > - **Automate a scenario** — describe what you want to test, or give me a link to the app
 > - **Scale an existing project** — add more scenarios to an existing test suite
 > - **Fix or edit a test** — debug a failing test or modify an existing one
@@ -294,11 +295,51 @@ Only show the greeting menu if the user's message is vague or just says somethin
 
 ### Routing
 
+- **Onboarding intent** — phrases like "onboard this project", "set up element-interactions", "start from scratch", "automate this app from zero", OR a vague message on a project whose cascade detector (see below) reports a non-onboarded state → invoke the `onboarding` companion skill. Do not run Stages 1–4 inline.
 - **User already described a scenario** — Skip the greeting. Go directly to Stage 1 (fast path if scenario is complete, full discovery if vague).
 - **API question** — Answer directly from the API Reference section below. No stages needed.
 - **Fix or edit a test** — Skip to Stage 3 (Fix/Edit Mode).
 - **Scale existing project** — Read existing test files and `page-repository.json` first to understand current coverage, then proceed to Stage 1 with that context.
-- **Vague or no context** — Show the greeting menu and wait for the user's response.
+- **Vague or no context** — Run the onboarding cascade detector (see the `onboarding` skill). If it returns Level A, B, or C, invoke `onboarding`. If everything is present, show the greeting menu and wait.
+
+#### Onboarding cascade detector (quick reference)
+
+| Signal | Level | Action |
+|---|---|---|
+| `@civitas-cerebrum/element-interactions` not in `package.json` | A | Invoke `onboarding` |
+| Package present but any of `playwright.config.ts`, `tests/fixtures/base.ts`, `page-repository.json` missing | B | Invoke `onboarding` |
+| Scaffold present but `tests/e2e/docs/journey-map.md` missing OR missing sentinel on line 1 | C | Invoke `onboarding` |
+| All present | None | No action — greet as normal |
+
+---
+
+## Autonomous mode
+
+When the `onboarding` skill (or any other companion) invokes this orchestrator with `args` containing `autonomousMode: true`, the hard gates are disabled and Stages 1–4 run sequentially without prompts.
+
+### Required companion inputs
+
+When `autonomousMode: true`, the caller MUST provide:
+
+- `happyPathDescription: "<one sentence>"` — replaces the Stage-1 discovery conversation. The orchestrator reformats this into Given/When/Then silently.
+
+### Gate suspension
+
+In autonomous mode:
+
+- Stage-1 scenario approval — skipped. Reformatted scenario is treated as approved.
+- Stage-2 page-repository approval — skipped. Proposed entries are written directly (this is the ONLY exception to Rule 2, and it applies only inside autonomous mode).
+- Stage-3 stage-advancement prompts — skipped.
+- Stage-4 API Compliance Review — still runs, still fixes misuse. A failed review does NOT prompt; it auto-corrects and re-runs.
+- Failure-diagnosis on any test failure — still runs, still classifies. App bugs halt the autonomous flow and surface to the caller.
+
+### Commit discipline
+
+Autonomous mode still commits after each passing + compliant test, same as interactive mode. The caller is responsible for the outer commit boundary (e.g. the `test: happy path — <name>` commit from onboarding).
+
+### Returning control
+
+When Stages 1–4 complete in autonomous mode, the orchestrator returns to the caller with a short summary: `{ status: 'passed' | 'failed', testsWritten: [paths], appBugs: [...] }`. It does NOT advance to Stage 5 or show the Onboarding Completion Gate on its own — the caller decides what happens next.
 
 ---
 

--- a/skills/journey-mapping/SKILL.md
+++ b/skills/journey-mapping/SKILL.md
@@ -311,6 +311,18 @@ If any P0 journey has less than 100% step coverage, the test suite is **not comp
 
 ---
 
+## Invocation options
+
+This skill accepts one optional parameter via the `args` string when invoked through the Skill tool. The default (`phases: 'full'`) matches the original behaviour.
+
+| Mode | Behaviour |
+|---|---|
+| `phases: 'full'` (default) | Run Phases 1–5 as documented above. |
+| `phases: 'phase-1-only'` | Run Phase 1 (Page Discovery) only. Write a sentinel-bearing `journey-map.md` whose body contains the site map and empty `## User Journeys` / `## Gated Areas` / `## Coverage Checkpoint Template` headings for a later invocation to fill in. Do not run Phases 2, 3, 4, or 5. Commit with the message `docs: initial app-context and site map` if the caller is `onboarding`. |
+| `phases: 'phases-2-4'` | Require that `tests/e2e/docs/journey-map.md` already exists and carries the sentinel on line 1. Read its Phase-1 site map. Run Phases 2, 3, and 4, overwriting the file in place with the full journey map (sentinel preserved). Do not re-run Phase 1 or Phase 5. |
+
+Parameter parsing: the Skill tool passes `args` as a free-form string; the skill should recognise the literal substrings `phase-1-only`, `phases-2-4`, or `full` anywhere in `args`. If none appear, default to `full`. Reject conflicting combinations (e.g. both `phase-1-only` and `phases-2-4`) with a clear error, do nothing, and return.
+
 ## Integration with Other Skills
 
 ### element-interactions (main orchestrator)

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: onboarding
+description: >
+  Use this skill when asked to "onboard this project", "set up element-interactions",
+  "start from scratch", "automate this app from zero", or any request to bring a new
+  project from no test automation to a comprehensive element-interactions test suite.
+  Also auto-invoked by the element-interactions orchestrator when the cascade detector
+  reports a non-onboarded project state (missing framework dep, missing scaffold, or
+  missing sentinel-bearing journey-map.md). Runs the full pipeline autonomously after
+  a single front-load confirmation: install civitas-cerebrum + playwright deps,
+  scaffold framework files, crawl the app, automate the happy path, complete the
+  journey map, run five priority/depth-tiered coverage-expansion passes, run two
+  bug-hunt passes, and produce a summary deck plus onboarding report. Emits periodic
+  progress updates; requires no further prompts after the initial gate.
+---
+
+# Onboarding — Autonomous Project Setup
+
+The onboarding skill brings a fresh project from zero to a comprehensive test suite. It is the orchestrator that sequences the existing element-interactions, journey-mapping, test-composer, bug-discovery, failure-diagnosis, and work-summary-deck skills behind a single user confirmation.
+
+**Design reference:** `docs/superpowers/specs/2026-04-22-onboarding-skill-design.md`.
+
+---
+
+## Activation
+
+This skill activates when:
+
+1. The user's message matches onboarding intent ("onboard this project", "set up element-interactions", "start from scratch", "automate this app from zero").
+2. The `element-interactions` orchestrator's Routing block invokes this skill after running the cascade detector.
+
+On activation, immediately run the cascade detector (below). Do not prompt the user yet.
+
+### Cascade detector
+
+Run in order; stop at the first match.
+
+| # | Check | Result | Level |
+|---|---|---|---|
+| 1 | Is `@civitas-cerebrum/element-interactions` listed as a dependency in `package.json`? | No | **A** — install + scaffold + pipeline |
+| 2 | Are all of `playwright.config.ts`, `tests/fixtures/base.ts`, and `page-repository.json` present? | Any missing | **B** — scaffold + pipeline |
+| 3 | Does `tests/e2e/docs/journey-map.md` exist **and** have `<!-- journey-mapping:generated -->` on line 1? | No | **C** — pipeline only |
+| 4 | All of the above pass | Yes | **None** — exit with the re-invocation message |
+
+Use the Read and Glob tools to check these. Do not use Bash `ls` / `cat` for the detection.
+
+### Already-onboarded exit message
+
+If the detector reports **None**, print this message and stop — do not run the pipeline:
+
+> "This project is already onboarded (found `tests/e2e/docs/journey-map.md` with the journey-mapping sentinel, scaffold complete). To expand coverage further, invoke `test-composer`. To run more bug hunts, invoke `bug-discovery`. To rebuild from scratch, delete `tests/e2e/docs/journey-map.md` and re-run onboarding."
+
+---
+
+## Front-load gate
+
+Exactly one user interaction, at the start. After the user confirms, no further prompts until the run completes.
+
+Construct the gate message as follows:
+
+```
+Onboarding activated for <project name from package.json or directory basename>.
+
+Detected: Level <A | B | C> — <one-line summary of what's missing>
+
+Before I run, I need two things:
+  1. App URL: <auto-detected from playwright.config.ts baseURL if present; otherwise
+     ask the user>
+  2. One-sentence description of the primary thing a user most wants to do in this
+     app.
+
+I will then, autonomously and without further prompts:
+  <bullet list of phases that apply at the detected level, with the scaffolding /
+   install items elided for Level C and the install item elided for Level B>
+  • Full Phase-1 discovery (breadth-first crawl via Playwright MCP)
+  • Automate the happy path you described (Stages 1–4 inline)
+  • Full journey-mapping (Phases 2–4)
+  • 5 coverage-expansion passes (priority + depth tiered)
+  • 2 bug-hunt passes (element probing, then flow probing)
+  • Work summary deck + onboarding-report.md
+
+Expected runtime: tens of minutes to several hours.
+
+Proceed? (y / describe changes)
+```
+
+Wait for the user's reply. On `y` / `yes` / `proceed` / equivalent affirmative, move to the pipeline. On any other reply, treat it as a scope change request: restate the gate with the change applied and ask again. Do not move past the gate without an explicit affirmative.
+
+---
+
+## Progress output
+
+After every major milestone, emit a single line prefixed with `[onboarding]` to the terminal. Do not emit multi-line status dumps, do not paginate logs from companion skills, do not print intermediate MCP transcripts.
+
+Examples:
+
+```
+[onboarding] Level A detected — installing civitas-cerebrum + playwright
+[onboarding] Dependencies installed (3 packages)
+[onboarding] Scaffolding tests/fixtures/base.ts, page-repository.json, playwright.config.ts
+[onboarding] Phase 1 discovery — 12 pages visited so far…
+[onboarding] Phase 1 complete — 23 pages, 4 gated
+[onboarding] Journey mapping — 7 journeys identified (2 P0, 3 P1, 2 P2)
+[onboarding] Happy path test written, stabilizing…
+[onboarding] Happy path green — committed
+[onboarding] Coverage pass 1/5 (P0 happy paths) — 6 tests added, 6 green, 0 skipped
+[onboarding] Coverage pass 2/5 (P1 + P0 error states) — 9 tests added, 8 green, 1 skipped (data seed)
+[onboarding] Coverage pass 3/5 (P2 + P0/P1 edge cases) — 7 tests added, 7 green
+[onboarding] Coverage pass 4/5 (P3 + mobile) — 4 tests added, 4 green
+[onboarding] Coverage pass 5/5 (residual gaps) — 5 tests added, 5 green
+[onboarding] Bug-hunt 1/2 (element probing) — 2 issues logged
+[onboarding] Bug-hunt 2/2 (flow probing) — 3 issues logged
+[onboarding] Generating work-summary-deck
+[onboarding] Done. See onboarding-report.md.
+```
+
+---
+
+## Pipeline
+
+Seven phases. Each phase ends with exactly one commit. Phases are skipped when the cascade level does not require them (Level A runs all phases; Level B skips install; Level C skips install and scaffold).
+
+### Phase 1 — Scaffold (Level A/B only)
+
+**Owner:** onboarding (direct).
+
+**Level A install scope:** install **only** missing packages from `@civitas-cerebrum/*` and Playwright:
+
+- `@civitas-cerebrum/element-interactions` if missing from `dependencies`.
+- `@civitas-cerebrum/element-repository` if missing.
+- `@playwright/test` if missing.
+- Run `npx playwright install chromium` (Chromium only; other browsers on request).
+
+Do **not** add, remove, or upgrade any other dependencies. Do **not** modify the user's `package.json` scripts beyond adding a `test:e2e` script if one doesn't already exist.
+
+**Scaffold files** (Level A and B, whichever are missing):
+
+- `playwright.config.ts` — minimal config with `baseURL` from the front-load gate, `testDir: './tests/e2e'`, `reporter: 'html'`, headless true.
+- `tests/fixtures/base.ts` — `baseFixture` export wiring `Steps` and `ContextStore`. Exact content: see `references/api-reference.md` from the `element-interactions` skill.
+- `page-repository.json` — `{}` at the repo root (or `tests/e2e/page-repository.json`; follow existing convention if partial scaffold exists).
+- `tests/e2e/` — directory created if missing.
+- `tests/e2e/docs/` — directory created if missing.
+
+**Commit:** `chore: scaffold element-interactions framework`.
+
+### Phase 2 — Groundwork discovery
+
+**Delegate to:** `journey-mapping` with `args: "phase-1-only"`.
+
+The companion writes `tests/e2e/docs/app-context.md` and a sentinel-bearing `tests/e2e/docs/journey-map.md` whose body contains only the site map (Phase-2–4 sections are empty headings).
+
+**Commit:** `docs: initial app-context and site map`.
+
+### Phase 3 — Happy path
+
+**Delegate to:** `element-interactions` with `args: "autonomousMode: true happyPathDescription: '<one-sentence description from the front-load gate>'"`.
+
+The companion runs Stages 1–4 inline with gates suspended, using the description + the site map from Phase 2 to pick the target flow. Any failure routes through `failure-diagnosis` automatically.
+
+**Commit:** `test: happy path — <scenario name>`. The orchestrator returns the scenario name in its summary; use that.
+
+### Phase 4 — Full journey mapping
+
+**Delegate to:** `journey-mapping` with `args: "phases-2-4"`.
+
+The companion reads the existing sentinel-bearing Phase-1 map and fills in Phases 2–4 (flow identification, prioritisation, journey map document). File is overwritten in place; sentinel preserved.
+
+**Commit:** `docs: journey map — <N> journeys prioritized`.
+
+### Phase 5 — Coverage expansion (five passes)
+
+Five sequential invocations of `test-composer`, one per pass. Between every invocation run the refresh step (below) so each pass plans against the most recent `app-context.md` and `journey-map.md`.
+
+| Pass | `args` |
+|---|---|
+| 1 | `passScope: priority=P0 depth=happy-path` |
+| 2 | `passScope: priority=P1 depth=happy-path,error-states` |
+| 3 | `passScope: priority=P2 depth=happy-path,error-states,edge-cases` |
+| 4 | `passScope: priority=P3 depth=happy-path,mobile` |
+| 5 | `passScope: priority=P3 depth=cross-feature,data-lifecycle` |
+
+(Pass 5 uses P3 as the priority to cast the widest net; the `depth` tokens direct the pass toward residual cross-cutting gaps. The skill's own gap analysis picks up anything not yet covered.)
+
+**Refresh step (run before every pass and after every pass):**
+
+```
+1. Read tests/e2e/docs/app-context.md (take a snapshot of the content).
+2. Read tests/e2e/docs/journey-map.md. Verify the sentinel on line 1.
+3. List all spec files under tests/e2e/ and group by journey.
+4. Compute coverage matrix: journey × step → covered / missing.
+5. Compute gap set: missing steps ordered by priority, then by depth token.
+6. Pass the matrix + gap set into the next test-composer invocation via args.
+7. After the pass returns:
+   a. Read the updated app-context.md and journey-map.md.
+   b. Diff against the pre-pass snapshot.
+   c. Append a "Pass <N> — new knowledge" section to onboarding-report.md
+      summarising what was added.
+```
+
+**Commit:** after each pass, `test: coverage pass <N/5> — <priority + depth summary>`.
+
+### Phase 6 — Bug hunts (two passes)
+
+Two sequential invocations of `bug-discovery`:
+
+| Pass | `args` |
+|---|---|
+| 1 | `phase: 1a-element-probing` |
+| 2 | `phase: 1b-flow-probing` |
+
+Findings go to `tests/e2e/docs/onboarding-report.md` under "App bugs logged". The companion must NOT commit skipped tests for the findings; it logs them and continues.
+
+**Commits:** `docs: bug-hunt 1/2 findings` and `docs: bug-hunt 2/2 findings`.
+
+### Phase 7 — Final summary
+
+1. Invoke `work-summary-deck` to produce `qa-summary-deck.html`.
+2. Finalise `tests/e2e/docs/onboarding-report.md` with the sections in the next heading.
+
+**Commit:** `docs: onboarding report and summary deck`.
+
+---
+
+## Onboarding report (`tests/e2e/docs/onboarding-report.md`)
+
+Accumulated throughout the run, committed at Phase 7. Structure:
+
+```markdown
+# Onboarding Report — <app name>
+
+**Date:** YYYY-MM-DD
+**Detected level:** A | B | C
+**Happy path:** <user-supplied sentence>
+**Runtime:** Xm Ys
+
+## Coverage
+| Priority | Journeys | Steps | Covered | % |
+| P0 | <n> | <n> | <n> | <n> |
+| P1 | <n> | <n> | <n> | <n> |
+| P2 | <n> | <n> | <n> | <n> |
+| P3 | <n> | <n> | <n> | <n> |
+
+## Skipped tests
+<list: test name + reason>
+
+## App bugs logged
+<list: short description + source phase>
+
+## Knowledge gained per pass
+Pass 1 — <3-line summary>
+Pass 2 — <3-line summary>
+Pass 3 — <3-line summary>
+Pass 4 — <3-line summary>
+Pass 5 — <3-line summary>
+
+## Next steps
+- Address app bugs listed above.
+- Rerun test-composer once blockers clear.
+```
+
+---
+
+## Failure handling
+
+Every failure — in any phase — routes through `failure-diagnosis`. Four classifications:
+
+| Classification | Action |
+|---|---|
+| Test issue | Fix autonomously, re-run. If still failing after 3 stabilization cycles, skip with a comment and log to the onboarding report. |
+| App bug | Skip the test with a comment referencing the report; append the bug to `onboarding-report.md` under "App bugs logged"; continue. |
+| Ambiguous | Skip + log + continue. |
+| MCP / infra error | Halt. Commit what is stable. Print a clear stop reason with the last progress line. |
+
+The only halt conditions are infra errors. The pipeline never halts on test or app failures.
+
+---
+
+## Re-invocation semantics
+
+Onboarding never auto-overwrites an already-onboarded project. If the cascade detector returns **None**, it prints the already-onboarded exit message and stops. To rebuild from scratch, the user deletes `tests/e2e/docs/journey-map.md` (breaking the sentinel check) and re-invokes.
+
+---
+
+## Non-goals
+
+This skill explicitly does not:
+
+- Configure CI/CD.
+- Set up test data fixtures beyond the scaffold file.
+- Invoke `agents-vs-agents` (AI guardrail testing is opt-in).
+- Publish to npm, push tags, or modify any git remote.
+- Touch dependencies outside `@civitas-cerebrum/*` and Playwright.
+
+If the user wants any of these, they ask for them separately after onboarding finishes.

--- a/skills/test-composer/SKILL.md
+++ b/skills/test-composer/SKILL.md
@@ -330,3 +330,42 @@ Do NOT dispatch multiple subagents that modify the same file (especially page-re
 **Over-mocking:** E2E tests should exercise the real application. Don't mock APIs, don't intercept network requests, don't stub components. If a feature needs external data, use `test.skip()` instead of faking it.
 
 **Giant spec files:** Keep spec files under 200 lines. Split by area, not by "I kept adding tests to the same file."
+
+---
+
+## Invocation options
+
+When invoked without arguments, test-composer runs its full iterative cycle against the entire app. When invoked with a `passScope` directive in `args`, it limits a single pass to the specified priority and depths.
+
+### passScope grammar
+
+The caller encodes a pass scope in `args` using this shape (literal string, one line):
+
+```
+passScope: priority=<P0|P1|P2|P3> depth=<csv of depth tokens>
+```
+
+Valid `depth` tokens:
+
+| Token | Meaning |
+|---|---|
+| `happy-path` | Full journey tests from entry to exit. |
+| `error-states` | Validation, network failure, session expiry, and negative flows. |
+| `edge-cases` | Boundary inputs, unusual timing, empty/overflow data. |
+| `mobile` | Mobile viewport + responsive checks. |
+| `cross-feature` | Two-tab/two-role interactions, filter-across-feature flows. |
+| `data-lifecycle` | Create/edit/delete across sessions, draft persistence, bulk ops. |
+
+Example: `args: "passScope: priority=P1 depth=happy-path,error-states"`.
+
+### Pass behaviour when passScope is present
+
+1. Inventory existing tests as usual.
+2. Restrict the coverage matrix (Step 1 of the cycle) to journeys whose priority matches `priority` plus any journeys of higher priority that still have uncovered steps of any listed `depth` token. Rationale: a P1 pass with `depth=error-states` should also backfill P0 error states if they are missing — this is what "depth accumulates" means.
+3. Run Steps 2–7 of the cycle against that restricted matrix only. Do not touch out-of-scope journeys.
+4. When the pass ends, emit a one-line summary of tests added per depth token plus any new entries written to `app-context.md` and `journey-map.md` (which the skill already updates).
+5. Commit as usual but use the caller-supplied commit suffix if present: `test: coverage pass <N/5> — <passScope summary>`.
+
+### Default (no passScope)
+
+Full iterative cycle across all journeys, unchanged from the existing behaviour.


### PR DESCRIPTION
## Summary
- New `onboarding` companion skill that auto-detects whether a project has the element-interactions framework set up and, if not, runs the full pipeline autonomously after a single front-load confirmation.
- Cascade detection: Level A (missing dep) / B (missing scaffold) / C (missing journey-map sentinel) / None (already onboarded).
- Install scope restricted to `@civitas-cerebrum/*` + Playwright — unrelated dependencies never touched.
- Progress printed per milestone; no further prompts after the gate.
- All delegable work delegated: `journey-mapping`, `element-interactions`, `test-composer`, `bug-discovery`, `failure-diagnosis`, `work-summary-deck`. Onboarding owns detection, scaffolding, the refresh loop, and the onboarding report.
- Companion skill contracts extended with additive invocation options: `journey-mapping phases`, `element-interactions autonomousMode`, `test-composer passScope`, `bug-discovery phase`.

## Test plan
- [ ] On an empty directory, invoke the skill and confirm Level A pipeline runs end-to-end.
- [ ] On a directory with the dep but missing `page-repository.json`, confirm Level B path.
- [ ] On a directory with a non-sentinel `journey-map.md`, confirm Level C path.
- [ ] On a fully onboarded repo, confirm the already-onboarded exit message.
- [ ] Confirm progress lines are emitted at every documented milestone.

Spec (local, not tracked): `docs/superpowers/specs/2026-04-22-onboarding-skill-design.md`.
Plan (local, not tracked): `docs/superpowers/plans/2026-04-22-onboarding-skill.md`.

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>