### PR TITLE
fix(jsdoc): stop verifyText from appearing deprecated in IDEs

### DIFF
--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -685,8 +685,9 @@ export class Steps {
      * @param elementName - The element name as defined under the given page.
      * @param pageName - The page name as defined in `page-repository.json`.
      * @param expectedText - The exact text to match against. Omit to assert "not empty".
-     * @param verifyOptions - Optional verification options.
-     *   @deprecated Passing `{ notEmpty: true }` is redundant — omit `expectedText` instead.
+     * @param verifyOptions - Optional verification options. Passing `{ notEmpty: true }`
+     *   is redundant — omit `expectedText` to get the same behavior. The `notEmpty`
+     *   flag on `TextVerifyOptions` is itself deprecated.
      * @param options - Optional step options for element resolution.
      */
     async verifyText(elementName: string, pageName: string, expectedText?: string, verifyOptions?: TextVerifyOptions, options?: StepOptions): Promise<void> {

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -289,8 +289,9 @@ export class ElementAction {
      * Assert the element's text content. Call with no argument to assert "not empty".
      *
      * @param expected - Expected exact text. Omit to assert the element has any non-empty text.
-     * @param options - Optional verification options.
-     *   @deprecated Passing `{ notEmpty: true }` is redundant — omit `expected` instead.
+     * @param options - Optional verification options. Passing `{ notEmpty: true }`
+     *   is redundant — omit `expected` to get the same behavior. The `notEmpty`
+     *   flag on `TextVerifyOptions` is itself deprecated.
      */
     async verifyText(expected?: string, options?: TextVerifyOptions): Promise<void> {
         if (options?.notEmpty !== undefined) {


### PR DESCRIPTION
## Summary
- `@deprecated` was sitting inside `@param` blocks on `verifyText()` in both `CommonSteps.ts` and `ElementAction.ts`. JSDoc has no parameter-scoped `@deprecated`, so the tag leaked up to the method — VS Code and TS LSP rendered every `steps.verifyText(...)` call with strikethrough, making the whole API look deprecated.
- Rewrote the parameter descriptions as plain prose. Runtime warnings and the property-level `@deprecated` on `TextVerifyOptions.notEmpty` are untouched, so IDE hover now strikes through the actual deprecated surface (the `notEmpty` option) rather than the method.

## Test plan
- [ ] `npx tsc --noEmit` clean
- [ ] In VS Code, hover `steps.verifyText(...)` — no strikethrough on the method
- [ ] Hover `{ notEmpty: true }` — strikethrough on the option, as before
- [ ] CI green

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>