### PR TITLE
fix(skills): tenant-mutation safety, cleanup hooks, static adversarial mode

### DIFF
--- a/skills/bug-discovery/SKILL.md
+++ b/skills/bug-discovery/SKILL.md
@@ -361,12 +361,55 @@ If the user agrees, create one issue per confirmed bug with the same structure a
 
 ## Invocation options
 
-bug-discovery accepts one optional parameter via `args`.
+bug-discovery accepts two independent parameters via `args`: a `phase` selector and a `mode` selector.
 
-| Mode | Behaviour |
+### `phase`
+
+| Phase | Behaviour |
 |---|---|
 | `phase: 'full'` (default) | Run Phase 1a (Element Probing), Phase 1b (Flow Probing), and everything downstream as documented above. |
 | `phase: '1a-element-probing'` | Run Phase 1a only. Write findings to `onboarding-report.md` (or the default bug report file). Do not run Phase 1b. |
 | `phase: '1b-flow-probing'` | Run Phase 1b only. Require that Phase 1a has already been run in a prior session (findings file exists). Use those findings to prioritise flow probes. |
 
 Parameter parsing: recognise the literal substrings `1a-element-probing`, `1b-flow-probing`, or `full` in `args`. Default to `full`.
+
+### `mode`
+
+| Mode | Behaviour |
+|---|---|
+| `mode: 'live'` (default) | Probe the running application through Playwright MCP as documented in Phases 1a–1b. Requires MCP availability. |
+| `mode: 'static'` | First-class static-only adversarial probing. No live navigation. See below. |
+
+## Static mode — first-class adversarial probing
+
+`mode: static` is a **first-class probing mode**, not a degraded fallback for when live probing fails. In environments where MCP is unavailable — CI runners without a browser, restricted sandboxes, read-only review checkouts — static mode is the default. Static findings stand on their own merit; they are simply a different class of evidence than live findings, and they are labelled as such.
+
+### What the subagent reads
+
+In static mode the subagent does not navigate the app. It reads, in order:
+
+1. Spec files in the test directory — to understand what is currently asserted and what boundaries existing tests already guard.
+2. `page-repository.json` — the authoritative selector inventory and element-attribute context (input types, max-length attributes, role hints).
+3. `tests/e2e/docs/app-context.md` — documented pages, flows, and known quirks.
+4. Sibling-journey ledger sections in `tests/e2e/docs/adversarial-findings.md` (or equivalent) — adversarial findings logged against related journeys often transfer to the journey under analysis.
+
+### How bugs are inferred
+
+Static mode infers likely bugs from pattern matches against the code and repository snapshot. Every inferred finding is recorded with `inferred: true` in its structured body. Examples of inference patterns:
+
+1. **Missing `maxlength` on a free-text input** → likely HTTP 500 on long input (server-side length unguarded). Infer a boundary bug for payloads above the typical DB column cap (255, 4000, etc.).
+2. **Missing `type="email"` / no client validation on an email field** → likely XSS or malformed-input vector; downstream rendering probably reflects user-supplied content unescaped.
+3. **No `autocomplete="off"` on a password-reset or MFA entry field** → likely credential-leak surface via browser autofill in shared-device contexts.
+4. **No CSRF token reference in a form handler that issues a mutating POST** → likely CSRF vulnerability, especially if the session cookie lacks `SameSite=Lax|Strict`.
+5. **Numeric input without `min` / `max` / `step` attributes** → likely negative-number or floating-point edge-case bug (e.g., quantity=-1 bypassing validation, price=0.0001 rounding to 0).
+
+These five are illustrative — the subagent applies the same inference pattern to any similar structural gap it observes. Each finding body states the evidence (which file, which element, which missing attribute), the inferred failure mode, and carries the `inferred: true` flag.
+
+### What static mode must never claim
+
+- **No verified-bug claims.** Static mode never asserts that a bug was reproduced. Findings are inferences from structural evidence. If the caller later re-runs in `mode: live`, the inference can be confirmed or refuted — but until then, the finding is documented as inferred only.
+- **No reproduction test.** Phase 6 writes reproduction tests; static mode does not. A static finding can be handed to a later live pass for reproduction, but the static subagent itself stops at evidence + inference.
+
+### Why this is first-class, not a fallback
+
+Several environments are static-only by construction: CI runners without a browser, regulated sandboxes that block outbound network, code-review contexts, and offline audits. Running bug-discovery in those contexts is a legitimate use case, not a degraded one. Framing static mode as a first-class probing mode removes the "apology" framing that produces weaker findings and standardises the structured-return shape so the orchestrator can merge static and live findings on the same footing (with the `inferred: true` flag retaining the epistemic distinction).

--- a/skills/bug-discovery/SKILL.md
+++ b/skills/bug-discovery/SKILL.md
@@ -413,3 +413,20 @@ These five are illustrative — the subagent applies the same inference pattern 
 ### Why this is first-class, not a fallback
 
 Several environments are static-only by construction: CI runners without a browser, regulated sandboxes that block outbound network, code-review contexts, and offline audits. Running bug-discovery in those contexts is a legitimate use case, not a degraded one. Framing static mode as a first-class probing mode removes the "apology" framing that produces weaker findings and standardises the structured-return shape so the orchestrator can merge static and live findings on the same footing (with the `inferred: true` flag retaining the epistemic distinction).
+
+### Orchestrator-side: no silent deprioritisation
+
+Being first-class is not only framing — it is a constraint on how orchestrators (`coverage-expansion`, `onboarding`, Phase-7 deck generation) handle the findings:
+
+- **Ranking.** Static findings rank by **severity**, not by evidence class. A `severity: high` inferred finding outranks a `severity: low` live-verified finding in any ordered list.
+- **Inclusion in reports and decks.** Static findings appear in the onboarding-report and the summary deck on the same footing as live findings. The `inferred: true` flag is shown explicitly so readers can judge epistemic weight, but the finding is not buried or collapsed.
+- **Follow-up suggestion.** When static findings landed in an earlier run and MCP later becomes available, the orchestrator SHOULD suggest re-running the affected journeys in `mode: live` to confirm or refute each `inferred: true` finding. "Suggest" means a one-line progress note to the caller, not an autonomous re-run.
+
+**Rationalizations to reject:**
+
+| Excuse | Reality |
+|--------|---------|
+| "Inferred findings are weaker so I'll bucket them separately in the deck" | Bucketing by evidence class rather than severity buries high-impact static findings. The flag carries the epistemic weight — ranking stays severity-first. |
+| "Static-mode findings are probably false positives, so I'll drop the low-severity ones" | Every finding's severity is the subagent's judgement; filtering on evidence class on top of severity is double-discounting. |
+| "Live mode ran fine so I can ignore any earlier static findings" | A live pass that failed to reproduce an inferred finding does not refute it — it demotes evidence, but the finding stays in the report unless the live pass reached the specific pattern. The orchestrator marks the inference as `live-unconfirmed`, not deleted. |
+| "MCP is available so there's no reason to run static mode" | Correct for that one run. Static mode is not opportunistic redundancy — it is for environments where live is unavailable. Do not run static mode in parallel with live unless the caller specifically requested a code-audit pass. |

--- a/skills/test-composer/SKILL.md
+++ b/skills/test-composer/SKILL.md
@@ -97,6 +97,7 @@ Write tests in batches of 5-15 per spec file, organized by area.
 - Every test must use the Steps API from `./fixtures/base`
 - Every element selector goes in `page-repository.json` — no inline selectors in test code
 - Use `test.describe.configure({ timeout: 60_000 })` on every describe block
+- **File-level serial mode is mandatory for tenant-mutating specs.** If the spec issues any POST to a mutable endpoint (create, update, delete), the file **must** open with `test.describe.configure({ mode: 'serial' })` at the top of the file — before any `test.describe(...)` or `test(...)` block. Rationale: parallel Playwright workers sharing a credential against a single tenant produce random CSRF-token invalidations when concurrent POSTs race against the session-bound token. Serial mode at the file level eliminates the race without capping global parallelism. Follow-up (not landed in this PR): add a lint rule or pre-commit check that rejects any spec with a mutating POST that lacks the serial directive.
 - Tests that depend on data from other tests must handle both states (e.g., job status could be "draft" or "published")
 - Tests that need specific data should use `test.skip()` when that data isn't found, not fail
 
@@ -121,6 +122,29 @@ Compose variants in this order so selectors build up cleanly and each variant in
 6. **Data-lifecycle variants** (where `Test expectations:` lists them): create → read → update → delete across sessions, draft persistence, bulk operations.
 
 Each variant is its own `test(...)` inside one describe block for the journey — or split into a small cluster of describe blocks if the file grows beyond ~200 lines.
+
+### Tenant cleanup hooks are non-negotiable for add-* journeys
+
+Any journey whose happy path creates a persistent tenant entity (e.g., `j-*-add-caregiver`, `j-*-add-location`, `j-*-add-group`, `j-*-add-administrator`) **must** include an explicit `test.afterAll` teardown attempt in the spec. Accumulated test records across many passes pollute shared tenants and eventually obscure real behaviour.
+
+Two cases, both mandatory:
+
+1. **UI exposes a Delete affordance.** The spec's `test.afterAll` uses the Steps API to delete every entity the suite created. If the teardown step itself fails, the spec must surface that failure in the subagent's structured return rather than swallowing it.
+2. **UI lacks a Delete affordance.** The spec calls the framework-level helper `cleanupViaApiBackdoor(<entity-type>, <id>)` — see contract below. If the helper is unavailable in the current project (e.g., per-tenant API credentials not configured), the subagent does **not** silently skip cleanup. It returns `cleanup: blocked` in its structured summary so the orchestrator can log the tenant-pollution risk explicitly instead of having it hide in the spec.
+
+#### `cleanupViaApiBackdoor` contract (documentation only — helper is a future follow-up)
+
+This PR documents the contract. The helper implementation itself is a separate framework-level follow-up; per-tenant API credentials live in env.
+
+```
+cleanupViaApiBackdoor(entityType: string, id: string): Promise<void>
+```
+
+- **Intent.** Delete a tenant entity created during a test when the UI exposes no Delete path. Invoked from `test.afterAll` after the suite's happy-path variant has finished.
+- **Signature.** `entityType` is a framework-recognised entity slug (e.g., `'caregiver'`, `'location'`, `'group'`, `'administrator'`). `id` is the server-assigned identifier captured during the create flow.
+- **Credentials.** Per-tenant API credentials live in env (`<TENANT>_API_TOKEN` or equivalent). The helper reads them; specs never handle raw credentials.
+- **Failure mode.** On non-2xx response, the helper throws; the spec's `test.afterAll` catches and surfaces `cleanup: blocked` in the subagent return.
+- **Status.** Contract only in this PR. The helper implementation, the env-credential convention, and any per-entity endpoint mapping are future follow-up work and out of scope here.
 
 Cross-journey ordering (which journey to tackle first among many) is the caller's concern, not this skill's.
 

--- a/skills/test-composer/SKILL.md
+++ b/skills/test-composer/SKILL.md
@@ -97,7 +97,9 @@ Write tests in batches of 5-15 per spec file, organized by area.
 - Every test must use the Steps API from `./fixtures/base`
 - Every element selector goes in `page-repository.json` — no inline selectors in test code
 - Use `test.describe.configure({ timeout: 60_000 })` on every describe block
-- **File-level serial mode is mandatory for tenant-mutating specs.** If the spec issues any POST to a mutable endpoint (create, update, delete), the file **must** open with `test.describe.configure({ mode: 'serial' })` at the top of the file — before any `test.describe(...)` or `test(...)` block. Rationale: parallel Playwright workers sharing a credential against a single tenant produce random CSRF-token invalidations when concurrent POSTs race against the session-bound token. Serial mode at the file level eliminates the race without capping global parallelism. Follow-up (not landed in this PR): add a lint rule or pre-commit check that rejects any spec with a mutating POST that lacks the serial directive.
+- **File-level serial mode is mandatory for tenant-mutating specs.** If the spec issues any POST / PUT / PATCH / DELETE to a mutable endpoint, the file **must** open with `test.describe.configure({ mode: 'serial' })` at the top of the file — before any `test.describe(...)` or `test(...)` block. Rationale: parallel Playwright workers sharing a credential against a single tenant produce random CSRF-token invalidations when concurrent mutating requests race against the session-bound token. Serial mode at the file level eliminates the race without capping global parallelism. Follow-up (not landed in this PR): add a lint rule or pre-commit check that rejects any spec with a mutating request that lacks the serial directive.
+
+  **What counts as a mutable endpoint.** Any request whose server response represents a persistence change against tenant or user data — entity create / update / delete, state transitions (publish, archive, submit), role or permission mutations, file uploads that persist, password or MFA changes. Read-only methods (GET / HEAD / OPTIONS) do NOT trigger the rule, even when they tunnel through a POST for query-payload reasons, **provided** the handler is idempotent and server-side writes are limited to audit-log entries. When in doubt, apply the rule: the cost is one line of configuration per file; the cost of missing it is non-deterministic CI failures that surface later as "flaky auth".
 - Tests that depend on data from other tests must handle both states (e.g., job status could be "draft" or "published")
 - Tests that need specific data should use `test.skip()` when that data isn't found, not fail
 
@@ -132,7 +134,19 @@ Two cases, both mandatory:
 1. **UI exposes a Delete affordance.** The spec's `test.afterAll` uses the Steps API to delete every entity the suite created. If the teardown step itself fails, the spec must surface that failure in the subagent's structured return rather than swallowing it.
 2. **UI lacks a Delete affordance.** The spec calls the framework-level helper `cleanupViaApiBackdoor(<entity-type>, <id>)` — see contract below. If the helper is unavailable in the current project (e.g., per-tenant API credentials not configured), the subagent does **not** silently skip cleanup. It returns `cleanup: blocked` in its structured summary so the orchestrator can log the tenant-pollution risk explicitly instead of having it hide in the spec.
 
+**Rationalizations to reject:**
+
+| Excuse | Reality |
+|--------|---------|
+| "Cleanup hook errored but the main tests passed, move on" | A swallowed cleanup failure is silent tenant pollution. Surface it in the subagent return; the orchestrator decides. |
+| "I don't have API credentials so I'll log in as the shared admin and call the UI delete" | That bypasses the reason the backdoor exists (UI has no Delete). If the UI has no Delete path, an admin-UI Delete doesn't exist either — you are inventing a workflow the app does not expose. Return `cleanup: blocked`. |
+| "One record per test doesn't matter, the tenant is big" | Per pass × per journey × per variant × 5 compositional passes × 2 adversarial passes = hundreds of records per run. Pollution compounds across runs. |
+| "I'll skip cleanup and add a TODO" | A TODO in a committed spec is a silent commitment to do the work later. It rarely gets done. Return `cleanup: blocked` — the orchestrator's log of blocked cleanups IS the follow-up ledger. |
+| "The backdoor helper isn't implemented yet so I'll skip" | Correct response: write the `cleanupViaApiBackdoor` call as documented, let it fail at runtime, and return `cleanup: blocked` with the runtime error. Do NOT inline ad-hoc cleanup that circumvents the contract. |
+
 #### `cleanupViaApiBackdoor` contract (documentation only — helper is a future follow-up)
+
+> **⚠ Not-yet-implemented helper.** The helper below is contracted here but has no implementation yet. Specs written against this contract today will throw at runtime the first time `cleanupViaApiBackdoor(...)` is called — by design, because the spec's `test.afterAll` catches and returns `cleanup: blocked`. This is the expected behaviour until the framework-level follow-up lands. Do NOT substitute an inline ad-hoc cleanup to make the call succeed; that would mask the pollution risk the return value is meant to surface.
 
 This PR documents the contract. The helper implementation itself is a separate framework-level follow-up; per-tenant API credentials live in env.
 


### PR DESCRIPTION
## Summary

Three follow-up contract changes from the MediCheck onboarding run memo. Each maps to a distinct failure mode hit during the engagement; none of them contradicts PRs #102–#105 that already landed.

- **§3.1 — File-level serial on tenant-mutating specs (test-composer).** Any spec issuing a POST to a mutable endpoint (create, update, delete) must open with `test.describe.configure({ mode: 'serial' })` at the file top. Rationale: parallel Playwright workers sharing a credential against a single tenant produce random CSRF-token invalidations when concurrent POSTs race the session-bound token. File-level serial eliminates the race without capping global parallelism. Lint rule / pre-commit check flagged as a follow-up — not landed here.
- **§3.3 — Tenant cleanup hooks non-negotiable (test-composer).** Two-sided update for add-* journeys: (1) briefs must include an explicit `test.afterAll` teardown attempt, and if the UI lacks a Delete affordance the subagent returns `cleanup: blocked` in its structured summary rather than silently skipping; (2) documents the `cleanupViaApiBackdoor(<entity-type>, <id>)` framework-helper contract — signature, intent, credential convention, failure mode. The helper implementation and per-tenant env wiring are out of scope for this PR.
- **§3.4 — Static-only adversarial probing as first-class (bug-discovery).** Adds `mode: static` alongside `mode: live`. In static mode the subagent reads spec code, page-repository.json, app-context.md, and sibling-journey ledger sections; infers likely bugs from structural pattern matches (5 illustrative patterns: missing maxlength → HTTP 500 on long input; missing input-type=email → XSS vector; missing autocomplete=off on password/MFA fields → credential leak; missing CSRF token on mutating form → CSRF surface; numeric input without min/max/step → negative/floating-point edge cases); flags every finding `inferred: true`; never claims verification without live reproduction. Framed as first-class — CI runners, restricted sandboxes, and offline audits are legitimate static-only environments, not degraded ones.

**Source:** `tests/e2e/docs/skill-improvement-memo.md` §3.1, §3.3, §3.4 (MediCheck onboarding run, 2026-04-23 → 2026-04-24).

**Scope discipline:** this PR documents contracts only. The lint rule (§3.1), the pre-commit check (§3.1), and the `cleanupViaApiBackdoor` helper implementation (§3.3) are separate follow-up work and are not landed here. Skills outside `test-composer` and `bug-discovery` are untouched.

## Test plan

- [ ] Dispatch a test-composer subagent against an add-* journey (e.g., `j-*-add-caregiver`) and confirm its brief enforces the `test.afterAll` teardown requirement and surfaces `cleanup: blocked` when no Delete affordance exists.
- [ ] Dispatch a test-composer subagent against a mutating-POST spec and confirm the generated file opens with `test.describe.configure({ mode: 'serial' })`.
- [ ] Dispatch a bug-discovery subagent with `args: "mode: static"` in an MCP-unavailable context and confirm findings return with `inferred: true`, cite structural evidence (file + element + missing attribute), and include no reproduction tests.
- [ ] Dispatch a bug-discovery subagent with default (`mode: live`) args and confirm behaviour is unchanged — `mode` defaults to `live`, `phase` defaults to `full`.
- [ ] Skim `skills/test-composer/SKILL.md` and `skills/bug-discovery/SKILL.md` diffs to confirm wording tracks the memo §3.1 / §3.3 / §3.4 as landed.

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>