### PR TITLE
fix(skills): every journey gets every dispatch — no skip-by-scoping

### DIFF
--- a/skills/coverage-expansion/SKILL.md
+++ b/skills/coverage-expansion/SKILL.md
@@ -35,6 +35,31 @@ Do NOT use this for:
 
 ---
 
+## No-skip contract
+
+This section closes the "scope-to-gap-journeys" loophole that a 2026-04-23 Pass 2 run exposed (Wave 1 dispatched test-composer for 3 of 44 journeys, the orchestrator declared the other 41 "no-op by scoping," and marked Pass 2 complete). It stacks on top of §"Non-negotiables for depth mode" — that section ensures all 5 passes + cleanup run; this section ensures every pass covers every journey. Both sets of rules are hard rules, not guidance.
+
+1. **Every journey in the map gets a dispatch every compositional pass.** Pass 2 and Pass 3's wording "re-attempt any journey where pass 1 deferred stabilization or returned coverage gaps" names ONE legitimate reason to prioritise; it does NOT authorise skipping un-gapped journeys. Scoping the dispatch to only "interesting" journeys is a shortcut and constitutes partial-pass-completion.
+2. **Every journey in the map gets a dispatch every adversarial pass.** Pass 4 and Pass 5 run bug-discovery per journey — 0 journeys × Pass 4 is not Pass 4. A journey whose adversarial subagent returns "no meaningful boundaries found" must still be recorded in the ledger section with that result — the dispatch happened.
+3. **Every dispatch returns a structured result.** Options are `new-tests-landed`, `no-new-tests (exhaustively covered)`, `blocked (reason)`, or `skipped (reason + who-authorized)`. The fourth option (`skipped`) is only valid when the orchestrator has the user's explicit in-conversation authorisation to skip that specific journey; an LLM orchestrator may not authorise itself.
+4. **Scope compression is a caller-facing decision.** If the orchestrator determines before dispatching that a journey's Pass-N work is likely no-op, it still dispatches; if it wants to formally skip, it RETURNS TO THE CALLER with a scope-compression proposal and waits for the caller to approve. Silent scope compression is a contract violation.
+5. **No-op dispatches are cheap by design.** A well-behaved test-composer subagent, given an already-exhaustive journey, returns `no-new-tests` in seconds with no test-run — there is no budget justification for scope-compression on that basis.
+
+```
+❌ WRONG: "Pass 2 Wave 1 covered the 3 journeys with Pass-1 gaps; the remaining 41 had no
+   map-growth so I skipped them."
+
+✅ RIGHT: "Pass 2 dispatched test-composer for all 44 journeys in 11 waves of 4 parallel.
+   38 returned `no-new-tests` (exhaustive), 3 returned `new-tests-landed`, 3 returned
+   `blocked (tenant data)`. Pass 2 complete."
+```
+
+### Per-pass completion criteria — no silent compression
+
+This subsection extends §"Per-pass completion criteria" (see below). A pass's completion criteria are NOT satisfied by covering the journeys the orchestrator judged interesting. The criteria are satisfied by covering every journey in the map, with each covered journey returning one of the four structured results above. An orchestrator that writes "41 journeys had no gaps — no-op dispatches not run" in a state file is not writing a state file, it is writing a rationalisation; the state file should say either "pass complete, N/N journeys dispatched" or "pass incomplete, N/M journeys dispatched, waiting to resume."
+
+---
+
 ## Prerequisites
 
 1. `tests/e2e/docs/journey-map.md` must exist with `<!-- journey-mapping:generated -->` on line 1. If missing, stop and invoke `journey-mapping` first.

--- a/skills/coverage-expansion/SKILL.md
+++ b/skills/coverage-expansion/SKILL.md
@@ -41,22 +41,43 @@ This section closes the "scope-to-gap-journeys" loophole that a 2026-04-23 Pass 
 
 1. **Every journey in the map gets a dispatch every compositional pass.** Pass 2 and Pass 3's wording "re-attempt any journey where pass 1 deferred stabilization or returned coverage gaps" names ONE legitimate reason to prioritise; it does NOT authorise skipping un-gapped journeys. Scoping the dispatch to only "interesting" journeys is a shortcut and constitutes partial-pass-completion.
 2. **Every journey in the map gets a dispatch every adversarial pass.** Pass 4 and Pass 5 run bug-discovery per journey — 0 journeys × Pass 4 is not Pass 4. A journey whose adversarial subagent returns "no meaningful boundaries found" must still be recorded in the ledger section with that result — the dispatch happened.
-3. **Every dispatch returns a structured result.** Options are `new-tests-landed`, `no-new-tests (exhaustively covered)`, `blocked (reason)`, or `skipped (reason + who-authorized)`. The fourth option (`skipped`) is only valid when the orchestrator has the user's explicit in-conversation authorisation to skip that specific journey; an LLM orchestrator may not authorise itself.
+3. **Every dispatch returns a structured result.** Options are `new-tests-landed`, `no-new-tests (exhaustively covered)`, `blocked (reason)`, or `skipped (reason + who-authorized)`. `blocked` is **subagent-returned** and does not need orchestrator or user approval — it is the subagent saying "I dispatched but cannot complete because of tenant data / environment / credential gaps" (e.g., admin seed user missing in demo tenant). `skipped` is **orchestrator-proposed** and is only valid when the orchestrator has the user's explicit in-conversation authorisation to skip that specific journey; an LLM orchestrator may not authorise itself, and the budget-pressure clause in §"Non-negotiables for depth mode" is NOT such authorisation. If the orchestrator cannot tell whether a journey should be blocked or skipped, it dispatches and lets the subagent decide — that is always the correct default.
 4. **Scope compression is a caller-facing decision.** If the orchestrator determines before dispatching that a journey's Pass-N work is likely no-op, it still dispatches; if it wants to formally skip, it RETURNS TO THE CALLER with a scope-compression proposal and waits for the caller to approve. Silent scope compression is a contract violation.
 5. **No-op dispatches are cheap by design.** A well-behaved test-composer subagent, given an already-exhaustive journey, returns `no-new-tests` in seconds with no test-run — there is no budget justification for scope-compression on that basis.
 
-```
-❌ WRONG: "Pass 2 Wave 1 covered the 3 journeys with Pass-1 gaps; the remaining 41 had no
-   map-growth so I skipped them."
+### Structured-return recording
 
-✅ RIGHT: "Pass 2 dispatched test-composer for all 44 journeys in 11 waves of 4 parallel.
-   38 returned `no-new-tests` (exhaustive), 3 returned `new-tests-landed`, 3 returned
-   `blocked (tenant data)`. Pass 2 complete."
+Every dispatch's return goes in two places, and both are required:
+
+- **Progress log for the current run** — a per-journey line in the caller-visible progress output, of the form `j-<slug>: <return-type> — <reason-if-any>`.
+- **`coverage-expansion-state.json`** — in the per-pass record, a `dispatches` array with one entry per journey: `{ journey: "j-<slug>", result: "new-tests-landed|no-new-tests|blocked|skipped", reason: "<text or null>", authorizer: "<user|null>" }`. `authorizer` is only non-null for `skipped`.
+
+A state file without the `dispatches` array for every pass that has run is incomplete — it cannot be used to verify the no-skip contract was honoured on resume.
+
+### Applies to both modes
+
+This contract applies to **both** `mode: depth` and `mode: breadth`. Breadth mode runs one horizontal sweep across all journeys — the same no-skip rule applies per tier. An orchestrator running breadth mode that scopes Tier-1 to "only journeys with P0 priority and recent commits" is committing the same loophole; breadth mode's single sweep must still dispatch for every journey in the map, returning one of the four structured results for each.
+
+```
+❌ WRONG (compositional): "Pass 2 Wave 1 covered the 3 journeys with Pass-1 gaps; the
+   remaining 41 had no map-growth so I skipped them."
+
+✅ RIGHT (compositional): "Pass 2 dispatched test-composer for all 44 journeys in 11 waves
+   of 4 parallel. 38 returned `no-new-tests` (exhaustive), 3 returned `new-tests-landed`,
+   3 returned `blocked (tenant data)`. Pass 2 complete."
+
+❌ WRONG (adversarial): "Pass 4 probed the 9 journeys with state-changing APIs; the other
+   35 were read-only so I didn't dispatch."
+
+✅ RIGHT (adversarial): "Pass 4 dispatched bug-discovery for all 44 journeys. 9 returned
+   verified boundaries, 28 returned `no boundaries probed — no state-changing surface in
+   this journey` (recorded in the ledger per the schema), 7 returned
+   `blocked (read-only journey gated by admin seed user)`. Pass 4 complete."
 ```
 
 ### Per-pass completion criteria — no silent compression
 
-This subsection extends §"Per-pass completion criteria" (see below). A pass's completion criteria are NOT satisfied by covering the journeys the orchestrator judged interesting. The criteria are satisfied by covering every journey in the map, with each covered journey returning one of the four structured results above. An orchestrator that writes "41 journeys had no gaps — no-op dispatches not run" in a state file is not writing a state file, it is writing a rationalisation; the state file should say either "pass complete, N/N journeys dispatched" or "pass incomplete, N/M journeys dispatched, waiting to resume."
+This subsection extends §"Per-pass completion criteria" (see below). A pass's completion criteria are NOT satisfied by covering the journeys the orchestrator judged interesting. The criteria are satisfied by covering every journey in the map, with each covered journey returning one of the four structured results above. An orchestrator that writes "41 journeys had no gaps — no-op dispatches not run" in a state file is not writing a state file, it is writing a rationalisation; the state file should say either "pass complete, N/N journeys dispatched" or "pass incomplete, N/M journeys dispatched, waiting to resume" — using the exact same wording as §"Non-negotiables for depth mode" so resume logic can key off a single shared string.
 
 ---
 

--- a/skills/element-interactions/SKILL.md
+++ b/skills/element-interactions/SKILL.md
@@ -170,6 +170,10 @@ They do NOT hold:
 
 Parallel subagents own their own context windows. Context weight lives with the worker, not the conductor. This is how the skill architecture scales to many journeys without blowing the orchestrator's token budget.
 
+### 13. No scope compression in any pass, stage, or phase
+
+If the skill contract says "dispatch per journey" or "run both phases," the orchestrator dispatches per journey and runs both phases. An orchestrator that silently narrows scope is violating the contract regardless of budget, time, or perceived no-op likelihood. Budget-constrained runs return early with a resume-needed message; they do not silently narrow.
+
 ### Workflow
 - **Run the tests** to validate your work. Do not skip this.
 - **Commit** after every confirmed success. Do not batch.

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -178,6 +178,8 @@ Between and after the five passes, `coverage-expansion` itself refreshes its vie
 
 **Commits:** `coverage-expansion` commits once per pass (`test: coverage expansion pass <N>/5 — <summary>`). Onboarding adds no extra commit here.
 
+**No stage may be silently skipped.** Onboarding has seven phases and each phase has its own internal stages (element-interactions has Stages 1–4; coverage-expansion has Passes 1–5 + cleanup; bug-discovery has Phases 1a and 1b). Partial-phase completion is reportable; partial-phase completion disguised as full-phase completion is a contract violation. The onboarding-report and any summary deck MUST state partial status explicitly when applicable — "Phase 5: Pass 1 complete (44/44), Pass 2 partial (3/44), Pass 3–5 pending" — not "Phase 5 complete."
+
 ### Phase 6 — Bug hunts (two passes)
 
 Two sequential invocations of `bug-discovery`:


### PR DESCRIPTION
## Motivating incident

A 2026-04-23 farmed-visie-fresh onboarding run hit the "scope-to-gap-journeys" loophole during coverage-expansion Pass 2:

- Pass 1 had dispatched `test-composer` for all 44 journeys.
- Pass 2 Wave 1 dispatched `test-composer` for only **3 of 44** journeys — the three that had returned gaps or deferred stabilization in Pass 1.
- The orchestrator declared the remaining 41 "no-op by scoping" and marked Pass 2 complete.
- User caught the shortcut. The contract says "dispatches `test-composer` per journey" — not "per journey with gaps."

PR #104 (still open) closes the orthogonal loophole — "only Pass 1 ran; passes 2–5 were deferred for budget." This PR stacks a second tier on top: even once all 5 passes run, each pass must cover every journey, not a scoped subset.

## New rules

### 1. `skills/coverage-expansion/SKILL.md` — new `## No-skip contract` section

Placed after §"Non-negotiables for depth mode" (PR #104). Five hard rules:

1. Every journey in the map gets a dispatch every compositional pass (Pass 2/3's "re-attempt gapped journeys" authorises prioritisation, not skipping).
2. Every journey in the map gets a dispatch every adversarial pass (0 journeys × Pass 4 is not Pass 4; "no meaningful boundaries found" returns are still recorded).
3. Every dispatch returns one of four structured results: `new-tests-landed` | `no-new-tests (exhaustively covered)` | `blocked (reason)` | `skipped (reason + who-authorized)`. The fourth requires explicit user in-conversation authorisation — the LLM orchestrator may not authorise itself.
4. Scope compression is a caller-facing decision. If the orchestrator wants to formally skip, it returns to the caller with a scope-compression proposal and waits; silent scope compression is a contract violation.
5. No-op dispatches are cheap by design. A well-behaved `test-composer` given an exhaustive journey returns `no-new-tests` in seconds with no test-run — there is no budget justification for scope-compression.

Section ends with a wrong/right example block showing the Pass 2 / 44-journey pattern explicitly.

### 2. `skills/coverage-expansion/SKILL.md` — extends `### Per-pass completion criteria`

Added as a new subsection "Per-pass completion criteria — no silent compression" that extends the PR-#104 criteria section. Spells out that pass completion = N/N journeys dispatched, not "the journeys the orchestrator judged interesting." State files must report `"pass complete, N/N"` or `"pass incomplete, N/M, waiting to resume"` — not `"41 journeys had no gaps — no-op dispatches not run"`.

### 3. `skills/onboarding/SKILL.md` — mirror rule for phases/stages

New paragraph after the Phase-5 reinforcement paragraph (PR #104): **No stage may be silently skipped.** Onboarding has seven phases; each phase has internal stages (element-interactions Stages 1–4, coverage-expansion Passes 1–5 + cleanup, bug-discovery Phases 1a/1b). Partial-phase completion is reportable; partial-phase disguised as complete is a contract violation. Reports must say e.g. `"Phase 5: Pass 1 complete (44/44), Pass 2 partial (3/44), Pass 3–5 pending"` — not `"Phase 5 complete."`

### 4. `skills/element-interactions/SKILL.md` — new rule #13 in ABSOLUTE RULES

One sentence appended to the absolute-rules preamble: **No scope compression in any pass, stage, or phase.** Budget-constrained runs return early with a resume-needed message; they do not silently narrow scope.

## Stacking

- Stacks on #104 (open). Merge #104 first so the "after existing Non-negotiables" / "extends Per-pass completion criteria" / "after the Phase-5 reinforcement" anchors land in their intended neighbourhoods.
- Complementary to #102 (Phase-5 pass count 3→5) and #103 (parallel MCP subagent dispatch).

## Test plan

- [ ] `grep -Rn "No-skip contract" skills/coverage-expansion/SKILL.md` returns 1 hit.
- [ ] `grep -Rn "scope compression" skills/` returns 2+ hits (coverage-expansion + element-interactions).
- [ ] `grep -Rn "41 journeys had no gaps" skills/` returns 1 hit in the wrong/right example / criteria extension.
- [ ] `grep -Rn "No stage may be silently skipped" skills/onboarding/SKILL.md` returns 1 hit.
- [ ] Next onboarding run: orchestrator dispatches `test-composer` for all N journeys in every compositional pass and bug-discovery for all N in every adversarial pass. No "scoped to interesting journeys" shortcut.
- [ ] Orchestrator that wants to compress scope returns a proposal to the caller instead of silently compressing.

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>