### PR TITLE
fix(hooks): suite-gate windowed ratchet — block any-red in last N runs (issue #131)

### DIFF
--- a/hooks/suite-gate-ratchet.sh
+++ b/hooks/suite-gate-ratchet.sh
@@ -2,15 +2,26 @@
 # suite-gate-ratchet.sh
 #
 # Two-event hook split:
-#   - PostToolUse on Bash for `playwright test` runs: records pass/fail to
-#     `<repo-root>/.claude/last-suite-result.json` (timestamp + status).
-#   - PreToolUse on Bash for `git commit`: if commit message indicates a
-#     phase-progression (`test(j-...):`, `docs(ledger):`, `chore: scaffold`,
-#     etc.) and the last-suite-result is failed or older than 1 hour, blocks
-#     the commit with a redirect to re-run the suite.
+#   - PostToolUse on Bash for `playwright test` runs: appends pass/fail to a
+#     sliding window of the last N runs in
+#     `<repo-root>/.claude/last-suite-result.json` (array shape).
+#   - PreToolUse on Bash for `git commit`: if the commit message indicates a
+#     phase-progression (`test(j-...):`, `docs(ledger):`, etc.) and ANY run
+#     in the window is failed (or oldest run >1h old, or window not yet
+#     filled), blocks with a redirect to re-run the suite.
 #
-# Behavior is dispatched by the hookSpecificOutput / event name: the harness
-# fires the same script for PreToolUse and PostToolUse, and the script branches.
+# Behaviour is dispatched by the hook_event_name: the harness fires the same
+# script for PreToolUse and PostToolUse, and the script branches.
+#
+# Window size — defaults to 3 (matches the "stabilize 3x" convention in
+# element-interactions Stage 3). Override via env var:
+#
+#     CIVITAS_SUITE_GATE_WINDOW=5
+#
+# Issue #131 promoted the gate from a one-shot to a windowed ratchet because
+# real-world flakes (serial-mode, click-PUT race, auth-state eviction) pass
+# an isolated single run but fail across 3-5 reviewer-driven re-runs. The
+# windowed gate catches that class at the gate, not in the next pass.
 
 set -euo pipefail
 
@@ -28,6 +39,13 @@ REPO_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
 STATE_FILE="$REPO_ROOT/.claude/last-suite-result.json"
 mkdir -p "$REPO_ROOT/.claude" 2>/dev/null || true
 
+# Window size — env override or default 3.
+WINDOW_SIZE="${CIVITAS_SUITE_GATE_WINDOW:-3}"
+case "$WINDOW_SIZE" in
+  ''|*[!0-9]*) WINDOW_SIZE=3 ;;  # ignore non-integer overrides
+esac
+[ "$WINDOW_SIZE" -lt 1 ] && WINDOW_SIZE=1
+
 emit_deny() {
   jq -n --arg r "$1" '{
     "hookSpecificOutput": {
@@ -38,9 +56,27 @@ emit_deny() {
   }'
 }
 
-# === PostToolUse branch: record `playwright test` result ===
+# Read the current state, auto-migrating the legacy single-object shape into
+# a 1-element window seed. Emits the runs array as a JSON value on stdout.
+load_runs_array() {
+  if [ ! -f "$STATE_FILE" ]; then
+    echo "[]"
+    return
+  fi
+  jq '
+    if type == "object" and has("runs") and (.runs | type) == "array" then
+      .runs
+    elif type == "object" and has("status") then
+      # Legacy single-object format — seed the window with this one run.
+      [ { status: .status, timestamp: (.timestamp // ""), exitCode: (.exitCode // "unknown") } ]
+    else
+      []
+    end
+  ' "$STATE_FILE" 2>/dev/null || echo "[]"
+}
+
+# === PostToolUse branch: append `playwright test` result to the window =====
 if [ "$EVENT_NAME" = "PostToolUse" ]; then
-  # Only fire on `playwright test` invocations.
   RUNNERS='(npx|bunx|pnpm[[:space:]]+exec|yarn[[:space:]]+exec)[[:space:]]+'
   SEP='(^|[;|][[:space:]]*|&&[[:space:]]*|\|\|[[:space:]]*)'
   if ! echo "$CMD" | grep -qE "${SEP}(${RUNNERS})?playwright[[:space:]]+test"; then
@@ -51,7 +87,6 @@ if [ "$EVENT_NAME" = "PostToolUse" ]; then
   EXIT_CODE=$(echo "$TOOL_RESPONSE" | jq -r '.exitCode // .exit_code // .returncode // "unknown"')
   STDOUT=$(echo "$TOOL_RESPONSE" | jq -r '.stdout // .output // ""' 2>/dev/null || echo "")
 
-  # Heuristic: if stdout has "X failed" or exit code != 0, mark fail.
   STATUS="passed"
   if [ "$EXIT_CODE" != "0" ] && [ "$EXIT_CODE" != "unknown" ]; then
     STATUS="failed"
@@ -61,75 +96,104 @@ if [ "$EVENT_NAME" = "PostToolUse" ]; then
   fi
 
   TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  jq -n --arg s "$STATUS" --arg t "$TIMESTAMP" --arg c "$EXIT_CODE" \
-    '{status: $s, timestamp: $t, exitCode: $c}' > "$STATE_FILE" 2>/dev/null || true
+  CURRENT=$(load_runs_array)
+
+  # Append + trim to last WINDOW_SIZE entries, then write the new shape.
+  jq -n \
+    --argjson runs "$CURRENT" \
+    --argjson size "$WINDOW_SIZE" \
+    --arg     s    "$STATUS" \
+    --arg     t    "$TIMESTAMP" \
+    --arg     c    "$EXIT_CODE" \
+    '
+      ($runs + [{ status: $s, timestamp: $t, exitCode: $c }])
+      | (if length > $size then .[length - $size : length] else . end) as $trimmed
+      | { window_size: $size, runs: $trimmed }
+    ' > "$STATE_FILE.tmp" 2>/dev/null && mv "$STATE_FILE.tmp" "$STATE_FILE" || rm -f "$STATE_FILE.tmp"
   exit 0
 fi
 
-# === PreToolUse branch: gate phase-progression commits ===
+# === PreToolUse branch: gate phase-progression commits =====================
 if [ "$EVENT_NAME" = "PreToolUse" ]; then
-  # Only fire on git commit.
   if ! echo "$CMD" | grep -qE '(^|[;&|][[:space:]]*)git[[:space:]]+commit([[:space:]]|$)'; then
     exit 0
   fi
 
   MSG=$(echo "$CMD" | grep -oE -- "-m[[:space:]]*['\"][^'\"]+['\"]" | head -1 | sed -E "s/^-m[[:space:]]*['\"]//;s/['\"]$//" || true)
 
-  # Only gate phase-progression commits — those that add or update test specs
-  # / ledger / state-file. Other commits (docs, deps, chore scaffolding) pass.
   if ! echo "$MSG" | grep -qE '^(test\(j-[a-z0-9-]+|test\(j-[a-z0-9-]+-regression|docs\(ledger|docs\(coverage-expansion-state)'; then
     exit 0
   fi
 
   if [ ! -f "$STATE_FILE" ]; then
-    emit_deny "[BLOCKED] No suite-gate result on file.
+    emit_deny "[BLOCKED] No suite-gate window on file.
 
 Commit: \"${MSG}\"
 
-Fix: run the whole suite first to establish a green baseline.
+Fix: run the whole suite ${WINDOW_SIZE}× to establish a stable green window.
 
-  npx playwright test --reporter=list
+  for i in \$(seq 1 ${WINDOW_SIZE}); do npx playwright test --reporter=list; done
 
-Then re-attempt the commit. The suite gate ratchet records the most recent run; phase-progression commits (test(j-...), docs(ledger): ...) require the most recent run to be green within 1 hour.
+Then re-attempt the commit. The suite-gate windowed ratchet (issue #131) tracks the last ${WINDOW_SIZE} runs and blocks phase-progression on any-red.
 
-Why: phase-progression commits without a recent green suite-gate produce a broken HEAD that flake-rots over passes. See coverage-expansion §\"Whole-suite re-run gate (per-pass exit)\"."
+Why: phase-progression commits without a stable green window produce a broken HEAD that flake-rots over passes. A single passing run can mask serial-mode flakes / race conditions / auth-state eviction that surface across re-runs. See coverage-expansion §\"Whole-suite re-run gate\"."
     exit 0
   fi
 
-  STATUS=$(jq -r '.status // "unknown"' "$STATE_FILE" 2>/dev/null || echo "unknown")
-  TIMESTAMP=$(jq -r '.timestamp // ""' "$STATE_FILE" 2>/dev/null || echo "")
+  RUNS=$(load_runs_array)
+  RUN_COUNT=$(echo "$RUNS" | jq 'length')
 
-  if [ "$STATUS" != "passed" ]; then
-    emit_deny "[BLOCKED] Suite-gate is currently failed.
+  # Window not yet filled.
+  if [ "$RUN_COUNT" -lt "$WINDOW_SIZE" ]; then
+    MISSING=$((WINDOW_SIZE - RUN_COUNT))
+    emit_deny "[BLOCKED] Suite-gate window not yet filled (${RUN_COUNT}/${WINDOW_SIZE}).
 
 Commit: \"${MSG}\"
-Last suite-gate: status=${STATUS} at ${TIMESTAMP}
 
-Fix: re-run the whole suite, fix any failures, then re-commit.
+Fix: run the whole suite ${MISSING} more time(s) to fill the window.
 
-  npx playwright test --reporter=list
+  for i in \$(seq 1 ${MISSING}); do npx playwright test --reporter=list; done
 
-Why: phase-progression commits build on a green baseline. Committing on top of a red suite makes the regression untraceable when bisecting and rots the next pass's gate. See coverage-expansion §\"Whole-suite re-run gate\"."
+Why: the windowed ratchet needs ${WINDOW_SIZE} consecutive runs to gate. A flake that passes once but fails on re-run gets caught by the window — which is the whole point. Single-shot gates miss this class. (Override: \`CIVITAS_SUITE_GATE_WINDOW=N\` if your project's stability convention differs.)"
     exit 0
   fi
 
-  # Staleness check: result older than 1 hour.
-  if [ -n "$TIMESTAMP" ]; then
+  # Any-red in window — collect failed-run timestamps for the deny message.
+  FAILED_TIMESTAMPS=$(echo "$RUNS" | jq -r '[.[] | select(.status == "failed") | .timestamp] | join(", ")')
+  if [ -n "$FAILED_TIMESTAMPS" ]; then
+    emit_deny "[BLOCKED] Suite-gate window contains failed runs.
+
+Commit: \"${MSG}\"
+Window size: ${WINDOW_SIZE}
+Failed run timestamps: ${FAILED_TIMESTAMPS}
+
+Fix: stabilise the suite — run it until the last ${WINDOW_SIZE} consecutive runs are all green. Each new green run displaces the oldest run in the window.
+
+  for i in \$(seq 1 ${WINDOW_SIZE}); do npx playwright test --reporter=list; done
+
+Why: a single passing re-run after a flake doesn't clear the window — by design. The windowed ratchet exists to catch flakes that pass 70% of the time but fail intermittently in CI. See coverage-expansion §\"Whole-suite re-run gate\"."
+    exit 0
+  fi
+
+  # All green in window — check staleness against the OLDEST run. If any run
+  # has aged past 1h, the window is no longer reflective of current code.
+  OLDEST_TS=$(echo "$RUNS" | jq -r '.[0].timestamp // ""')
+  if [ -n "$OLDEST_TS" ]; then
     NOW_EPOCH=$(date -u +%s)
-    THEN_EPOCH=$(date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$TIMESTAMP" +%s 2>/dev/null || date -u -d "$TIMESTAMP" +%s 2>/dev/null || echo "0")
+    THEN_EPOCH=$(date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$OLDEST_TS" +%s 2>/dev/null || date -u -d "$OLDEST_TS" +%s 2>/dev/null || echo "0")
     if [ "$THEN_EPOCH" != "0" ]; then
       AGE=$((NOW_EPOCH - THEN_EPOCH))
       if [ "$AGE" -gt 3600 ]; then
-        emit_deny "[BLOCKED] Suite-gate result is stale (>1 hour old).
+        emit_deny "[BLOCKED] Suite-gate window is stale (oldest run >1h old).
 
 Commit: \"${MSG}\"
-Last suite-gate: passed at ${TIMESTAMP} ($((AGE / 60)) minutes ago)
+Oldest run in window: ${OLDEST_TS} ($((AGE / 60)) minutes ago)
 
-Fix: re-run the whole suite to refresh the gate.
+Fix: re-run the suite ${WINDOW_SIZE}× to refresh the window.
 
-  npx playwright test --reporter=list
+  for i in \$(seq 1 ${WINDOW_SIZE}); do npx playwright test --reporter=list; done
 
-Why: a stale gate doesn't reflect current code state. Re-run before progressing."
+Why: a stale window doesn't reflect current code state. The whole-window age is checked against the oldest run, so a single fresh run on top of stale entries is not enough — re-fill the window."
         exit 0
       fi
     fi

--- a/skills/coverage-expansion/SKILL.md
+++ b/skills/coverage-expansion/SKILL.md
@@ -560,6 +560,10 @@ After a pass's per-journey subagents return clean and per-pass completion criter
 
 **Why it runs here:** per-journey subagent stabilization confirms each journey's tests pass in isolation, but cumulative state across the suite (DB pollution, port collisions, fixture drift, shared-resource depletion) only surfaces when the whole suite runs together. Running this gate at every pass exit catches integration-time regressions at the earliest pass that introduces them, rather than at end-of-pipeline.
 
+**Harness-enforced as a windowed ratchet (issue #131).** The same gate is enforced at the commit boundary by `hooks/suite-gate-ratchet.sh` (auto-installed alongside the dispatch-guard). The hook tracks the **last N runs** in a sliding window — default `N=3`, override via `CIVITAS_SUITE_GATE_WINDOW=<int>` — and blocks phase-progression commits (`test(j-...)`, `docs(ledger)`, `docs(coverage-expansion-state)`) if ANY run in the window was red, OR the window is not yet filled, OR the oldest run is more than 1 hour old. The state file is `<repo>/.claude/last-suite-result.json` (legacy single-object format auto-migrates to the new array shape on the next PostToolUse).
+
+The windowed shape catches a class of failure single-shot gates miss: serial-mode flakes, click-PUT race conditions, and auth-state eviction that pass an isolated single run but fail across 3-5 reviewer-driven re-runs. A flake that passes 70% of the time displaces no failed entry from a 3-run window — by design — so the gate can't be cleared by one lucky re-run after a real regression. Pair this with §"Whole-suite re-run gate" above for end-to-end coverage: the orchestrator-side check fires at every pass exit; the harness ratchet fires at every commit on top of the same window.
+
 ### Parallelism
 
 The parallelism model has three layers:


### PR DESCRIPTION
Stacked on #133 → #125. Re-target to \`main\` after both merge.

Closes #131.

## Why

Real-world finding from a recent BookHive coverage-expansion run: 4 of 12 cycle-2 specs passed isolated single runs but **failed across reviewer-driven 3-5x re-runs** (serial-mode flakes, click-PUT race conditions, auth-state eviction post-refresh). The pre-#131 one-shot gate caught the lucky-green; the reality was an intermittent regression. The gate is too coarse.

The windowed shape catches this class at the gate, not in the next pass. A single passing re-run after a flake displaces no failed entry from a 3-run window — by design — so the gate can't be cleared by one lucky re-run on top of a real regression.

## What changed

- \`hooks/suite-gate-ratchet.sh\`:
  - PostToolUse: appends each \`playwright test\` result to a sliding-window array, trims to last N entries.
  - PreToolUse: blocks phase-progression commits (\`test(j-...)\` / \`docs(ledger)\` / \`docs(coverage-expansion-state)\`) if ANY run in the window is failed, OR the window has fewer than N entries, OR the oldest run is >1h old.
  - Default N=3 (matches the \"stabilize 3x\" convention from element-interactions Stage 3).
  - Override via env: \`CIVITAS_SUITE_GATE_WINDOW=<int>\` — clamped to ≥1, integer-only.
  - Auto-migration: legacy single-object format (pre-#131 shape) is detected on read and seeded as a 1-element window, then filled by subsequent PostToolUse appends. No consumer-side migration required.

- \`skills/coverage-expansion/SKILL.md\` §\"Whole-suite re-run gate\": new paragraph documenting the harness-enforced windowed ratchet alongside the orchestrator-side per-pass-exit gate. Names the env-var override and the failure-class motivation.

## Pipe-test summary

| Scenario | Expected | Observed |
|---|---|---|
| Empty state, commit | DENY (no window) | ✓ |
| 1 passed run, commit | DENY (1/3 — window not filled) | ✓ |
| 3 passed runs, commit | ALLOW | ✓ |
| 2 passed + 1 failed in window | DENY (any-red) | ✓ |
| 3 passed but oldest >1h | DENY (stale) | ✓ |
| Legacy single-object state | Migrates on next PostToolUse to {window_size:3, runs:[...]} | ✓ |
| CIVITAS_SUITE_GATE_WINDOW=5, 3 runs | DENY (3/5 — window not filled) | ✓ |

## Test plan

- [ ] Pull the branch on a consumer project and confirm legacy \`last-suite-result.json\` (single-object) migrates on the first \`playwright test\` after upgrade — no manual intervention required.
- [ ] Try a \`test(j-foo): add\` commit before any test runs — expect DENY with \"window not yet filled\" message.
- [ ] Run \`npx playwright test\` 3× green; commit allowed.
- [ ] Introduce a deliberate fail; commit denied; revert + run 3× green; window cleared.
- [ ] Set \`CIVITAS_SUITE_GATE_WINDOW=5\` in shell env; verify the gate now wants 5 runs.

## Coordination

The state-file lifecycle interacts with \`hooks/coverage-state-schema-guard.sh\` (PR #125) — both write to \`.claude/\` but at different filenames; no conflict.