### PR TITLE
fix(coverage-expansion): scope preview, auto-compaction, re-pass discipline, batched dispatch, state-file contract

### DIFF
--- a/skills/coverage-expansion/SKILL.md
+++ b/skills/coverage-expansion/SKILL.md
@@ -72,6 +72,10 @@ State file shape (minimum fields):
 
 The state file is rewritten after every per-pass commit (and whenever auto-compaction triggers — see §"Auto-compaction between passes" below).
 
+**Journey-roster mutability.** The roster for a given pass is frozen at the start of that pass — it is a snapshot of the journey IDs the orchestrator intends to dispatch *this pass*. If a compositional pass discovers and promotes a new journey or sub-journey mid-pass, the new entry is appended to the **next** pass's roster, not retroactively to the current pass's. This prevents the "did I cover everything?" ambiguity where `journeyRoster` and `completedJourneys` diverge because the roster keeps growing. Reconciliation commits (Pass 2/3) write the new roster to the state file at the same commit that appends the new map blocks, so the post-compact resume reads a consistent roster-to-map alignment.
+
+**Corrupted or stale state file.** If the state file is present but references journeys that no longer appear in `journey-map.md`, or if `currentPass` is set but `completedJourneys` is a superset of `journeyRoster`, the orchestrator stops and reports the mismatch to the caller rather than guessing. Self-repair is out of scope — a corrupted state file is a manual-triage signal, not a silent reset.
+
 ---
 
 ## Modes
@@ -176,6 +180,16 @@ If the orchestrator's context is **>70% consumed**:
 
 Framing: this is a platform-aware seam for long runs. It is not a cost-reduction mechanism. The optimisation target remains complete coverage; auto-compaction exists so complete coverage doesn't get halved by a context ceiling.
 
+**Rationalizations to reject:**
+
+| Excuse | Reality |
+|--------|---------|
+| "Context is at 75% but I can push one more pass before compacting" | 70% is the floor, not a guideline. Every pass adds subagent-return summaries that grow the state file and the running adversarial totals. One more pass from 75% often lands at 95%+ and forces an in-pass compact that loses roster state not yet committed. |
+| "I'll compact at 50% to be safe" | Preemptive compaction destroys the prompt cache unnecessarily. 70% is the threshold because below it the seam costs more than it saves. |
+| "The state file is small, there's nothing to save before compacting" | The state file is not the point — the orchestrator's own context (subagent returns, map index, reconciliation scratch) is. State is written *so* compaction is safe. Skipping the write because "state is small" is the bug. |
+| "I'll run Pass 4 to finish the compositional-to-adversarial boundary, then compact" | The compositional-to-adversarial boundary is inside the pass loop, not at 70%. If the threshold was crossed before Pass 4, compact before Pass 4. |
+| "Auto-compact failed once so I'll skip it this time" | The fallback is the manual-compaction safe-seam message, not silent progression. If `/compact` errors, emit the safe-compact line and stop; the user compacts and re-invokes. Never continue past 70% without either auto- or manual-compaction. |
+
 ### Re-pass mode for compositional passes 2–3
 
 Passes 2 and 3 dispatch `test-composer` with an explicit `mode: re-pass` argument. Pass 1 already composed the journey's full variant set; re-pass work is valuable only as a disciplined audit against three specific triggers.
@@ -195,6 +209,18 @@ Passes 2 and 3 dispatch `test-composer` with an explicit `mode: re-pass` argumen
 > **No tool-use budget. No tool-use cap.** Cost is not the optimisation target; signal quality is. The value of a re-pass is disciplined evidence that Pass 1 was exhaustive. An undisciplined cheap no-op is worse than a thorough no-op.
 
 The re-pass mode's contribution is **disciplined justification**, not speed. Every return becomes an auditable artifact — either new tests with their rationale, or `covered-exhaustively` with the full mapping table and the three-trigger check. The orchestrator rejects any pass-2 / pass-3 return that does not include the per-expectation mapping and the three-trigger check, and re-dispatches that journey.
+
+**Rationalizations to reject (subagent side):**
+
+| Excuse | Reality |
+|--------|---------|
+| "Obvious no-op — I'll mark `covered-exhaustively` without reading Pass-1 returns" | The three-trigger check requires evidence. Fabricating "Pass-1 reported no gaps" without reading the return is the exact failure the orchestrator's rejection-and-redispatch step is designed to catch; the redispatch wastes more time than reading the return would have. |
+| "The mapping table is obvious, I'll shorthand it" | Shorthand fails the orchestrator's check. The mapping table enumerates each expectation with the specific test covering it — not "all covered by existing tests". One-line-per-expectation or redispatch. |
+| "Sibling-bug ledger is probably empty for this journey, skip it" | The check is "I read the ledger and found no regression candidates for this journey", not "I assumed there are none". Skipping the read is skipping the trigger. |
+| "No tool-use budget means I can spam tool calls freely" | "No budget" is a signal that signal quality matters more than cost; it is NOT an invitation to over-probe. Use the tools needed to satisfy the three triggers and no more. |
+| "Pass 1 was thorough so Pass 2/3 is always `covered-exhaustively`" | The three triggers explicitly include "map delta since Pass 1" and "sibling-bug regression candidate" — conditions that can only be evaluated at Pass 2/3 time, not inherited from Pass 1's confidence. The returning-it-without-inspection shortcut voids the pass. |
+
+**Orchestrator-side rejection check.** When a pass-2 or pass-3 return arrives, the orchestrator greps the return for (a) the literal string "trigger 1", "trigger 2", "trigger 3", (b) a mapping-table header row, and (c) per-expectation entries. If any is missing the orchestrator re-dispatches the journey with a brief explicitly quoting the rejected parts. The orchestrator does NOT accept partial returns as a concession to save re-dispatch cost — the discipline holds on both sides.
 
 ### Batched dispatch for P3 peripheral journeys
 
@@ -224,6 +250,16 @@ Adjacent low-impact journeys (typically P3 smoke tests or admin-portal siblings 
 - Eight P3 journeys in one brief → must be split into two briefs (e.g., 5 + 3), never one brief past the cap.
 
 Batching cuts dispatches for peripheral work by roughly half without touching per-journey fidelity. The per-expectation mapping, the three-trigger check (for passes 2–3), and the probe/regression contract (for passes 4–5) still apply to every journey in the batch. The return must include one clearly-labelled section per journey — no merged summaries.
+
+**Rationalizations to reject:**
+
+| Excuse | Reality |
+|--------|---------|
+| "This 8th journey is almost identical to the 7 in the batch, I'll include it" | Cap 7 is not negotiable. Split the batch (5 + 3, 4 + 4, etc). The cap bounds brief size and per-journey attention — "one more" compounds across batches and dilutes discipline. |
+| "All these journeys are P3 and share a project, and this admin journey *could* be grouped — skip the P1 carve-out" | P0 / P1 always dispatch individually. Priority is load-bearing; a journey at P1 deserves its own brief even if it happens to share pages with P3 siblings. |
+| "The journeys share most pages, same project, roughly P3 — skip the 'shared Playwright project' check" | Different Playwright projects require different MCP instances; batching across projects introduces browser-swap complexity that defeats the dispatch optimisation. |
+| "Batching is faster so I'll batch everything that isn't explicitly forbidden" | Batching is allowed, not preferred. P0/P1 individual dispatch is the default; batching is specifically for P3 peripheral sweeps. Defaulting to batch on P2 quietly compresses scope. |
+| "One journey in the batch has a coverage-gap flag from Pass 1, but the gap is trivial" | Any flag in the three re-pass triggers kicks the journey out of the batch into individual dispatch. "Trivial" is the subagent's judgement after reading Pass-1 returns — which cannot happen inside a batched brief. |
 
 ---
 

--- a/skills/coverage-expansion/SKILL.md
+++ b/skills/coverage-expansion/SKILL.md
@@ -42,6 +42,38 @@ Do NOT use this for:
 
 ---
 
+## Authoritative state file — read first, always
+
+The skill's **first action on entry**, before anything else, is to read `tests/e2e/docs/coverage-expansion-state.json`. Resumption is a contract, not a convention.
+
+```
+1. Read tests/e2e/docs/coverage-expansion-state.json.
+2. If the file is absent, or status == "complete", start Pass 1 from scratch.
+3. If currentPass is set, resume from that pass's journey roster.
+4. Skip journeys already marked complete in the state file for the current pass.
+5. Only when all 5 passes + cleanup show complete, return "coverage-expansion finished".
+```
+
+The state file is authoritative. The orchestrator must not reason about "where did we leave off" from chat history, commit log, or journey-map deltas — those are diagnostic, not authoritative. If the file says currentPass=3 with 22 of 45 journeys complete, Pass 3 resumes with the remaining 23 journeys and Pass 4/5/cleanup run afterwards.
+
+State file shape (minimum fields):
+
+```json
+{
+  "status": "in-progress",            // "in-progress" | "complete"
+  "currentPass": 3,                   // 1..5, or "cleanup"
+  "journeyRoster": ["j-...", ...],    // full roster for currentPass
+  "completedJourneys": ["j-...", ...],// IDs already returned green this pass
+  "inFlightJourneys": ["j-...", ...], // dispatched but not yet returned
+  "adversarialTotals": { ... },       // passes 4–5 only
+  "updatedAt": "2026-04-24T..."
+}
+```
+
+The state file is rewritten after every per-pass commit (and whenever auto-compaction triggers — see §"Auto-compaction between passes" below).
+
+---
+
 ## Modes
 
 | Mode | Invocation | Behaviour |
@@ -57,22 +89,25 @@ Each pass runs a journey-by-journey pipeline with parallel dispatch where indepe
 
 ### Per-pass pipeline
 
-Every pass in depth mode runs this pipeline; steps 4 and 6 differ between compositional (1–3) and adversarial (4–5) passes.
+Every pass in depth mode runs this pipeline; steps 4 and 7 differ between compositional (1–3) and adversarial (4–5) passes.
 
 1. **Read the map** (sentinel-verified). Build an in-memory index: `[(j-id, priority, pages-touched, test-expectations)]`. Read **only** these fields per journey — not full step lists, branches, or state variations.
 2. **Recompute priority ordering.** Honour the map's priorities, but if a journey's `Test expectations` or pages touched have changed since the last pass (because a prior pass reconciled new branches into the map), adjust position.
 3. **Build the journey independence graph** (see §"Journey independence graph" below). The graph is the same across compositional and adversarial passes — journey co-residence on pages determines parallelism either way.
-4. **Dispatch subagents** — parallel for independent journeys, sequential for dependent ones. Model chosen per the heuristic below.
-   - **Compositional passes (1–3):** each invocation dispatches `test-composer` with `args: "journey=<j-id>"`.
+4. **Emit the per-pass scope preview** (see §"Per-pass scope preview" below). This is declarative, not interactive — no confirmation prompt, no timeout, no abort option. The preview exists so mid-pass rationalisation is visible against the declared scope.
+5. **Dispatch subagents** — parallel for independent journeys, sequential for dependent ones. Model chosen per the heuristic below.
+   - **Compositional passes (1–3):** each invocation dispatches `test-composer` with `args: "journey=<j-id>"`. For passes 2–3, pass `mode: re-pass` (see §"Re-pass mode for compositional passes 2–3" below).
    - **Adversarial passes (4–5):** each invocation dispatches the adversarial probe subagent per `references/adversarial-subagent-contract.md`, passing the journey ID and the pass number. The subagent internally invokes `bug-discovery` scoped to its journey.
-5. **Collect subagent returns.** Each return is a structured discovery report — for compositional passes per `test-composer`'s return format, for adversarial passes per the adversarial subagent contract's return shape.
-6. **Reconcile artefacts.**
+6. **Collect subagent returns.** Each return is a structured discovery report — for compositional passes per `test-composer`'s return format, for adversarial passes per the adversarial subagent contract's return shape.
+7. **Reconcile artefacts.**
    - **Compositional passes:** reconcile the map. Append new branches to existing journey blocks. Add new `j-<slug>` or `sj-<slug>` blocks for newly-discovered journeys or sub-journeys. Append new pages/elements to `app-context.md`. Run a mini Phase 3.5 revision (see `journey-mapping`) if the pass introduced new overlaps.
    - **Adversarial passes:** the map is NOT reconciled. The ledger file is authoritative; its content is already written by the subagents during their append step. Aggregate the return summaries into the orchestrator's running adversarial-totals counter (journeys probed, boundaries verified, suspected-bug count by severity, regression tests added).
-7. **Commit.** One commit per pass. Commit message template:
+8. **Commit, then update state file.** One commit per pass. Commit message template:
    - Compositional: `test: coverage expansion pass <N>/5 — <summary>`
    - Pass 4: `test: coverage expansion pass 4/5 — adversarial probing (<N> journeys, <B> boundaries, <S> suspected bugs)`. Commit diff is the ledger file only.
    - Pass 5: `test: coverage expansion pass 5/5 — adversarial consolidation (<N> journeys, <R> regression tests, <B> total boundaries)`. Commit diff is the ledger file plus the new `j-<slug>-regression.spec.ts` files.
+
+   After the commit lands, rewrite `tests/e2e/docs/coverage-expansion-state.json` with the new pass counter, completed-journey set, and (for adversarial passes) updated adversarial totals. Then run the auto-compaction check (see §"Auto-compaction between passes" below) before the next pass's dispatch.
 
 ### Pass differences
 
@@ -106,6 +141,89 @@ Orchestrator picks a model per subagent between `sonnet` and `opus` only. Journe
 Override: promote from `sonnet` to `opus` on a journey that previously returned a stabilization, API-review, or coverage-verification failure.
 
 For adversarial passes (4 and 5), default to **opus** regardless of journey size. Adversarial probing requires judgment to recognize subtle boundary failures. Sonnet is acceptable only for the smallest journeys (steps ≤ 4 AND pages ≤ 2 AND priority ∈ {P2, P3}). Any journey that returned a stabilization or coverage-verification failure in passes 1–3 must run on opus in passes 4 and 5.
+
+### Per-pass scope preview
+
+Before every pass dispatch (step 4 of the per-pass pipeline), emit a declarative scope preview. The preview is informational only — there is no confirmation prompt, no timeout, no abort option, and no reduce-scope offer. The contract is every journey, every pass; the preview makes that contract explicit so any mid-pass rationalisation is visible against the declared scope.
+
+Template (values filled in per pass, from the map index, independence graph, and dispatch heuristic):
+
+```
+[coverage-expansion] Pass <N>/5 — dispatching <test-composer | adversarial probe> per journey
+  Journeys: <count> (<delta-note, e.g., "3 newly promoted in pass <N-1>">)
+  Independence graph: <G> groups, <K>-way parallel dispatch possible (cap <C>)
+  Model mix: <opus-count> opus (P0/P1/complex), <sonnet-count> sonnet (P2/P3/simple)
+  Expected wall-clock: ~<H>h at <K>-parallel
+  Contract: every journey, this pass. No skips. No batching beyond the explicit P3-batching allowance.
+```
+
+The model mix numbers come from the existing sonnet/opus heuristic applied to the current roster — do not recompute or soften the rule inside the preview. The wall-clock estimate is a ballpark from the per-subagent run times observed so far this run (or a default of ~20 min per opus dispatch / ~10 min per sonnet dispatch if no prior data exists).
+
+Completion check: if a pass starts with N journeys and ends with returns from fewer than N, the orchestrator must re-dispatch the missing journeys before claiming the pass is complete. The preview's journey count is the ground truth for the end-of-pass reconciliation.
+
+### Auto-compaction between passes
+
+Between passes — after the per-pass commit and state-file rewrite (step 8), before the next pass's dispatch — the orchestrator checks its own context usage. Context exhaustion is a transparent seam, not a pipeline-halt.
+
+If the orchestrator's context is **>70% consumed**:
+
+1. Write full state to `tests/e2e/docs/coverage-expansion-state.json` (journey roster, completed IDs, in-flight IDs, pass counter, adversarial totals — the shape documented in §"Authoritative state file — read first, always").
+2. Emit exactly one line: `[coverage-expansion] context approaching budget — auto-compacting and resuming from state file`.
+3. Invoke `/compact` (or the platform-equivalent compaction primitive exposed to the orchestrator).
+4. On the post-compact turn, the skill's first action — reading the state file — picks up the run exactly where it left off. That's why §"Authoritative state file" is non-negotiable as the first action.
+
+**Platform note.** If no programmatic compaction primitive is available to the orchestrator, the skill must still make the seam safe for manual compaction: emit an unambiguous `[coverage-expansion] safe to compact — state is durable at tests/e2e/docs/coverage-expansion-state.json, resume with the same invocation args` line between passes whenever the >70% threshold is crossed. The user can then compact manually without losing progress, and the next turn resumes from the state file the same way.
+
+Framing: this is a platform-aware seam for long runs. It is not a cost-reduction mechanism. The optimisation target remains complete coverage; auto-compaction exists so complete coverage doesn't get halved by a context ceiling.
+
+### Re-pass mode for compositional passes 2–3
+
+Passes 2 and 3 dispatch `test-composer` with an explicit `mode: re-pass` argument. Pass 1 already composed the journey's full variant set; re-pass work is valuable only as a disciplined audit against three specific triggers.
+
+**Preamble embedded in every pass-2 / pass-3 test-composer brief:**
+
+> You are a re-pass subagent. Pass 1 already composed this journey. Pass 2/3 work is valuable only when:
+> - The journey map was materially enriched since Pass 1 (look for delta markers against the pre-pass journey block).
+> - The journey's Pass-1 return reported `coverage-gaps: [...]` or `stabilization: deferred`.
+> - A sibling journey surfaced a bug that should be regressed here too.
+>
+> You must perform the full inspection regardless — read the current journey block, read the Pass-1 return, read any sibling-bug ledger entries. Only *after* inspection may you return `status: covered-exhaustively` with:
+> - a per-expectation mapping table showing which test covers which Pass-1 expectation,
+> - an explicit check against each of the three triggers above ("trigger 1: no delta markers since Pass 1", "trigger 2: Pass-1 return reported no gaps or deferred stabilization", "trigger 3: sibling-bug ledger contains no regression candidates for this journey"),
+> - no unexplained shorthand.
+>
+> **No tool-use budget. No tool-use cap.** Cost is not the optimisation target; signal quality is. The value of a re-pass is disciplined evidence that Pass 1 was exhaustive. An undisciplined cheap no-op is worse than a thorough no-op.
+
+The re-pass mode's contribution is **disciplined justification**, not speed. Every return becomes an auditable artifact — either new tests with their rationale, or `covered-exhaustively` with the full mapping table and the three-trigger check. The orchestrator rejects any pass-2 / pass-3 return that does not include the per-expectation mapping and the three-trigger check, and re-dispatches that journey.
+
+### Batched dispatch for P3 peripheral journeys
+
+Adjacent low-impact journeys (typically P3 smoke tests or admin-portal siblings that share a single Playwright project) may be covered by one subagent in a single brief, **cap 7 journeys per brief**. Batching is a dispatch optimisation, not scope compression — each journey in the batch still receives the same contract (probe / re-pass / regression, per the pass), with its own section in the return.
+
+**When batching is allowed:**
+
+- Priority is P3 (or P2 smoke when the journeys share every non-universal page with a sibling already in the batch).
+- The journeys share a Playwright project (so one subagent / one MCP instance is sufficient).
+- None of the journeys has a pending stabilization failure, coverage-gap flag, or sibling-bug regression candidate from a prior pass — those trigger individual re-pass dispatches regardless of priority.
+- Up to 7 journeys per brief. Past 7, split into multiple batches.
+
+**When batching is NOT allowed:**
+
+- P0 or P1 journeys — always dispatched individually.
+- Journeys on different Playwright projects (distinct MCP instances needed).
+- Any journey flagged by any of the three re-pass triggers in §"Re-pass mode for compositional passes 2–3".
+
+**Examples — allowed:**
+
+- Pass 4 adversarial sweep of five admin-portal add-* journeys (`j-manager-add-caregiver`, `j-manager-add-location`, `j-manager-add-group`, `j-manager-add-administrator`, `j-manager-add-administrator-api-gebruiker`) — all P3, all on the admin-portal project, no prior failures → one batched brief, 5 journeys.
+- Pass 3 consolidation across seven P3 smoke journeys on the public marketing project → one batched brief (capped at 7).
+
+**Examples — not allowed:**
+
+- Mixing a P1 checkout journey into a P3 admin-portal batch → dispatch the P1 individually.
+- Eight P3 journeys in one brief → must be split into two briefs (e.g., 5 + 3), never one brief past the cap.
+
+Batching cuts dispatches for peripheral work by roughly half without touching per-journey fidelity. The per-expectation mapping, the three-trigger check (for passes 2–3), and the probe/regression contract (for passes 4–5) still apply to every journey in the batch. The return must include one clearly-labelled section per journey — no merged summaries.
 
 ---
 
@@ -220,7 +338,7 @@ Never hold in context:
 
 One bounded exception for pass 5: when dispatching a pass-5 subagent, the orchestrator does read the journey's pass-4 ledger section from the ledger file and pass it along as an input. This is strictly bounded to one journey's section for one subagent; the orchestrator releases it from context as soon as the dispatch is sent.
 
-If orchestrator context approaches a budget boundary mid-pass, write state to `docs/superpowers/state/coverage-expansion.json` and resume on next invocation.
+If orchestrator context approaches a budget boundary, follow the auto-compaction flow in §"Auto-compaction between passes". The authoritative state file is `tests/e2e/docs/coverage-expansion-state.json` (see §"Authoritative state file — read first, always"); resumption on any subsequent invocation is driven from that file.
 
 ---
 


### PR DESCRIPTION
## Summary

Lands five coverage-expansion flow improvements from the skill-improvement memo — all additive to the existing "every journey, every pass, no skips" contract. None of these are framed as cost reduction; the optimisation target is complete coverage with auditable scope.

- **§4.1 — Per-pass scope preview.** Before every pass dispatches, emit a declarative preview with journey count, independence-graph groups + parallel dispatch cap, opus/sonnet model mix from the existing heuristic, and a wall-clock ballpark. No confirmation prompt, no timeout, no abort option, no reduce-scope offer. The preview is informational only, and its journey count is ground truth for end-of-pass completion reconciliation so mid-pass rationalisation is visible against declared scope.
- **§4.1b — Auto-compaction between passes.** After each per-pass commit and state rewrite, the orchestrator checks its own context usage. If >70% consumed, it writes full state, emits `[coverage-expansion] context approaching budget — auto-compacting and resuming from state file`, invokes `/compact` (or platform equivalent), and the next turn resumes from the state file. Platform-aware fallback: when no programmatic compaction primitive is available, emit an unambiguous "safe to compact — state is durable" signal so manual compaction doesn't lose progress.
- **§4.2 — Re-pass mode for passes 2–3 with disciplined justification, no tool-use budget.** `test-composer` is invoked with explicit `mode: re-pass`. Subagents must read the current journey block, the Pass-1 return, and sibling-bug ledger entries before returning. `status: covered-exhaustively` requires a per-expectation mapping table plus an explicit three-trigger check (map delta, pass-1 coverage-gaps/deferred, sibling-bug regression candidate). No tool-use cap. Signal quality is the optimisation target; an undisciplined cheap no-op is worse than a thorough no-op.
- **§4.3 — Batched dispatch for P3 peripheral journeys.** Adjacent low-impact journeys (typically P3 smoke or admin-portal siblings sharing one Playwright project) can be covered by one subagent in a single brief, cap 7 journeys per brief. Each journey in a batch still receives the same contract (probe/re-pass/regression); batching is a dispatch optimisation, not scope compression. Allowed/not-allowed criteria plus worked examples included.
- **§4.4 — Authoritative state file contract.** `tests/e2e/docs/coverage-expansion-state.json` is read as the skill's first action on every entry. If absent or `status == "complete"`, start Pass 1. If `currentPass` is set, resume from that pass's journey roster, skipping journeys already marked complete. Only return "coverage-expansion finished" when all 5 passes + cleanup show complete. Resumption is a contract, not a convention. Also removes the now-stale reference to the old `docs/superpowers/state/coverage-expansion.json` path.

Source: skill-improvement-memo §4.1, §4.1b, §4.2, §4.3, §4.4 — 2-day MediCheck onboarding run (2026-04-23 → 2026-04-24), ~209 subagent dispatches, 97 commits, 288 tests, 150+ findings.

Builds on the already-landed #102/#103/#104/#105 foundation (no-skip contract, per-pass completion criteria, 5-pass count alignment). These changes augment that contract rather than replacing it.

## Test plan

- [ ] Trigger a fresh depth-mode coverage-expansion run on a small mapped app; confirm the scope preview prints before every pass dispatch with journey count, parallel cap, opus/sonnet counts, and wall-clock estimate.
- [ ] Simulate a >70% context usage between passes; confirm the orchestrator writes `coverage-expansion-state.json`, emits the auto-compact line, invokes `/compact`, and the post-compact turn resumes by reading the state file.
- [ ] Verify Pass 2 and Pass 3 `test-composer` invocations include `mode: re-pass` and that `covered-exhaustively` returns carry the per-expectation mapping table plus the explicit three-trigger check.
- [ ] Dispatch a P3 admin-portal batch of 5 add-* journeys in a single brief; confirm each journey appears as its own section in the return and that per-journey fidelity (per-expectation mapping, probe/regression contract) is preserved.
- [ ] Kill the orchestrator mid-Pass-3, re-invoke coverage-expansion; confirm the first action reads the state file and resumes from the remaining Pass-3 journeys rather than restarting from Pass 1.
- [ ] Try dispatching 8 P3 journeys in one brief — confirm the skill splits into two briefs (5 + 3) rather than exceeding the cap.
- [ ] Mix a P1 journey into a P3 batch — confirm the P1 is extracted and dispatched individually.

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>