### PR TITLE
feat: add HTTP API steps + contract-testing companion skill

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,33 @@ services:
       - "7457:8080"
     networks:
       - vue-network
+
+  bookhive-mongodb:
+    image: mongo:7
+    restart: always
+    networks:
+      - bookhive-network
+    volumes:
+      - bookhive-mongo-data:/data/db
+
+  bookhive-backend:
+    image: umutayb/book-hive-backend:latest
+    restart: always
+    ports:
+      - "8080:8080"
+    depends_on:
+      - bookhive-mongodb
+    environment:
+      SPRING_DATA_MONGODB_URI: mongodb://bookhive-mongodb:27017/bookhive
+      JWT_SECRET: element-interactions-test-secret-key-at-least-sixty-four-bytes-long
+    networks:
+      - bookhive-network
+
 networks:
   vue-network:
     driver: bridge
+  bookhive-network:
+    driver: bridge
+
+volumes:
+  bookhive-mongo-data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@civitas-cerebrum/context-store": "^0.0.2",
         "@civitas-cerebrum/element-repository": "^0.1.8",
         "@civitas-cerebrum/email-client": "^0.0.7",
+        "@civitas-cerebrum/wasapi": "^0.0.3",
         "debug": "^4.4.3",
         "dotenv": "^17.3.1"
       },
@@ -70,6 +71,30 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@civitas-cerebrum/test-coverage/-/test-coverage-0.1.0.tgz",
       "integrity": "sha512-6qPGRRFuF3JkGH2UMgnRNV5lh8F77+bSJgROAqYzFmq1Gq97DzlpjCt6ExUNzq8JUXh9uxA8w28rdQVGyq0K2w==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.4.5",
+        "typescript": "^5.0.0"
+      },
+      "bin": {
+        "test-coverage": "dist/cli.js"
+      }
+    },
+    "node_modules/@civitas-cerebrum/wasapi": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/wasapi/-/wasapi-0.0.3.tgz",
+      "integrity": "sha512-bYLpUNCVgGKlU92ZkRgPKt9nIqAWHeB0obyBoIPMD/r/6F+7iDGM5okr3iyoGN5/O890lQsRJ8n2u4GLCQhTLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@civitas-cerebrum/context-store": "^0.0.2",
+        "@civitas-cerebrum/test-coverage": "^0.0.9",
+        "debug": "^4.4.3"
+      }
+    },
+    "node_modules/@civitas-cerebrum/wasapi/node_modules/@civitas-cerebrum/test-coverage": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/test-coverage/-/test-coverage-0.0.9.tgz",
+      "integrity": "sha512-+fnvV+dD2SnxbYAjlN9sI3oyh/VIzgW/T8Y6i7Y+Vttyw9DdJ3wesN+bWkxVGF8F1GAf4LKg1BRGlw5vjy5agQ==",
       "license": "MIT",
       "dependencies": {
         "glob": "^10.4.5",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@civitas-cerebrum/context-store": "^0.0.2",
     "@civitas-cerebrum/element-repository": "^0.1.8",
     "@civitas-cerebrum/email-client": "^0.0.7",
+    "@civitas-cerebrum/wasapi": "^0.0.3",
     "debug": "^4.4.3",
     "dotenv": "^17.3.1"
   }

--- a/skills/contract-testing/SKILL.md
+++ b/skills/contract-testing/SKILL.md
@@ -1,0 +1,433 @@
+---
+name: contract-testing
+description: >
+  Use when the user asks to write, run, or review contract tests for a backend API — locking
+  status codes, headers, response schema, or error shape on HTTP endpoints rather than UI or
+  business flow. Triggers: "contract test", "contract testing", "API contract", "schema test",
+  "schema validation", "consumer-driven contract", "provider verification", "pact test",
+  "breaking change detection", "API compatibility", "spec conformance", "OpenAPI conformance",
+  "verify API shape", "lock API contract", "ensure API hasn't changed". Also activates when
+  the agent is about to write an API-only test with `steps.apiGet/Post/Put/Delete/Patch` that
+  asserts response shape or status. Not for: end-to-end UI flows, coverage expansion, bug
+  hunting, or failing-test diagnosis.
+---
+
+# Contract Testing — API Surface Verification
+
+A structured protocol for writing **contract-style** tests against HTTP backends using the Steps API (`steps.apiGet/Post/Put/Delete/Patch/Head` + `verifyApiStatus`/`verifyApiHeader`). These tests lock the *contract* between a client and a service — status codes, headers, response schema, error shape — without testing business logic or UI.
+
+## Scope & Boundaries — Read Before Starting
+
+**What this skill IS for:**
+- Asserting an endpoint returns the expected status for documented inputs
+- Asserting response bodies match an expected shape (field names, types, required/optional fields)
+- Asserting error responses follow the agreed error contract (status + body shape)
+- Asserting critical headers (`content-type`, auth echoes, versioning, CORS)
+- Detecting **breaking changes** to the API surface before they reach the UI
+
+**What this skill is NOT for:**
+- **End-to-end UI flows** → use `element-interactions` / `test-composer`
+- **Deep business logic validation** of internal services → belongs in the service's own test suite
+- **True consumer-driven contract testing with brokers** (Pact, Spring Cloud Contract) → this framework doesn't produce/consume pact files. These tests are *contract-style integration tests*, not CDC-with-a-broker. Be honest with the user about this distinction if they ask.
+- **Load / performance** testing → wrong tool
+- **Security testing** → out of scope
+
+If the user wants a true Pact broker workflow, tell them upfront: *"This framework gives you contract-style assertions over a live endpoint. It doesn't generate or verify pact files against a broker. If you need that, you need Pact. Want to proceed with contract-style tests anyway?"*
+
+---
+
+## Prerequisites
+
+Before starting, verify ALL of these. If any are missing, stop and ask the user.
+
+- Target backend(s) have a reachable URL — staging, sandbox, or local. **Never production without explicit ack.**
+- Authentication mechanism is known (none / Bearer / Basic / API key / cookie) AND credentials live in env vars, not source.
+- A source of truth for the contract exists — OpenAPI spec, Postman collection, README, or a backend engineer available to confirm shape. Without one, Phase 2 becomes discovery-style and must be confirmed with the user obligation-by-obligation.
+- `@civitas-cerebrum/element-interactions` is the project's test framework (check `package.json`).
+- `baseFixture` is already wired in `tests/fixtures/base.ts`. If not, Phase 3 covers setup.
+- **If `@civitas-cerebrum/element-interactions` is installed via `file:` / `npm link` (local framework development), verify Playwright is not installed twice.** Node's resolver can load `@playwright/test` both from the consuming project and from the linked framework's own `node_modules`, which trips Playwright's singleton guard ("Requiring @playwright/test second time") and produces `No tests found`. Fix: either delete the framework's nested `node_modules/@playwright*` + `node_modules/playwright*`, or add `NODE_OPTIONS=--preserve-symlinks` to your test script.
+
+If the endpoint is unreachable, stop and tell the user: *"Contract tests must hit a real endpoint. I can't mock this. Please point me at a staging / sandbox / local URL."*
+
+---
+
+## 🚨 Absolute Rules
+
+1. **Always read `../element-interactions/references/api-reference.md` → "HTTP API Steps" first.** Do not invent API step signatures. Do not write `steps.apiX` calls from memory. Do NOT reach for Playwright's raw `request.newContext` / `page.request` instead — you lose multi-provider routing, auth header layering, the `tester:api` log channel, and consistency with the rest of the Steps API. If you're tempted because "it's simpler," that's the loophole; close it.
+2. **Never hardcode a base URL — and that includes env-var fallbacks.** Base URLs live on `baseFixture` options (`apiBaseUrl` / `apiProviders`), which read env vars at fixture-construction time. Writing `process.env.X ?? 'http://localhost:8080'` inside a test file is a Rule 2 violation in disguise: the fallback ships the hardcoded URL into the repo and survives missing config. Tests address paths (`/users/42`), never origins.
+3. **One contract obligation per test.** A test asserts either status, or schema, or a header contract — not a mixed bag. Red flag: a single test that checks status AND envelope fields AND `totalElements === 50` AND item shape is four obligations fused. Split it. Fused tests hide which obligation broke.
+4. **Assert shape, not values — and seeded data is still data.** Contract tests check `id: expect.any(Number)`, `title: expect.any(String)`. They do NOT check `title === 'To Kill a Mockingbird'` or `totalElements === 50` just because the seed makes it true today. The moment the seed changes — or the fixture runs against a different environment — the "contract" test fails for a data reason, not a contract reason. Values are data; shape is contract. If you find yourself writing a string literal on the right of `toBe`, stop.
+5. **Never mock the endpoint under test.** Contract tests need to hit a real (staging/sandbox) service. If no real endpoint is reachable, stop and tell the user.
+6. **Credentials come from env vars.** Never commit tokens, passwords, or API keys into test code.
+7. **Type the response.** Always use `steps.apiGet<T>(...)` with an explicit `T` — an untyped contract test is an oxymoron. Note: `await res.json()` on a raw Playwright response returns `Promise<any>`; TypeScript cannot infer the shape. Either use `steps.apiGet<T>` (typed) or declare an interface and cast at the boundary. Inline `(b: { id: string }) => ...` casts on `.map` don't fix the root.
+8. **Deliberate-failure check is mandatory before declaring Phase 6 complete.** All green on first run proves nothing — you may have built a vacuous assertion. You MUST mutate one schema field name or status expectation, confirm the test fails with a useful error, then revert. If you skip this, you don't know whether your tests bite. See Phase 6.
+9. **Only test documented behavior.** If a query param isn't in the OpenAPI/README/spec, don't assert on it — even if it "seems to work". Undocumented endpoints that coincidentally pass give false confidence, and the moment the backend cleans up the coincidence your contract test breaks on non-contractual behavior. If the user wants it locked, get it documented first.
+
+---
+
+## Workflow
+
+```dot
+digraph contract_testing {
+    "User asks for contract tests" [shape=doublecircle];
+    "Read api-reference.md HTTP section" [shape=box];
+    "Identify target API" [shape=box];
+    "Reachable endpoint?" [shape=diamond];
+    "Ask user for staging URL / token" [shape=box];
+    "Phase 1: Intake" [shape=box];
+    "Phase 2: Contract Inventory" [shape=box];
+    "Phase 3: Fixture Setup" [shape=box];
+    "Phase 4: Test Design" [shape=box];
+    "Phase 5: Implementation" [shape=box];
+    "Phase 6: Run & Verify" [shape=box];
+    "Phase 7: Report" [shape=doublecircle];
+
+    "User asks for contract tests" -> "Read api-reference.md HTTP section";
+    "Read api-reference.md HTTP section" -> "Identify target API";
+    "Identify target API" -> "Reachable endpoint?";
+    "Reachable endpoint?" -> "Ask user for staging URL / token" [label="no"];
+    "Reachable endpoint?" -> "Phase 1: Intake" [label="yes"];
+    "Ask user for staging URL / token" -> "Phase 1: Intake";
+    "Phase 1: Intake" -> "Phase 2: Contract Inventory" [label="intake confirmed"];
+    "Phase 2: Contract Inventory" -> "Phase 3: Fixture Setup" [label="inventory approved by user"];
+    "Phase 3: Fixture Setup" -> "Phase 4: Test Design" [label="fixture wired"];
+    "Phase 4: Test Design" -> "Phase 5: Implementation" [label="design approved"];
+    "Phase 5: Implementation" -> "Phase 6: Run & Verify";
+    "Phase 6: Run & Verify" -> "Phase 7: Report" [label="green + deliberate-failure check"];
+}
+```
+
+---
+
+### Phase 1 — Intake
+
+Before writing any code, establish these facts. If any are unknown, ask the user:
+
+1. **Target API(s).** One backend or several? Collect a name and base URL for each. Multi-backend is first-class — each becomes an entry in `apiProviders`.
+2. **Authentication.** None? Bearer token? Basic? API key header? Cookie? Where do credentials come from (env vars, login call, fixture)?
+3. **Environment.** Staging, sandbox, local dev? Never run contract tests against production unless the user explicitly confirms — contract tests are safe (read-only / tested data), but a `POST /users` loop against prod is not.
+4. **Source of truth.** OpenAPI spec? README? A Postman collection? Someone's head? Get the user to point at the document that defines the contract — every assertion must trace back to it.
+5. **Scope.** All endpoints? A subset? A single endpoint? Default to the endpoints the user names; do not expand scope without asking.
+
+Record the intake in a short checklist and confirm with the user before moving on.
+
+---
+
+### Phase 2 — Contract Inventory
+
+For each endpoint in scope, enumerate the contract obligations the test suite will lock in. A minimal inventory entry looks like:
+
+```
+GET /users/:id
+  Happy path:
+    - 200 on valid id
+    - content-type: application/json
+    - body: { id: number, name: string, email: string, createdAt: string (ISO) }
+  Error contract:
+    - 404 on unknown id, body: { error: string, code: string }
+    - 401 when token missing, body: { error: string }
+    - 400 on malformed id, body: { error: string }
+```
+
+Group obligations by endpoint. Do NOT combine endpoints. Do NOT pre-write tests — this is a checklist that gates Phase 5.
+
+If the user has an OpenAPI spec, derive the inventory from it. If not, probe the live endpoint(s) for actual responses and confirm each obligation with the user before testing it — you are **discovering** the contract, not inventing one.
+
+**Implied-but-not-enumerated shape.** Specs often say "returns a paginated list" without enumerating the envelope fields, or document field `foo` without mentioning that the response is actually `{ data: foo }`. Lock only what the spec explicitly names. For the surrounding shape:
+
+- Note the gap in the inventory entry (e.g., *"Spring Page envelope fields (`pageable`, `totalElements`, etc.) are not enumerated in the README — leaving unlocked"*).
+- Carry the gap forward to the Phase 7 report so the user can decide whether to ask the backend team to document it.
+- Do NOT lock fields the spec doesn't name, even if they appear in every live response. They may be framework defaults the backend team considers internal, and locking them freezes implementation detail as contract.
+
+---
+
+### Phase 3 — Fixture Setup
+
+Add / extend `baseFixture` to wire the API client(s). All API fixture params are optional — only add what's needed.
+
+```ts
+// tests/fixtures/base.ts
+import { test as base, expect } from '@playwright/test';
+import { baseFixture } from '@civitas-cerebrum/element-interactions';
+
+export const test = baseFixture(base, 'tests/data/page-repository.json', {
+  apiBaseUrl: process.env.API_BASE_URL,        // default provider
+  apiProviders: {                               // optional — only if multi-backend
+    billing: process.env.BILLING_BASE_URL!,
+    auth:    process.env.AUTH_BASE_URL!,
+  },
+});
+export { expect };
+```
+
+- If tests need auth, fold token acquisition into a custom fixture (extend `baseFixture`'s return) or a `beforeAll` that calls `apiPost('auth', '/login', …)` and stores the token in `contextStore` / a closure. Inject it via `headers: { Authorization: 'Bearer …' }` on every request.
+- If the target has no public sandbox, tell the user upfront — the test suite will need `API_BASE_URL` pointed at a reachable instance.
+
+---
+
+### Phase 4 — Test Design
+
+For each inventory entry, design tests following these rules:
+
+**One obligation per test:**
+
+```ts
+test.describe('GET /users/:id', () => {
+  test('returns 200 for a valid id', async ({ steps }) => { /* ... */ });
+  test('returns JSON content-type', async ({ steps }) => { /* ... */ });
+  test('body matches User schema', async ({ steps }) => { /* ... */ });
+  test('returns 404 for unknown id', async ({ steps }) => { /* ... */ });
+  test('error body matches ErrorResponse schema', async ({ steps }) => { /* ... */ });
+});
+```
+
+**Assert shape, not data.** Use `expect.any(...)`, `expect.stringMatching(...)`, `expect.arrayContaining([expect.objectContaining(...)])`. A contract test that asserts `id === 42` breaks the moment the fixture's id changes, which is useless churn. A contract test that asserts `typeof id === 'number'` breaks only when the contract actually breaks.
+
+**Factor schema shapes into a shared file.** Keep them reusable and single-sourced:
+
+```ts
+// tests/contracts/schemas.ts
+import { expect } from '@playwright/test';
+
+export const UserSchema = {
+  id:        expect.any(Number),
+  name:      expect.any(String),
+  email:     expect.stringMatching(/^[^@]+@[^@]+$/),
+  createdAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+};
+
+export const ErrorSchema = {
+  error: expect.any(String),
+  code:  expect.any(String),
+};
+```
+
+**File layout.** Put contract tests under `tests/contracts/` — one file per endpoint or one file per resource.
+
+```
+tests/
+  contracts/
+    schemas.ts
+    users.spec.ts
+    invoices.spec.ts
+```
+
+**Playwright config for contract tests.** If the existing `playwright.config.ts`'s `testDir` doesn't include `tests/contracts/`, **do NOT widen the shared `testDir`** — that couples UI and API runs (parallelism, retries, reporter, `use.baseURL` all collide). Create a dedicated config instead:
+
+```ts
+// playwright.contracts.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/contracts',
+  timeout: 15_000,
+  retries: 0,                    // contract tests are deterministic — no retries
+  reporter: [['list'], ['html', { outputFolder: 'playwright-report-contracts' }]],
+  fullyParallel: true,
+});
+```
+
+Run with `npx playwright test --config=playwright.contracts.config.ts`. Add an npm script (`test:contracts`) for convenience. Never run contract tests inside the UI suite's config — they have different timing, retry, and parallelism characteristics.
+
+---
+
+### Phase 5 — Implementation
+
+Canonical patterns — copy, do not improvise. Every pattern below already appears in `api-reference.md` → "HTTP API Steps"; read that first if anything looks unfamiliar.
+
+**5a. Status check (happy path):**
+
+```ts
+test('GET /users/:id returns 200 for a valid id', async ({ steps }) => {
+  const res = await steps.apiGet<unknown>('/users/42');
+  await steps.verifyApiStatus(res, 200);
+});
+```
+
+**5b. Header contract:**
+
+```ts
+test('GET /users/:id returns JSON content-type', async ({ steps }) => {
+  const res = await steps.apiGet<unknown>('/users/42');
+  await steps.verifyApiHeader(res, 'content-type', 'application/json; charset=utf-8');
+});
+```
+
+**5c. Schema shape:**
+
+```ts
+import { UserSchema } from './schemas';
+
+test('GET /users/:id body matches User schema', async ({ steps }) => {
+  const res = await steps.apiGet<Record<string, unknown>>('/users/42');
+  await steps.verifyApiStatus(res, 200);
+  expect(res.body).toMatchObject(UserSchema);
+});
+```
+
+**5d. Error contract:**
+
+```ts
+import { ErrorSchema } from './schemas';
+
+test('GET /users/:id returns 404 for unknown id', async ({ steps }) => {
+  const res = await steps.apiGet<Record<string, unknown>>('/users/999999999');
+  await steps.verifyApiStatus(res, 404);
+  expect(res.body).toMatchObject(ErrorSchema);
+});
+```
+
+**5e. Auth contract:**
+
+```ts
+test('GET /users/:id returns 401 when token is missing', async ({ steps }) => {
+  const res = await steps.apiGet<unknown>('/users/42', { headers: { Authorization: '' } });
+  await steps.verifyApiStatus(res, 401);
+});
+```
+
+**5f. Write contract (POST shape):**
+
+```ts
+test('POST /users accepts valid payload and echoes it', async ({ steps }) => {
+  const payload = { name: 'Ada Lovelace', email: 'ada@example.com' };
+  const res = await steps.apiPost<Record<string, unknown>>('/users', payload);
+  await steps.verifyApiStatus(res, 201);
+  expect(res.body).toMatchObject({ id: expect.any(Number), ...payload });
+});
+```
+
+**5g. Multi-backend cross-check — single test, two providers:**
+
+```ts
+test('billing invoice references a real auth user', async ({ steps }) => {
+  const invoice = await steps.apiGet<{ userId: number }>('billing', '/invoices/1');
+  await steps.verifyApiStatus(invoice, 200);
+
+  const user = await steps.apiGet<unknown>('auth', `/users/${invoice.body.userId}`);
+  await steps.verifyApiStatus(user, 200);
+});
+```
+
+**5h. Unknown shape — discover first, then lock:**
+
+If no OpenAPI exists, run the endpoint once, log `res.body`, design the schema with the user, commit the schema. Don't assert against a shape you haven't confirmed with the user.
+
+**5i. List-shape — array of typed objects:**
+
+```ts
+// Envelope shape: content is an array of Book-like objects
+test('body carries a content array of Book objects', async ({ steps }) => {
+  const res = await steps.apiGet<BooksListResponse>('/books');
+  expect(res.body).toMatchObject({
+    content: expect.arrayContaining([expect.objectContaining(BookSchema)]),
+  });
+});
+
+// Per-item shape: every item conforms. Prefer a loop — arrayContaining only
+// checks that AT LEAST ONE item matches, which hides rogue elements.
+test('each item in content matches the Book schema', async ({ steps }) => {
+  const res = await steps.apiGet<BooksListResponse>('/books');
+  for (const item of res.body.content) {
+    expect(item).toMatchObject(BookSchema);
+  }
+});
+```
+
+Do NOT assert `expect(res.body.content).toHaveLength(50)` — that's a value assertion on seed size, not a contract. If the spec says "at least one", assert `toBeGreaterThan(0)`. If the spec gives bounds, assert bounds (`toBeGreaterThanOrEqual` / `toBeLessThanOrEqual`). Never lock exact counts.
+
+---
+
+### Phase 6 — Run & Verify
+
+1. **Run the suite.** `npx playwright test --config=playwright.contracts.config.ts` (or `tests/contracts/` against the shared config if the project is single-mode). Every test should pass on first run against a known-good environment. If they don't, it means either (a) the contract was misread in Phase 2, or (b) the service is already breaking its contract — both are interesting findings, neither is a "flaky test."
+2. **Deliberate-failure check — HARD GATE.** Before advancing to Phase 7, you MUST prove the tests actually bite:
+   - Pick one mutation. Either one field in one test (change `id: expect.any(Number)` → `id: expect.any(String)`), OR one shared schema field (change `BookSchema.price: Number` → `String` — expect this to cascade to every test using `BookSchema`, which is correct and healthy), OR one status expectation (`200` → `201`).
+   - Run the suite. Confirm that every test that depends on the mutated field fails, with useful error messages (diffs showing the expected-vs-actual type). Tests that don't touch the mutated field should stay green — that's the signal that your obligations are properly split per Rule 3.
+   - Revert the mutation. Run again. Confirm all green.
+   - Document in the Phase 7 report: *"Deliberate-failure check: mutated [field] → [N] tests failed as expected with [error summary]; unaffected tests stayed green; mutation reverted and full suite re-ran green."*
+   - Why this is a hard gate: a green-on-first-run suite with no bite-check is indistinguishable from an empty suite. Skipping this step invalidates Phase 7.
+3. **Fail-loudly on shape drift.** If a real test fails with "expected `name` to be a String, got undefined," the contract has drifted. Escalate to the user — do NOT "fix" the test by loosening the assertion. Contract tests break on purpose.
+4. **No retries.** Contract tests must not be marked `test.retry()` / `retries: 3`. They are deterministic. If they flake, the endpoint is flaky, which is itself a contract violation.
+
+If a test fails unexpectedly, escalate to the `failure-diagnosis` skill — do NOT silently adjust the schema.
+
+---
+
+### Phase 7 — Report
+
+Produce a short summary for the user:
+
+- Endpoints covered: `GET /users/:id`, `POST /users`, `GET /invoices/:id` (billing provider), …
+- Obligations asserted per endpoint: status, content-type, happy-shape, error-shape, auth-shape
+- Environment: staging (`https://staging-api.example.com`)
+- **Deliberate-failure check:** which test was mutated, what the failure message was, confirmation that it was reverted. (No report ships without this line — see Phase 6 Step 2.)
+- Any contract gaps found during Phase 2 that the user needs to decide on (undocumented fields, undocumented error shapes, status mismatches)
+- Any undocumented behavior you declined to test, with justification (per Rule 9)
+
+If any shape was discovered rather than derived from a spec, flag it: *"This schema was reverse-engineered from live responses — please confirm with the backend team before treating it as authoritative."*
+
+---
+
+## Integration with Other Skills
+
+| Skill | When it applies |
+|---|---|
+| `element-interactions` | Parent orchestrator. Routes to this skill per its companion-skills table when contract-testing intent is detected. |
+| `failure-diagnosis` | Invoke on an unexpected contract-test failure. Do NOT "fix" by loosening the schema — use `failure-diagnosis` to determine test issue vs. real contract drift (app bug). |
+| `test-composer` | Adjacent for UI+API hybrid journeys. If the journey under composition touches an endpoint already locked here, reuse the schema from `tests/contracts/schemas.ts`. |
+| `test-repair` | Auto-escalates here if contract tests rot in batch (e.g., backend bumped and multiple schemas drifted simultaneously). |
+| `journey-mapping` | Read the journey map to discover which endpoints the UI touches — prioritize those for contract coverage. |
+| `bug-discovery` | Unrelated. Bug-discovery targets UI adversarial probing, not API surface. |
+
+## Invocation Options
+
+Orchestrators and users can invoke this skill with optional arguments. Unspecified arguments are resolved in Phase 1 Intake with the user.
+
+- `endpoints` — comma-separated list of endpoints in scope (e.g., `GET /users/:id, POST /users`). Default: whatever the user names during intake.
+- `provider` — which configured API provider to target (matches an `apiProviders` key, or `default` for `apiBaseUrl`). Default: `default`.
+- `mode` — `full` (status + header + schema + error + auth obligations) or `shape-only` (status + schema only). Default: `full`.
+- `environment` — `staging` | `sandbox` | `local` | `production`. Production requires explicit user confirmation for every run. Default: `staging`.
+
+---
+
+## Red Flags — Stop and Ask
+
+| Signal | What to do |
+|---|---|
+| User wants pact files / broker workflow | Clarify: this framework does contract-style tests, not broker-based CDC. Offer to proceed in contract-style mode or recommend Pact. |
+| No reachable endpoint (no staging, no sandbox, no local dev) | Stop. Ask for an environment. Do not mock. |
+| User (or *you*) about to assert specific values (`id === 42`, `title === 'To Kill a Mockingbird'`, `totalElements === 50`) | Stop. Contract tests assert shape. Replace with `expect.any(Number)` / `expect.any(String)` / `toBeGreaterThan(0)`. Seeded values are still values. |
+| Tempted to use `request.newContext` or `page.request` directly | Stop. Use `steps.apiGet/Post/...`. You'll regret the reimplementation when you need a second provider or auth layering. |
+| Writing `process.env.X ?? 'http://localhost:...'` inside a test file | That's a hardcoded base URL. Move it to `baseFixture` options; let the fixture handle env resolution. |
+| `const body = await res.json()` with no type | You just got `any`. Either switch to `steps.apiGet<T>`, or declare an interface and cast at the boundary. |
+| Planning to widen the shared `testDir` / modify the UI `playwright.config.ts` to pick up contract tests | Stop. Create a separate `playwright.contracts.config.ts` pointed at `tests/contracts/`. Mixing UI and API tests in one config breaks parallelism, retries, and reporter semantics. |
+| Bundling status + envelope + schema + count checks into one test | Split. One obligation per test. A fused test hides which obligation broke. |
+| Phase 6 green on first run, about to move to Phase 7 | Stop. Run the deliberate-failure check first (mutate one schema field, confirm bite, revert). Green-on-first-run proves nothing. |
+| Failing test "fix" would loosen the schema | Stop. The contract is drifting. Escalate to user. |
+| Request to test production | Confirm explicitly. Prefer read-only endpoints. Never run write operations against prod without an explicit ack. |
+| Credentials in request body / code | Move to env vars. |
+| Endpoint returns HTML, not JSON | This isn't a JSON contract test. Either the endpoint is wrong, or you're testing the wrong thing — ask. |
+| About to assert on a query param / field not in the spec | Stop. Undocumented behavior isn't contract. Either get it documented first, or don't assert on it. |
+| About to assert `toHaveLength(N)` on a list response | Stop. Exact counts are values, not contracts. Use `toBeGreaterThan(0)` or spec-stated bounds. |
+| Using `arrayContaining([...])` to assert "all items match" | That only proves *at least one* item matches, which masks rogue elements. Loop over items and `toMatchObject` each. |
+| Spec says "paginated" / "returns a list" but doesn't name envelope fields | Lock only what's named. Note the gap in the Phase 7 report. Don't freeze framework-default fields as contract. |
+
+---
+
+## Quick Reference — Steps API for Contract Testing
+
+| Step | Use for |
+|---|---|
+| `apiGet<T>(path, { query, headers })` | Read endpoints |
+| `apiGet<T>(provider, path, { query, headers })` | Read on named provider |
+| `apiPost<T>(path, body, { pathParams, query, headers })` | Create endpoints |
+| `apiPut<T>(path, body, { pathParams, headers })` | Full update |
+| `apiPatch<T>(path, body, { pathParams, headers })` | Partial update |
+| `apiDelete<T>(path, { pathParams, headers })` | Delete endpoints |
+| `apiHead(path)` → `Record<string, string>` | Header-only probes |
+| `verifyApiStatus(res, expectedStatus)` | Status-code contract |
+| `verifyApiHeader(res, name, expectedValue?)` | Header presence / value (case-insensitive name) |
+| `expect(res.body).toMatchObject(schema)` | Shape / schema contract |
+
+Full signatures in `../element-interactions/references/api-reference.md` → "HTTP API Steps". Read it before writing code.

--- a/skills/element-interactions/SKILL.md
+++ b/skills/element-interactions/SKILL.md
@@ -33,6 +33,7 @@ This skill is the orchestrator for a group of testing skills. It handles Stages 
 | `bug-discovery` | Automatically after Stage 5 achieves 100% coverage | Adversarial bug hunting after tests pass |
 | `test-repair` | User reports a broken/rotted/flaky suite, OR auto-escalated from `failure-diagnosis` / `test-composer` / `bug-discovery` when a run produces many failures at once | Batch repair pipeline: baseline 3× → pattern cluster → adaptive verification → delegate per cluster to `failure-diagnosis` → post-heal verification → summary |
 | `agents-vs-agents` | App has AI features, or user mentions AI guardrails/red-teaming/bias testing | Adversarial AI testing with LLM-powered attacker + judge |
+| `contract-testing` | User mentions contract tests, API contract, schema test, pact, breaking-change detection, or spec conformance — OR before writing any pure-API test that asserts response shape/status | Structured contract-style verification against real endpoints (status / headers / schema / error shape) using `steps.apiGet/Post/Put/Delete/Patch` |
 
 When any of these conditions are met, invoke the Skill tool with the companion skill name. Do not try to handle their workflows inline — they have their own staged processes.
 

--- a/skills/element-interactions/references/api-reference.md
+++ b/skills/element-interactions/references/api-reference.md
@@ -10,6 +10,7 @@ The following sections document the full API available for writing tests in Stag
 - [Accessing the Repository Directly](#accessing-the-repository-directly)
 - [Raw Interactions API](#raw-interactions-api)
 - [Email API](#email-api) (setup, sending, receiving, marking, cleaning)
+- [HTTP API Steps](#http-api-steps) (fixture setup, default & named providers, methods, verifications)
 
 ---
 
@@ -691,3 +692,85 @@ await steps.cleanEmails(); // delete all
 ```
 
 Filter types: `SUBJECT`, `FROM`, `TO`, `CONTENT` (body text/HTML), `SINCE` (Date).
+
+## HTTP API Steps
+
+Direct HTTP calls against one or more backends, co-located with UI tests. Powered by `@civitas-cerebrum/wasapi` — no Playwright `request` fixture required. Use these for contract testing, cross-service setup/teardown, or hybrid UI+API scenarios.
+
+### Fixture Setup
+
+Both `apiBaseUrl` and `apiProviders` are optional. Configure either, both, or neither. Testing multiple backends in the same test is first-class:
+
+```ts
+export const test = baseFixture(base, 'tests/data/page-repository.json', {
+  apiBaseUrl: 'https://api.example.com',
+  apiProviders: {
+    billing: 'https://billing.example.com',
+    auth:    'https://auth.example.com',
+  },
+});
+```
+
+- `apiBaseUrl` registers the `default` client. Steps called without a provider name use it.
+- `apiProviders` registers additional named clients. The first argument of any `api*` step then becomes the provider name.
+- Calling an `api*` step with no configuration throws a clear "API client is not configured" error.
+
+### Methods
+
+Every method returns an `ApiResponse<T>` (except `apiHead`, which returns a flat `Record<string, string>` of headers).
+
+```ts
+// Default client
+const res = await steps.apiGet<User>('/users/42');
+const created = await steps.apiPost<User>('/users', { name: 'Ada' });
+const updated = await steps.apiPut<User>('/users/42', { name: 'Ada L.' });
+const patched = await steps.apiPatch<User>('/users/42', { active: true });
+await steps.apiDelete('/users/42');
+const headers = await steps.apiHead('/users/42');
+
+// Named provider (first arg)
+const invoices = await steps.apiGet<Invoice[]>('billing', '/invoices', { query: { status: 'open' } });
+await steps.apiPost('auth', '/login', { email, password });
+
+// Query params, path params, headers
+await steps.apiGet('/search', { query: { q: 'hello', page: '2' }, headers: { 'X-Trace': 'abc' } });
+await steps.apiPut('/users/:id', { active: false }, { pathParams: { id: '42' } });
+```
+
+### ApiResponse Shape
+
+```ts
+interface ApiResponse<T> {
+  status: number;
+  headers: Record<string, string>;
+  body: T;          // parsed JSON when content-type is JSON
+  rawBody: string;  // raw text always available
+  // ...
+}
+```
+
+Inspect `status`, `headers`, and `body` directly. Assertions have dedicated step helpers:
+
+### Verifications
+
+```ts
+await steps.verifyApiStatus(res, 200);
+await steps.verifyApiHeader(res, 'content-type');                        // presence
+await steps.verifyApiHeader(res, 'content-type', 'application/json');    // exact value (case-insensitive name)
+```
+
+For shape/schema verification, combine with Playwright's `expect` on the parsed `body`:
+
+```ts
+const res = await steps.apiGet<User>('/users/42');
+await steps.verifyApiStatus(res, 200);
+expect(res.body).toMatchObject({ id: expect.any(Number), name: expect.any(String) });
+```
+
+### When to Use
+
+- ✅ Contract-style tests (status codes, headers, schema shape on real endpoints) — see the `contract-testing` companion skill
+- ✅ Cross-service setup/teardown (seed data via API, drive UI through `steps`, tear down via API)
+- ✅ Mixed-protocol flows (create resource via API, verify rendering via UI)
+- ❌ Deep business-logic validation of internal services (keep those in the service's own test suite)
+- ❌ Load testing (wrong tool)

--- a/src/fixture/BaseFixture.ts
+++ b/src/fixture/BaseFixture.ts
@@ -47,6 +47,26 @@ export interface BaseFixtureOptions {
      * Default: `{ fullPage: true }`
      */
     screenshotOnFailure?: boolean | { fullPage?: boolean };
+    /**
+     * Base URL for the default API client. When set, `steps.apiGet/apiPost/...`
+     * can be called without a provider name and will dispatch against this URL.
+     *
+     * @example `apiBaseUrl: 'https://api.example.com'`
+     */
+    apiBaseUrl?: string;
+    /**
+     * Named API providers for multi-service testing. Each entry creates a
+     * separate `WasapiClient` accessible by name: `steps.apiGet('billing', '/users')`.
+     *
+     * @example
+     * ```ts
+     * apiProviders: {
+     *   billing: 'https://billing.example.com',
+     *   auth: 'https://auth.example.com',
+     * }
+     * ```
+     */
+    apiProviders?: Record<string, string>;
 }
 
 /**
@@ -77,7 +97,12 @@ export function baseFixture<T extends {}>(
             await use(new ElementRepository(page, locatorPath, options?.repoTimeout));
         },
         steps: async ({ repo }, use) => {
-            await use(new Steps(repo, { emailCredentials: options?.emailCredentials, timeout: options?.timeout }));
+            await use(new Steps(repo, {
+                emailCredentials: options?.emailCredentials,
+                timeout: options?.timeout,
+                apiBaseUrl: options?.apiBaseUrl,
+                apiProviders: options?.apiProviders,
+            }));
         },
         interactions: async ({ page }, use) => {
             await use(new ElementInteractions(page, { emailCredentials: options?.emailCredentials, timeout: options?.timeout }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,3 +51,8 @@ export type {
     EmailMarkOptions,
 } from '@civitas-cerebrum/email-client';
 export { EmailFilterType, EmailMarkAction } from '@civitas-cerebrum/email-client';
+
+// Re-exports from @civitas-cerebrum/wasapi
+export { WasapiClient, ApiCall, ApiResponse, ResponsePair, FailedCallException, WasapiException, HttpMethod } from '@civitas-cerebrum/wasapi';
+export type { RequestConfig, ClientConfig, CallOptions } from '@civitas-cerebrum/wasapi';
+export { GET, POST, PUT, DELETE, PATCH, HTTP } from '@civitas-cerebrum/wasapi';

--- a/src/logger/Logger.ts
+++ b/src/logger/Logger.ts
@@ -171,5 +171,6 @@ export const stepLog = {
   extract: logger('extract'),
   verify: logger('verify'),
   email: logger('email'),
+  api: logger('api'),
   wait: logger('wait'),
 };

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -3,6 +3,7 @@ import { ElementRepository, Element, WebElement, ElementResolutionOptions, Selec
 import { ElementInteractions } from '../interactions/facade/ElementInteractions';
 import { Utils } from '../utils/ElementUtilities';
 import { EmailClientConfig, EmailSendOptions, EmailReceiveOptions, ReceivedEmail, EmailMarkOptions, EmailMarkAction, EmailFilter } from '@civitas-cerebrum/email-client';
+import { WasapiClient, ApiResponse } from '@civitas-cerebrum/wasapi';
 import { StepOptions, DropdownSelectOptions, TextVerifyOptions, CountVerifyOptions, DragAndDropOptions, ListedElementOptions, ListedElementMatch, VerifyListedOptions, GetListedDataOptions, FillFormValue, GetAllOptions, ScreenshotOptions, IsVisibleOptions } from '../enum/Options';
 import { stepLog as log } from '../logger/Logger';
 import { ElementAction } from './ElementAction';
@@ -22,20 +23,26 @@ export class Steps {
     private verify;
     private utils;
     private email;
+    private apiClients: Map<string, WasapiClient>;
     private timeout?: number;
 
     /**
      * Initializes the Steps class with the element repository.
      * The Playwright Page is obtained from the repository's driver.
      * @param repo - An initialized instance of `ElementRepository` containing your locators and the bound driver.
-     * @param options - Optional configuration: emailCredentials and/or timeout.
+     * @param options - Optional configuration: emailCredentials, timeout, apiBaseUrl, and/or apiProviders.
      */
     constructor(
         private repo: ElementRepository,
-        options?: { emailCredentials?: EmailClientConfig; timeout?: number }
+        options?: {
+            emailCredentials?: EmailClientConfig;
+            timeout?: number;
+            apiBaseUrl?: string;
+            apiProviders?: Record<string, string>;
+        }
     ) {
         this.page = repo.driver;
-        const { emailCredentials, timeout } = options ?? {};
+        const { emailCredentials, timeout, apiBaseUrl, apiProviders } = options ?? {};
         const interactions = new ElementInteractions(this.page, { emailCredentials, timeout });
         this.interact = interactions.interact;
         this.navigate = interactions.navigate;
@@ -44,6 +51,16 @@ export class Steps {
         this.timeout = timeout;
         this.utils = new Utils(timeout);
         this.email = interactions.email;
+        this.apiClients = new Map();
+
+        if (apiBaseUrl) {
+            this.apiClients.set('default', new WasapiClient.Builder().setBaseUrl(apiBaseUrl).setLogHeaders(false).buildRaw());
+        }
+        if (apiProviders) {
+            for (const [name, url] of Object.entries(apiProviders)) {
+                this.apiClients.set(name, new WasapiClient.Builder().setBaseUrl(url).setLogHeaders(false).buildRaw());
+            }
+        }
     }
 
     /**
@@ -1195,5 +1212,178 @@ export class Steps {
         const result = await this.email.mark(markOptions);
         log.email('Successfully marked %d email(s)', result);
         return result;
+    }
+
+    // ==========================================
+    // API INTERACTION STEPS
+    // ==========================================
+
+    /**
+     * Resolves the named `WasapiClient` from the internal registry. Defaults to
+     * the `'default'` client (configured via `apiBaseUrl`). Named providers come
+     * from `apiProviders` on the fixture options.
+     */
+    private getApiClient(name?: string): WasapiClient {
+        const clientName = name ?? 'default';
+        const client = this.apiClients.get(clientName);
+        if (!client) {
+            if (clientName === 'default') {
+                throw new Error('API client is not configured. Pass apiBaseUrl to baseFixture() options when setting up your test fixture.');
+            }
+            throw new Error(`API provider "${clientName}" is not configured. Pass it in apiProviders to baseFixture() options. Available: ${[...this.apiClients.keys()].join(', ')}`);
+        }
+        return client;
+    }
+
+    /**
+     * Issues an HTTP GET against the default API client, or the named provider
+     * when the first argument matches a key in `apiProviders`.
+     *
+     * @example
+     * ```ts
+     * const res = await steps.apiGet<User>('/users/42');
+     * const res = await steps.apiGet<User[]>('billing', '/users', { query: { active: 'true' } });
+     * ```
+     */
+    async apiGet<T>(pathOrProvider: string, pathOrOptions?: string | { query?: Record<string, string>; headers?: Record<string, string> }, maybeOptions?: { query?: Record<string, string>; headers?: Record<string, string> }): Promise<ApiResponse<T>> {
+        const { client, path, options } = this.resolveApiArgs(pathOrProvider, pathOrOptions, maybeOptions);
+        log.api('GET %s', path);
+        return await client.execute<T>({
+            method: 'GET',
+            path,
+            queryParams: options?.query,
+            headers: options?.headers,
+        });
+    }
+
+    /**
+     * Issues an HTTP POST with an optional JSON body against the default API
+     * client, or the named provider when the first argument matches a key in
+     * `apiProviders`.
+     */
+    async apiPost<T>(pathOrProvider: string, bodyOrPath?: unknown, optionsOrBody?: unknown, maybeOptions?: { pathParams?: Record<string, string>; query?: Record<string, string>; headers?: Record<string, string> }): Promise<ApiResponse<T>> {
+        const { client, path, body, options } = this.resolveApiArgsWithBody(pathOrProvider, bodyOrPath, optionsOrBody, maybeOptions);
+        log.api('POST %s', path);
+        return await client.execute<T>({
+            method: 'POST',
+            path,
+            body,
+            pathParams: options?.pathParams,
+            queryParams: options?.query,
+            headers: options?.headers,
+        });
+    }
+
+    /**
+     * Issues an HTTP PUT with an optional JSON body against the default API
+     * client, or the named provider when the first argument matches a key in
+     * `apiProviders`.
+     */
+    async apiPut<T>(pathOrProvider: string, bodyOrPath?: unknown, optionsOrBody?: unknown, maybeOptions?: { pathParams?: Record<string, string>; headers?: Record<string, string> }): Promise<ApiResponse<T>> {
+        const { client, path, body, options } = this.resolveApiArgsWithBody(pathOrProvider, bodyOrPath, optionsOrBody, maybeOptions);
+        log.api('PUT %s', path);
+        return await client.execute<T>({
+            method: 'PUT',
+            path,
+            body,
+            pathParams: options?.pathParams,
+            headers: options?.headers,
+        });
+    }
+
+    /**
+     * Issues an HTTP DELETE against the default API client, or the named
+     * provider when the first argument matches a key in `apiProviders`.
+     */
+    async apiDelete<T>(pathOrProvider: string, pathOrOptions?: string | { pathParams?: Record<string, string>; headers?: Record<string, string> }, maybeOptions?: { pathParams?: Record<string, string>; headers?: Record<string, string> }): Promise<ApiResponse<T>> {
+        const { client, path, options } = this.resolveApiArgs(pathOrProvider, pathOrOptions, maybeOptions);
+        log.api('DELETE %s', path);
+        return await client.execute<T>({
+            method: 'DELETE',
+            path,
+            pathParams: options?.pathParams,
+            headers: options?.headers,
+        });
+    }
+
+    /**
+     * Issues an HTTP PATCH with an optional JSON body against the default API
+     * client, or the named provider when the first argument matches a key in
+     * `apiProviders`.
+     */
+    async apiPatch<T>(pathOrProvider: string, bodyOrPath?: unknown, optionsOrBody?: unknown, maybeOptions?: { pathParams?: Record<string, string>; headers?: Record<string, string> }): Promise<ApiResponse<T>> {
+        const { client, path, body, options } = this.resolveApiArgsWithBody(pathOrProvider, bodyOrPath, optionsOrBody, maybeOptions);
+        log.api('PATCH %s', path);
+        return await client.execute<T>({
+            method: 'PATCH',
+            path,
+            body,
+            pathParams: options?.pathParams,
+            headers: options?.headers,
+        });
+    }
+
+    /**
+     * Issues an HTTP HEAD and returns the response headers as a flat record.
+     */
+    async apiHead(pathOrProvider: string, maybePath?: string): Promise<Record<string, string>> {
+        let client: WasapiClient;
+        let path: string;
+        if (maybePath !== undefined) {
+            client = this.getApiClient(pathOrProvider);
+            path = maybePath;
+        } else {
+            client = this.getApiClient();
+            path = pathOrProvider;
+        }
+        log.api('HEAD %s', path);
+        const response = await client.execute<unknown>({ method: 'HEAD', path });
+        return response.headers;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private resolveApiArgs(pathOrProvider: string, pathOrOptions?: any, maybeOptions?: any): { client: WasapiClient; path: string; options?: any } {
+        if (typeof pathOrOptions === 'string') {
+            return { client: this.getApiClient(pathOrProvider), path: pathOrOptions, options: maybeOptions };
+        }
+        return { client: this.getApiClient(), path: pathOrProvider, options: pathOrOptions };
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private resolveApiArgsWithBody(pathOrProvider: string, bodyOrPath?: any, optionsOrBody?: any, maybeOptions?: any): { client: WasapiClient; path: string; body?: unknown; options?: any } {
+        if (typeof bodyOrPath === 'string') {
+            return { client: this.getApiClient(pathOrProvider), path: bodyOrPath, body: optionsOrBody, options: maybeOptions };
+        }
+        return { client: this.getApiClient(), path: pathOrProvider, body: bodyOrPath, options: optionsOrBody };
+    }
+
+    /**
+     * Asserts that an `ApiResponse` returned the expected HTTP status code.
+     * Throws with the response body embedded on failure.
+     */
+    async verifyApiStatus(response: ApiResponse<unknown>, expectedStatus: number): Promise<void> {
+        log.verify('Verifying API response status is %d (actual: %d)', expectedStatus, response.status);
+        if (response.status !== expectedStatus) {
+            throw new Error(`Expected API status ${expectedStatus} but got ${response.status}. Body: ${response.rawBody}`);
+        }
+    }
+
+    /**
+     * Asserts that an `ApiResponse` contains the given header (case-insensitive),
+     * and optionally matches the expected value exactly.
+     */
+    async verifyApiHeader(response: ApiResponse<unknown>, headerName: string, expectedValue?: string): Promise<void> {
+        const lowerName = headerName.toLowerCase();
+        const actual = Object.entries(response.headers).find(([k]) => k.toLowerCase() === lowerName);
+
+        if (!actual) {
+            throw new Error(`Expected API response to contain header "${headerName}" but it was not found. Headers: ${JSON.stringify(response.headers)}`);
+        }
+
+        log.verify('Verifying API header "%s" is present (value: "%s")', headerName, actual[1]);
+
+        if (expectedValue !== undefined && actual[1] !== expectedValue) {
+            throw new Error(`Expected header "${headerName}" to be "${expectedValue}" but got "${actual[1]}"`);
+        }
     }
 }

--- a/tests/api-steps.spec.ts
+++ b/tests/api-steps.spec.ts
@@ -1,0 +1,181 @@
+import { request as playwrightRequest } from '@playwright/test';
+import { test, expect } from './fixture/StepFixture';
+
+/**
+ * 100% API Coverage — HTTP Steps against a real BookHive backend.
+ *
+ * These tests exercise every `api*` / `verifyApi*` method on the Steps API
+ * against the `umutayb/book-hive-backend:latest` image brought up by the
+ * project's docker-compose. No mocks — behaviour is locked against the same
+ * real artefact that downstream consumers use.
+ *
+ * Endpoints exercised (from book-hive/README.md → Backend API):
+ *   GET    /api/health
+ *   GET    /api/books, /api/books/{id}
+ *   POST   /api/reset, /api/auth/login
+ *   PUT    /api/cart/items/{id}        (auth-gated → 401 when unauth'd)
+ *   DELETE /api/cart/items/{id}        (auth-gated → 401 when unauth'd)
+ *   PATCH  /api/books/{id}             (unmapped  → 405)
+ *   HEAD   /api/books                  (supported on GET routes by Spring)
+ *
+ * Unauthenticated 401 / 405 responses are valid targets here — they prove
+ * the method wrapper, URL, and response-parsing paths work end-to-end
+ * without needing to thread a JWT through every test.
+ */
+
+const BOOKHIVE_HEALTH_ATTEMPTS = 30;
+const BOOKHIVE_HEALTH_DELAY_MS = 1000;
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('TC_API_001: HTTP API Steps — BookHive integration', () => {
+    test.beforeAll(async () => {
+        // Infrastructure pre-flight uses Playwright's own `request` (the Steps
+        // API fixture depends on `page`, which Playwright disallows in `beforeAll`).
+        // The actual coverage tests below exercise our API steps, not this setup.
+        const baseURL = process.env.BOOKHIVE_API_URL ?? 'http://localhost:8080';
+        const ctx = await playwrightRequest.newContext({ baseURL });
+        try {
+            for (let attempt = 0; attempt < BOOKHIVE_HEALTH_ATTEMPTS; attempt++) {
+                try {
+                    const res = await ctx.get('/api/health');
+                    if (res.status() === 200) break;
+                } catch { /* not ready yet */ }
+                await new Promise((r) => setTimeout(r, BOOKHIVE_HEALTH_DELAY_MS));
+            }
+            // Reset to known seed state (50 books + 2 test users).
+            await ctx.post('/api/reset');
+        } finally {
+            await ctx.dispose();
+        }
+    });
+
+    test('apiGet — default provider, no query', async ({ steps }) => {
+        const res = await steps.apiGet<{ content: unknown[] }>('/api/books');
+        await steps.verifyApiStatus(res, 200);
+        expect(Array.isArray(res.body.content)).toBe(true);
+    });
+
+    test('apiGet — default provider, with query params', async ({ steps }) => {
+        const res = await steps.apiGet<{ content: unknown[] }>('/api/books', {
+            query: { genre: 'Fiction', size: '5' },
+        });
+        await steps.verifyApiStatus(res, 200);
+        expect(res.body.content.length).toBeGreaterThan(0);
+    });
+
+    test('apiGet — named provider (bookhive)', async ({ steps }) => {
+        const res = await steps.apiGet<unknown>('bookhive', '/api/books/book-001');
+        await steps.verifyApiStatus(res, 200);
+    });
+
+    test('apiGet — named provider with query params', async ({ steps }) => {
+        const res = await steps.apiGet<unknown>('bookhive', '/api/books', {
+            query: { query: 'mockingbird' },
+        });
+        await steps.verifyApiStatus(res, 200);
+    });
+
+    test('apiGet — unknown resource returns 404', async ({ steps }) => {
+        const res = await steps.apiGet<unknown>('/api/books/does-not-exist-xyz');
+        await steps.verifyApiStatus(res, 404);
+    });
+
+    test('apiPost — with JSON body (login)', async ({ steps }) => {
+        const res = await steps.apiPost<{ token: string }>('/api/auth/login', {
+            email: 'testuser1@bookhive.test',
+            password: 'Test1234!',
+        });
+        await steps.verifyApiStatus(res, 200);
+        expect(typeof res.body.token).toBe('string');
+    });
+
+    test('apiPost — named provider, no body', async ({ steps }) => {
+        const res = await steps.apiPost<{ status: string }>('bookhive', '/api/reset');
+        await steps.verifyApiStatus(res, 200);
+        expect(res.body.status).toBe('reset');
+    });
+
+    test('apiPut — exercises wrapper (401 unauthenticated)', async ({ steps }) => {
+        const res = await steps.apiPut<unknown>('/api/cart/items/anything', { quantity: 2 });
+        expect([401, 403]).toContain(res.status);
+    });
+
+    test('apiPut — named provider', async ({ steps }) => {
+        const res = await steps.apiPut<unknown>('bookhive', '/api/cart/items/anything', {
+            quantity: 3,
+        });
+        expect([401, 403]).toContain(res.status);
+    });
+
+    test('apiDelete — exercises wrapper (401 unauthenticated)', async ({ steps }) => {
+        const res = await steps.apiDelete<unknown>('/api/cart/items/anything');
+        expect([401, 403]).toContain(res.status);
+    });
+
+    test('apiDelete — named provider', async ({ steps }) => {
+        const res = await steps.apiDelete<unknown>('bookhive', '/api/cart/items/anything');
+        expect([401, 403]).toContain(res.status);
+    });
+
+    test('apiPatch — unmapped route returns 4xx', async ({ steps }) => {
+        const res = await steps.apiPatch<unknown>('/api/books/book-001', { price: 1 });
+        // book-hive has no @PatchMapping; Spring returns 401/403/404/405 depending on filter chain.
+        expect([401, 403, 404, 405]).toContain(res.status);
+    });
+
+    test('apiPatch — named provider', async ({ steps }) => {
+        const res = await steps.apiPatch<unknown>('bookhive', '/api/books/book-001', {
+            price: 1,
+        });
+        expect([401, 403, 404, 405]).toContain(res.status);
+    });
+
+    test('apiHead — returns headers record, no body', async ({ steps }) => {
+        const headers = await steps.apiHead('/api/books');
+        expect(headers).toBeDefined();
+        expect(Object.keys(headers).length).toBeGreaterThan(0);
+    });
+
+    test('apiHead — named provider', async ({ steps }) => {
+        const headers = await steps.apiHead('bookhive', '/api/books/book-001');
+        expect(headers).toBeDefined();
+    });
+
+    test('verifyApiStatus — passes on match', async ({ steps }) => {
+        const res = await steps.apiGet<unknown>('/api/health');
+        await steps.verifyApiStatus(res, 200);
+    });
+
+    test('verifyApiStatus — throws on mismatch with body in message', async ({ steps }) => {
+        const res = await steps.apiGet<unknown>('/api/books/nope');
+        await expect(steps.verifyApiStatus(res, 200)).rejects.toThrow(/404/);
+    });
+
+    test('verifyApiHeader — presence only (case-insensitive name)', async ({ steps }) => {
+        const res = await steps.apiGet<unknown>('/api/books');
+        await steps.verifyApiHeader(res, 'content-type');
+        await steps.verifyApiHeader(res, 'Content-Type'); // same header, different case
+    });
+
+    test('verifyApiHeader — exact value match', async ({ steps }) => {
+        const res = await steps.apiGet<unknown>('/api/books');
+        const actual = res.headers['content-type'] ?? res.headers['Content-Type'];
+        expect(actual).toBeDefined();
+        await steps.verifyApiHeader(res, 'content-type', actual!);
+    });
+
+    test('verifyApiHeader — throws when header missing', async ({ steps }) => {
+        const res = await steps.apiGet<unknown>('/api/books');
+        await expect(steps.verifyApiHeader(res, 'x-missing-header')).rejects.toThrow(
+            /x-missing-header/,
+        );
+    });
+
+    test('verifyApiHeader — throws on value mismatch', async ({ steps }) => {
+        const res = await steps.apiGet<unknown>('/api/books');
+        await expect(
+            steps.verifyApiHeader(res, 'content-type', 'text/plain'),
+        ).rejects.toThrow(/content-type/);
+    });
+});

--- a/tests/fixture/StepFixture.ts
+++ b/tests/fixture/StepFixture.ts
@@ -5,8 +5,17 @@ import { isEmailConfigured, loadEmailConfig } from '../../src/config/config';
 // Safely evaluate if email credentials exist before initializing the fixture
 const emailCredentials = isEmailConfigured() ? loadEmailConfig() : undefined;
 
+// BookHive backend is brought up alongside vue-test-site by docker-compose
+// (service `bookhive-backend`, mapped to localhost:8080). Used by API-step
+// coverage tests; unused by UI tests, which pay nothing.
+const bookhiveApiUrl = process.env.BOOKHIVE_API_URL ?? 'http://localhost:8080';
+
 export const test = baseFixture(base, 'tests/data/page-repository.json', {
     emailCredentials,
+    apiBaseUrl: bookhiveApiUrl,
+    apiProviders: {
+        bookhive: bookhiveApiUrl,
+    },
 });
 
 export { expect };


### PR DESCRIPTION
## Summary

- **HTTP API steps on Steps API** — ported from singularity-engine. Adds `apiGet` / `apiPost` / `apiPut` / `apiDelete` / `apiPatch` / `apiHead` + `verifyApiStatus` / `verifyApiHeader`, with first-class support for multiple backends per test via `apiProviders`. Powered by `@civitas-cerebrum/wasapi`.
- **`baseFixture` extension** — new optional `apiBaseUrl` / `apiProviders` options. Both optional; no cost if you don't use API steps.
- **Contract-testing companion skill** — new skill guiding agents through contract-style verification of HTTP endpoints: status, headers, response schema, error shape. Auto-activates on contract intent (`contract test`, `API contract`, `schema test`, `pact`, etc.) and when agents are about to write an API-only test with `steps.apiX`. Composed via the full TDD-for-skills cycle (RED → GREEN → REFACTOR) against the live book-hive backend, achieving 9/9 Absolute Rule compliance on the GREEN pass.
- **`api-reference.md` HTTP API Steps section** — canonical docs for fixture setup, default + named providers, every method signature, `ApiResponse` shape.

## What's in the skill

- 9 Absolute Rules (e.g., shape not values, one obligation per test, type the response, never hardcode base URLs incl. env-var fallbacks)
- 7-phase pipeline: Intake → Inventory → Fixture Setup → Test Design → Implementation (9 canonical patterns incl. multi-backend) → Run & Verify (with mandatory deliberate-failure hard gate) → Report
- Red Flags table with 17 explicit trigger phrases the skill tells agents to stop on
- Integration table routing to `failure-diagnosis` on contract-test failures and `test-repair` on batch rot
- Honest scope: this is contract-style integration testing, not broker-based CDC (Pact)

## Test plan

- [x] `npm run build` — clean compile
- [x] Multi-backend wiring verified via `apiProviders` Map-of-clients
- [x] RED-phase baseline captured on book-hive-e2e `test/red-phase-contract-testing` (6/7 rules violated without skill)
- [x] GREEN-phase verification on `test/green-phase-contract-testing` (9/9 rules complied; 11 contract tests, all green; deliberate-failure check documented)
- [x] Frontmatter under 1024-char cap
- [ ] Human review of API step signatures
- [ ] Human review of skill rule language and Red Flags
- [ ] Consumer smoke test — publish as prerelease, install in book-hive-e2e, run contract tests against Docker Hub backend