### PR TITLE
fix(skills): close scope-compression loopholes in coverage-expansion + orchestrator

### DIFF
--- a/skills/coverage-expansion/SKILL.md
+++ b/skills/coverage-expansion/SKILL.md
@@ -29,6 +29,34 @@ The orchestrator for coverage growth. Iterates the user journey map, dispatches 
 
 ---
 
+## Two valid exits — read this before anything else
+
+There are exactly two ways for a coverage-expansion run to terminate:
+
+1. **All 5 passes + cleanup complete** for `mode: depth` (or the one breadth sweep complete for `mode: breadth`), with every journey dispatched in every pass.
+2. **Commit-what-landed + write `coverage-expansion-state.json` + stop with an explicit "resume needed" message** naming the completed passes, the in-flight pass, and the pending journeys.
+
+There is no third exit. Any framing that implies "partial run, but reasonable" — *"pragmatic Pass 1"*, *"honest Pass 1 only"*, *"most of the work done"*, *"deferred Passes 2–5 to a follow-up"*, *"reduced scope given session constraints"* — is the contract violation this skill exists to prevent. Tone does not change the contract: a "transparent" scope reduction is still a scope reduction, and silent scope reduction dressed in candid language is still silent scope reduction.
+
+If you are about to dispatch fewer passes than the mode requires, or fewer journeys than the map contains, you must EITHER (a) have explicit user authorisation in this conversation naming the reduction, OR (b) take exit #2 above. Self-authorisation is not authorisation. Auto-mode is not authorisation. Inferred user preference is not authorisation. Estimated session length is not authorisation.
+
+---
+
+## Self-talk red flags
+
+If your internal narrative includes any of the following framings, stop and re-read §"Two valid exits". You are about to violate the contract.
+
+| If you catch yourself thinking… | Reality |
+|---|---|
+| "Given session / conversation / context constraints, I'll run a subset…" | Budget pressure is not scope authorisation. Dispatch; if budget actually presses mid-run, take exit #2 (commit + state + stop). Pre-emptive reduction is forbidden. |
+| "Pragmatically / honestly / transparently I'll only run Pass N…" | Moral language framing scope compression as virtue. The contract is the contract; tone does not change it. |
+| "The user clearly wants results, not hours of subagent dispatch" | The user's authorisation is what they wrote, not what you infer. The onboarding front-load gate already explicitly authorised "tens of minutes to several hours" — hold them to their own authorisation. |
+| "I'll run [subset] and report state — that's resume-friendly" | Resume is for budget-driven mid-pipeline stops, not for pre-emptive scope reduction at the start. The state file is a resume marker, not a scope-reduction certificate. |
+| "Running all 5 passes is excessive for this app" | The map's content drives scope, not the orchestrator's judgement of "excessive". If the map has 16 journeys, every pass dispatches 16 journeys. |
+| "I'll be honest with the user that I'm reducing scope" | Naming the violation does not undo the violation. "Honest scope compression" is still scope compression. The fix is not honesty — it is asking the user before reducing, or running the full pipeline. |
+
+---
+
 ## Reading order for new contributors
 
 A new orchestrator implementer or contract-modifier should read these files in dependency order:
@@ -274,6 +302,34 @@ Both blocked statuses are valid terminal values under the no-skip contract (PR #
 
 1. `tests/e2e/docs/journey-map.md` must exist with `<!-- journey-mapping:generated -->` on line 1. If missing, stop and invoke `journey-mapping` first.
 2. The map must be in the precise-embedding format (each journey is a self-contained `### j-<slug>:` block with a `Pages touched:` line). If the map is in an older format without stable IDs, invoke `journey-mapping` to re-emit it.
+
+---
+
+## Mandatory intent declaration — required before any dispatch
+
+After the state-file read (next section) and before any subagent dispatch, the orchestrator MUST emit this declaration verbatim, with the placeholders filled:
+
+```
+[coverage-expansion] Pre-flight intent declaration
+  Mode: <depth | breadth>
+  Plan: dispatch every journey in `tests/e2e/docs/journey-map.md` for every required pass
+        (depth = 3 compositional + 2 adversarial + cleanup; breadth = 1 sweep).
+  Authorisation: <full-pipeline | user-authorised-scope>
+  If "user-authorised-scope":
+    Scope reduction: <description, e.g. "Pass 1 only across all journeys">
+    Authorising user message: "<exact verbatim quote of the user's authorising words>"
+    Conversation turn of authorisation: <turn number or "this turn">
+```
+
+Rules for this declaration:
+
+- It is emitted exactly once per invocation, before the first dispatch.
+- "Authorisation: full-pipeline" is the default and requires no quote — the full pipeline is what the skill exists to run.
+- "Authorisation: user-authorised-scope" requires a verbatim quote of the user's words. *Inferred* preferences ("the user clearly wants…") do not count and must not be cited. If you cannot fill in a verbatim quote, you do not have authorisation; either declare full-pipeline or stop and ask.
+- Auto-mode does not satisfy "user-authorised-scope". Auto-mode authorises proceeding without confirmation on routine decisions; scope-of-pipeline is not a routine decision per §"Two valid exits".
+- After the declaration is emitted, the orchestrator is bound to it. A run that declares "full-pipeline" and then runs only Pass 1 is in violation regardless of intent.
+
+The declaration also serves as the auditable record of *why* a partial run, if any, was sanctioned. A state file showing fewer passes than the mode requires must have a corresponding `user-authorised-scope` declaration in the progress log; otherwise it documents a contract violation.
 
 ---
 

--- a/skills/coverage-expansion/SKILL.md
+++ b/skills/coverage-expansion/SKILL.md
@@ -40,6 +40,19 @@ There is no third exit. Any framing that implies "partial run, but reasonable" �
 
 If you are about to dispatch fewer passes than the mode requires, or fewer journeys than the map contains, you must EITHER (a) have explicit user authorisation in this conversation naming the reduction, OR (b) take exit #2 above. Self-authorisation is not authorisation. Auto-mode is not authorisation. Inferred user preference is not authorisation. Estimated session length is not authorisation.
 
+### Reviewer parallelism is non-negotiable
+
+Stage B reviewers run **at host max parallelism**, not one at a time. A pass with 16 journeys dispatches up to 16 reviewers in one parallel wave (subject to the shared-resource audit's credential caps — see §"Parallel cap — lifted and jointly applied"). Reviewer dispatch is NOT a serialised cost.
+
+The contract:
+- **Per-journey**: each reviewer reads ONE journey's spec + journey block + live app (Stage B is never batched).
+- **Across journeys**: dispatched in parallel up to the host-max cap, sharing the same in-flight pool with Stage A retries.
+- **Within a journey**: Stage A and Stage B are sequential (a journey's own A and B never overlap), but its B can run while a sibling journey's A is in flight.
+
+If you are about to stop after Stage A claiming "running 16 reviewers is too much for this session" — re-read this section. 16 reviewers in parallel is one wave. The wave is the contract.
+
+See §"Parallelism — Intra-group pipelining (dual-stage)" for the full pipelining model.
+
 ---
 
 ## Self-talk red flags
@@ -54,6 +67,7 @@ If your internal narrative includes any of the following framings, stop and re-r
 | "I'll run [subset] and report state — that's resume-friendly" | Resume is for budget-driven mid-pipeline stops, not for pre-emptive scope reduction at the start. The state file is a resume marker, not a scope-reduction certificate. |
 | "Running all 5 passes is excessive for this app" | The map's content drives scope, not the orchestrator's judgement of "excessive". If the map has 16 journeys, every pass dispatches 16 journeys. |
 | "I'll be honest with the user that I'm reducing scope" | Naming the violation does not undo the violation. "Honest scope compression" is still scope compression. The fix is not honesty — it is asking the user before reducing, or running the full pipeline. |
+| "16 individual reviewer dispatches is too many" / "Stage B is too expensive to dispatch per-journey" | The dispatch count is not the cost. Stage B is parallel by design — 16 reviewers in one wave, not 16 sequential calls. The skill mandates host-max parallelism for both Stage A AND Stage B (see §"Parallelism — Intra-group pipelining"). If you find yourself counting reviewer dispatches as if each were sequential, you are misreading the parallelism model. Dispatch the wave. |
 
 ---
 
@@ -498,6 +512,7 @@ Co-residence on pages is the only dependency signal. Two journeys that both touc
 #### Intra-group pipelining (dual-stage)
 
 Within an independence group:
+- **Both stages are parallel by default.** Stage B is not a serial follow-up to Stage A — it is dispatched per-journey-as-soon-as-Stage-A-returns, sharing the parallel pool with sibling journeys' Stage A retries. An orchestrator that finishes Stage A for the whole pass and then begins Stage B serially is implementing a different (slower, contract-violating) protocol.
 - All journeys in the group start Stage A concurrently (subject to the parallel cap — see below).
 - Each journey's Stage B fires **as soon as that journey's Stage A returns** and the parallel cap has a slot — not after the whole group's Stage A completes.
 - Each journey's Stage A retry fires **as soon as that journey's Stage B returns with `improvements-needed`** and the cap has a slot.

--- a/skills/element-interactions/SKILL.md
+++ b/skills/element-interactions/SKILL.md
@@ -208,6 +208,18 @@ Parallel subagents own their own context windows. Context weight lives with the 
 
 If the skill contract says "dispatch per journey" or "run both phases," the orchestrator dispatches per journey and runs both phases. An orchestrator that silently narrows scope is violating the contract regardless of budget, time, or perceived no-op likelihood. Budget-constrained runs return early with a resume-needed message; they do not silently narrow.
 
+### 14. Companion-skill invocations run on the companion's contract, not the caller's estimate
+
+When this orchestrator (or `onboarding`, or any caller) invokes a companion skill — `journey-mapping`, `coverage-expansion`, `test-composer`, `bug-discovery`, `test-repair` — the companion's contract governs the run. The caller does NOT get to pre-emptively decide "I'll only run part of coverage-expansion because the full pipeline is too long," "I'll skip Pass 4–5 because adversarial probing is excessive for this app," or "I'll dispatch a subset of test-composer's variant set because the journey is small."
+
+If the caller estimates the companion's full contract is more work than the session can absorb, the caller has exactly two options:
+- **Invoke the companion as designed.** The companion itself owns budget pressure: its own §"Auto-compaction" / resume-needed message handles mid-pipeline budget hits. The caller's job is to dispatch and let the companion run its own contract.
+- **Ask the user for an explicit scope reduction before dispatching.** Quote the user's authorisation verbatim when relaying it to the companion (companions like `coverage-expansion` will have their own intent-declaration step that requires the verbatim quote).
+
+Auto-mode does not satisfy "explicit scope reduction." Inferred user preference does not satisfy it. Session-length anxiety does not satisfy it. If the caller cannot fill in a verbatim user quote authorising a reduced scope, the caller dispatches the full contract — period. Calling a companion with a self-authorised "lighter" scope is the same contract violation as silently narrowing one's own scope, just one layer higher.
+
+This rule applies regardless of how reasonable the caller's estimate is. "16 journeys × 5 passes = many hours" is a true statement and not authorisation. Onboarding's front-load gate already disclosed "tens of minutes to several hours" to the user — that disclosure is the user's authorisation for the full pipeline, and the caller is bound by it.
+
 ### Workflow
 - **Run the tests** to validate your work. Do not skip this.
 - **Commit** after every confirmed success. Do not batch.


### PR DESCRIPTION
## Why

A coverage-expansion run in `mode: depth` self-authorised running only Pass 1 of the 5-pass pipeline, framing it as *"pragmatic / honest / given session constraints"*. Every excuse it used was already named in the existing rejected-rationalizations tables — but those tables were passive context, not active gates. The orchestrator read them, then made the decision as if it hadn't.

## What this PR changes

1. **coverage-expansion — lift the "two valid exits" rule to opening prominence.** The rule that depth-mode runs terminate either with all 5 passes complete or via the commit-state-resume path was buried in §"Non-negotiables for depth mode". Lifted to a top-level callout right after the intro so it's the second thing the orchestrator reads.

2. **coverage-expansion — add a "Self-talk red flags" table.** The existing rejected-excuse tables target tactical excuses ("I'll skip Stage B for trivial journeys"). The meta-level framings that actually rationalise scope compression — *"pragmatic"*, *"honest"*, *"given session constraints"*, *"transparent"* — had no row. Added them with explicit "this is the contract violation this skill exists to prevent" framing.

3. **coverage-expansion — mandatory pre-flight intent declaration.** Before any dispatch, the orchestrator must paste a structured declaration stating its mode, plan, and authorisation source. If the authorisation is a user-authorised scope reduction, the declaration must include a *verbatim quote* of the user's authorising words. Self-authorisation, inferred preference, and auto-mode are explicitly NOT authorisation. The declaration becomes the auditable record of *why* any partial run was sanctioned.

4. **element-interactions — Rule 14: companion-skill invocations run on the companion's contract.** Closes the layer-above-the-companion loophole. When element-interactions (or onboarding, or any caller) invokes a companion skill, the companion's contract governs the run. The caller cannot pre-emptively reduce scope based on its own session-length estimate. Auto-mode does not satisfy the "explicit user authorisation" requirement.

## Reviewer checklist

- [ ] Only additions — no content removed from existing sections.
- [ ] Inserted sections sit at the documented anchor points: opening (after intro paragraphs), before state-file read, after Rule 13.
- [ ] Pre-flight declaration template is unambiguous and mirrors the existing dispatch-brief style.
- [ ] Rule 14 references companion skills by name and aligns with Rule 13's wording on resume-needed messages.
- [ ] No churn in unrelated sections.

## Test plan

- [ ] Re-trigger the original failure mode: invoke coverage-expansion against a 16-journey map in `mode: depth` with auto-mode active. Confirm the orchestrator either runs the full pipeline OR stops with a "resume needed" exit — and does NOT silently run Pass 1 only.
- [ ] Invoke coverage-expansion with an explicit user authorisation to skip a pass; confirm the pre-flight declaration captures the user's verbatim words and the run honours the reduced scope.
- [ ] Confirm `[coverage-expansion]` progress lines and existing per-pass commit conventions are unchanged.