### PR TITLE
docs(coverage-expansion): extract references + consolidate anti-rationalizations (#128 / #129)

### DIFF
--- a/skills/coverage-expansion/SKILL.md
+++ b/skills/coverage-expansion/SKILL.md
@@ -95,30 +95,36 @@ Every Agent dispatch description starts with a role-explicit prefix. The prefix 
 
 ## Self-talk red flags
 
-If your internal narrative includes any of the following framings, stop and re-read §"Two valid exits". You are about to violate the contract.
+When the orchestrator catches itself reasoning along certain framings — pre-emptive scope reduction, self-authorised batching, self-certifying greenlight, sonnet cost-down rationalisation, brief-leak, etc. — the relevant **failure-mode pattern** is documented in [`references/anti-rationalizations.md`](references/anti-rationalizations.md). The registry is keyed by category (not surface phrasing), names the symptoms that signal each pattern, the reality counter, and which hook (if any) catches that class mechanically.
 
-| If you catch yourself thinking… | Reality |
+A novel framing that doesn't obviously match anything → match to the closest existing pattern first; only add a new pattern if genuinely categorical-new. Symptom-level enumeration is what the registry consolidates **away** from — chasing every tactical excuse never keeps up.
+
+## Reference index
+
+This file is the orchestrator-side contract kernel. The heavy spec lives in `references/` — open the file relevant to what you're touching:
+
+| Reference file | What's in it |
 |---|---|
-| "Given session / conversation / context constraints, I'll run a subset…" | Budget pressure is not scope authorisation. Dispatch; if budget actually presses mid-run, take exit #2 (commit + state + stop). Pre-emptive reduction is forbidden. |
-| "Pragmatically / honestly / transparently I'll only run Pass N…" | Moral language framing scope compression as virtue. The contract is the contract; tone does not change it. |
-| "The user clearly wants results, not hours of subagent dispatch" | The user's authorisation is what they wrote, not what you infer. The onboarding front-load gate already explicitly authorised "tens of minutes to several hours" — hold them to their own authorisation. |
-| "I'll run [subset] and report state — that's resume-friendly" | Resume is for budget-driven mid-pipeline stops, not for pre-emptive scope reduction at the start. The state file is a resume marker, not a scope-reduction certificate. |
-| "Running all 5 passes is excessive for this app" | The map's content drives scope, not the orchestrator's judgement of "excessive". If the map has 16 journeys, every pass dispatches 16 journeys. |
-| "I'll be honest with the user that I'm reducing scope" | Naming the violation does not undo the violation. "Honest scope compression" is still scope compression. The fix is not honesty — it is asking the user before reducing, or running the full pipeline. |
-| "16 individual reviewer dispatches is too many" / "Stage B is too expensive to dispatch per-journey" | The dispatch count is not the cost. Stage B is parallel by design — 16 reviewers in one wave, not 16 sequential calls. The skill mandates host-max parallelism for both Stage A AND Stage B (see §"Parallelism — Intra-group pipelining"). If you find yourself counting reviewer dispatches as if each were sequential, you are misreading the parallelism model. Dispatch the wave. |
-| "16 individual Stage A composer dispatches is too many — I'll group them by area" | The dispatch count is not the cost. Stage A is parallel by design — 16 composers in one wave, not 4 group agents each covering 4 journeys. Grouping is forbidden for P0/P1/P2 (only P3 may batch, capped at 7 — see §"Batched dispatch for P3 peripheral journeys"). If you find yourself writing dispatch briefs whose names are area buckets ("composer-auth", "composer-cart-orders") rather than journey IDs, you are batching against the rule. Re-do as N parallel single-journey dispatches. |
-| "These 4 journeys naturally cluster — 1 agent can handle them efficiently" | Natural clustering is page-co-residence, which the independence graph already accounts for at the parallelism layer. It is not authorisation to put N journeys in one brief. The dispatch shape is fixed: one journey per brief, period (P3 batching exception aside). |
-
----
+| [`references/depth-mode-pipeline.md`](references/depth-mode-pipeline.md) | Per-pass pipeline (steps 1–8), pass differences, commit-message conventions, per-pass completion criteria, whole-suite re-run gate, parallelism model, model selection (cost-blind), auto-compaction between passes, re-pass mode for compositional passes 2–3, batched dispatch for P3 peripheral journeys, post-pass-5 ledger dedup. |
+| [`references/dual-stage-retry-loop.md`](references/dual-stage-retry-loop.md) | The 7-cycle Stage A↔B retry loop pseudocode, termination conditions, "fresh reviewer every cycle" invariant, dual-stage-specific anti-rationalizations. |
+| [`references/state-file-schema.md`](references/state-file-schema.md) | `coverage-expansion-state.json` shape, per-journey `dispatches[]` entry fields including dual-stage fields, journey-roster mutability, corrupt-state-refusal protocol. |
+| [`references/subagent-isolation.md`](references/subagent-isolation.md) | Per-role dispatch contracts (compositional, adversarial, cleanup): isolation guarantees, brief inputs, `playwright-cli` session naming, the orchestrator's never-hold-payload-content rule. |
+| [`references/process-validator-workflow.md`](references/process-validator-workflow.md) | The sub-orchestrator pattern: when to invoke `process-validator-<scope>:`, manifest shape, validator review checklist, response shape (mirrors reviewer-return), parent's response handling. |
+| [`references/anti-rationalizations.md`](references/anti-rationalizations.md) | Failure-mode patterns the orchestrator and subagents must recognise (keyed by category, not surface phrasing). Each entry: name, symptoms, reality, enforcing hook (or `markdown-only`), origin. |
+| [`references/reviewer-subagent-contract.md`](references/reviewer-subagent-contract.md) | Stage B contract: role, inputs, must-fix calibration, hard constraints, the 7-step process. |
+| [`references/adversarial-subagent-contract.md`](references/adversarial-subagent-contract.md) | Stage A contract for passes 4–5: probe categories, negative-case matrix, ledger append protocol, regression-test authoring rules. |
+| [`../element-interactions/references/subagent-return-schema.md`](../element-interactions/references/subagent-return-schema.md) | Canonical return + ledger schema. §1 finding-return shape; §2 return states; §2.4 reviewer-return; §3 ledger schema; §4 caller contract; §4.1 grep-based conformance check; §4.2 harness validator (issue #127). |
 
 ## Reading order for new contributors
 
-A new orchestrator implementer or contract-modifier should read these files in dependency order:
+1. **This file** — orchestrator-side kernel: two valid exits, role prefixes, no-skip contract, mandatory intent declaration, modes table.
+2. **`references/depth-mode-pipeline.md`** — the bulk of how depth-mode actually runs.
+3. **`references/dual-stage-retry-loop.md`** — the per-journey retry-loop semantics that the per-pass pipeline drives.
+4. **`references/reviewer-subagent-contract.md`** — Stage B specifics.
+5. **`references/adversarial-subagent-contract.md`** — Stage A specifics for passes 4–5.
+6. **`../element-interactions/references/subagent-return-schema.md`** — the return + ledger schema both stages produce.
 
-1. **This file (`coverage-expansion/SKILL.md`)** — the orchestrator-side contract: passes, retry loop, parallelism, state file, completion criteria. This is the entry point.
-2. **`references/reviewer-subagent-contract.md`** — Stage B contract: role, inputs, must-fix calibration, hard constraints. Read this to understand what the reviewer actually does.
-3. **`references/adversarial-subagent-contract.md`** — Stage A contract for passes 4–5 (probe + ledger + regression). Read for the adversarial-side specifics.
-4. **`../element-interactions/references/subagent-return-schema.md`** — canonical return + ledger schema. §1 + §2 (incl. §2.4 reviewer-return) + §3 (ledger) define the shape both stages produce. §4 (Caller contract) is the orchestrator's obligations; §4.1 is the grep-based validation surface for both Stage A and Stage B returns.
+Stage A skills (`test-composer`, `bug-discovery`) have short "Role under dual-stage" awareness paragraphs near the top of their own SKILL.md files but no dual-stage-specific rules — their behaviour is unchanged from the single-stage era; they just know they will be reviewed.
 
 Stage A skills (`test-composer`, `bug-discovery`) have short "Role under dual-stage" awareness paragraphs near the top of their own SKILL.md files but no dual-stage-specific rules — their behaviour is unchanged from the single-stage era; they just know they will be reviewed.
 
@@ -248,130 +254,14 @@ This subsection extends §"Per-pass completion criteria" (see below). A pass's c
 
 ## Dual-stage per-pass contract
 
-Every one of the 5 passes runs **per journey** as two sequential stages:
+Every one of the 5 passes runs **per journey** as two sequential stages — Stage A (compose / probe) and Stage B (adversarial review). They alternate in a bounded 7-cycle retry loop until the journey reaches one of four terminal `review_status` values: `greenlight`, `blocked-cycle-stalled`, `blocked-cycle-exhausted`, or `blocked-dispatch-failure`. The full retry-loop pseudocode, termination conditions, the "fresh reviewer every cycle" invariant, and dual-stage-specific anti-rationalizations are specified in [`references/dual-stage-retry-loop.md`](references/dual-stage-retry-loop.md).
 
-- **Stage A — Compose / Probe.** The existing `test-composer` (passes 1–3) or adversarial probe subagent (passes 4–5). Dispatch contract unchanged from the single-stage era.
-- **Stage B — Adversarial Review.** A fresh staff-level-QA reviewer subagent, per journey, with its own isolated context and its own isolated `playwright-cli` session (`-s=<journey-slug>-stage-b`). Reads Stage A's output and the live app; returns `greenlight` or `improvements-needed`. Never writes tests, never appends to the ledger, never modifies files.
+Key invariants kept here:
 
-The dual-stage design addresses a concrete failure mode: a single subagent that both does the work AND self-certifies it misses scenarios a fresh independent reviewer would catch. Stage B is that independent reviewer. It exists to catch what Stage A missed.
-
-**Per journey per pass**, Stage A and Stage B alternate in a bounded retry loop up to 7 A↔B cycles (see §"Retry loop" below). Worst case: 7 A dispatches + 7 B dispatches = 14 per journey per pass.
-
-**Contracts:**
-- Stage A: unchanged from its skill (see `test-composer` for compositional passes, `references/adversarial-subagent-contract.md` for adversarial passes).
-- Stage B: see `references/reviewer-subagent-contract.md` for the full contract and dispatch-brief template.
-- Return shape: both stages use the canonical subagent-return-schema. Stage B's return states (`greenlight`, `improvements-needed`) are additions; Stage A's existing states are unchanged.
-
-**Cost posture.** This skill is **cost-blind**. The optimisation targets are completeness and speed, not dispatch cost. Default opus for every dispatch in every stage. The sonnet-for-P2/P3 heuristic from the prior design is removed; a narrow sonnet exception for cycle-1 Stage B confirmation on previously-greenlit journeys is documented in §"Model selection".
-
-**No-skip extension.** Under dual-stage, the no-skip contract (PR #105) extends: every journey must receive both Stage A and Stage B in every pass. A journey with Stage A but no Stage B is incomplete. The terminal `review_status` set gains three subagent-evidenced blocked values — `blocked-cycle-stalled`, `blocked-cycle-exhausted`, and `blocked-dispatch-failure` — per §"Retry loop" termination conditions. (These hyphenated forms are the canonical `review_status` enum used in the state file's `dispatches[]` array; the no-skip `result` field's `blocked (reason)` shape may carry these strings as the reason text, but `review_status` itself is the bare hyphenated form.)
-
-**Dual-stage no-skip rationalizations to reject:**
-
-| Excuse | Reality |
-|--------|---------|
-| "Stage A returned `covered-exhaustively` with full mapping evidence — no need to dispatch Stage B for this journey" | Stage A's `covered-exhaustively` is one of four valid Stage A returns; it does not authorise skipping Stage B. The reviewer is the verification, not Stage A's self-certification. Dispatch B. |
-| "Cycle 1 Stage B will obviously greenlight this trivial journey, I'll skip it and record `greenlight` in the state file" | Self-certifying greenlights without a reviewer dispatch is exactly the failure mode dual-stage was introduced to close. Dispatch the reviewer; if it really is trivial, sonnet-confirmation is the fast path documented in §"Model selection". |
-| "The journey was greenlit last pass with no map delta — skip the whole A↔B for this pass" | Every journey gets both stages every pass, full stop. Sonnet-confirmation reduces the cost of the trivial-greenlight case but does not eliminate the dispatch. |
-| "The pass is otherwise clean — leaving one journey without a Stage B return is fine, I'll record review_status anyway" | A `review_status` written without a Stage B dispatch having occurred is fabricated state — corrupts the state file, breaks resume, and lies to telemetry. Dispatch B or surface the gap. |
-
-### Retry loop (orchestrator, per journey per pass)
-
-For each journey in the current pass's roster, the orchestrator runs:
-
-```
-stage_a_input = base_brief                             # initial cycle-1 input
-history = []
-
-for cycle in 1..7:
-  try:
-    a_return = dispatch Stage A with stage_a_input
-  except DispatchFailure:                              # transport / timeout / malformed
-    review_status = "blocked-dispatch-failure"
-    break
-
-  if not validates(a_return, schema_§4.1):             # malformed content
-    re-dispatch once with same brief; if it fails again:
-      review_status = "blocked-dispatch-failure"
-      break
-
-  b_return = dispatch Stage B (fresh ctx, fresh playwright-cli session) to review a_return
-
-  if b_return.status == "greenlight":
-    review_status = "greenlight"
-    break
-
-  must_fix = b_return.findings  # every reviewer finding is must-fix; no other priority exists
-
-  if must_fix is empty:                               # status was "improvements-needed" but findings empty
-    re-dispatch reviewer once with stricter brief; if same shape returns:
-      coerce to "greenlight" (no findings = no changes needed)
-      review_status = "greenlight"
-      break
-
-  # Stall detection — fires on either signal:
-  #   (a) reviewer's self-flagged stalled: true (per reviewer-contract step 7), OR
-  #   (b) three cycles in a row with identical must-fix lists (i.e., the
-  #       current cycle and the two immediately-prior cycles all share the
-  #       same must-fix list, meaning Stage A failed to address it across
-  #       two consecutive retry attempts).
-  # One match (current == prior-1) is NOT enough: a reviewer in cycle N+1 may
-  # legitimately catch a finding the cycle-N reviewer missed, then cycle N+2's
-  # reviewer matches N+1's — cycle N+1 was real progress, not stall. Require
-  # current == prior-1 == prior-2 (two consecutive matches, three identical
-  # lists in total). identical_run counts current + each prior that matches,
-  # so the threshold is >= 3.
-  identical_run = 1
-  for prior in reversed(history):
-    if prior.must_fix == must_fix:
-      identical_run += 1
-    else:
-      break
-  if b_return.stalled == true or identical_run >= 3:
-    review_status = "blocked-cycle-stalled"
-    break
-
-  history.append({"cycle": cycle, "must_fix": must_fix})
-  stage_a_input = base_brief + b_return.findings
-
-if cycle == 7 and review_status is unset:
-  review_status = "blocked-cycle-exhausted"
-
-# Precedence note: if cycle 7's must_fix matches a stalled run, the loop breaks
-# on blocked-cycle-stalled BEFORE the post-loop check. Stalled wins over exhausted
-# when both apply — different downstream signal (re-pass trigger 4 wording,
-# telemetry calibration). This is intentional.
-
-record journey review_status + cycle count + final must_fix list in state file
-```
-
-**Termination conditions:**
-
-| Condition | `review_status` | Action |
-|---|---|---|
-| Reviewer returns `greenlight` | `greenlight` | Accept, commit this journey's work this pass. |
-| Reviewer returns `improvements-needed` with **empty** findings, twice in a row | `greenlight` (coerced) | Empty findings = no changes needed; the `improvements-needed` status was malformed. Coerce after one re-dispatch. |
-| Reviewer's `must-fix` list identical for **3+ cycles in a row** (current == prior-1 == prior-2) OR reviewer sets `stalled: true` | `blocked-cycle-stalled` | Escalate — Stage A failed to address this list across two consecutive retries. Commit whatever Stage A landed; log the unresolved list. **Takes precedence over exhausted** when cycle 7's list satisfies the same condition. |
-| Cycle 7 reached without greenlight (and not stalled) | `blocked-cycle-exhausted` | Escalate — retry budget spent. Commit whatever Stage A landed; log the unresolved list. |
-| Stage A dispatch fails (transport / timeout / malformed schema), re-dispatch also fails | `blocked-dispatch-failure` | Escalate — infrastructure issue, not a discipline issue. Commit nothing for this journey this pass; carries to next pass with the failure noted in trigger-4 input. |
-
-Both blocked statuses are valid terminal values under the no-skip contract (PR #105). They are **not** pass failures — they are visible deferrals. The orchestrator records the `must-fix` list to the state file and carries it forward to the next pass as an explicit Stage A input (see §"Re-pass mode" trigger 4).
-
-**Why 7 cycles.** Gives genuine room for adversarial iteration: first review catches obvious gaps, second fills subtler ones, third addresses what the reviewer missed the first read. The bounded cap prevents runaway loops while leaving enough slack that exhaustion is the exception rather than the common case. The same numeric value (7) appears as the P3 batch cap in §"Batched dispatch for P3 peripheral journeys" — these two 7s are **independent design choices** that happen to share a number. Changing one does not require changing the other; the rationales are unrelated (cycle cap = adversarial-iteration-budget; batch cap = brief-size-and-per-journey-attention-budget).
-
-**Fresh reviewer every cycle.** Every Stage B dispatch is a fresh subagent with a fresh `playwright-cli` session — no context inheritance from the prior cycle's reviewer, no context inheritance from the paired Stage A. The fresh-eyes property is load-bearing; if the reviewer carries state across cycles, it will start agreeing with Stage A.
-
-**Rationalizations to reject:**
-
-| Excuse | Reality |
-|--------|---------|
-| "Cycle 3 has the same must-fix list but I think Stage A could fix them with one more try" | If the list is identical, Stage A has already failed to address these items with the same inputs twice. `blocked-cycle-stalled` is the correct terminal state; human or follow-up-pass attention is the next step. |
-| "Reviewer returned improvements-needed but the must-fix list is small; I'll skip the retry" | A single `must-fix` item is enough to block greenlight. Retry with the findings appended. |
-| "I'll compact findings from cycles 1–4 into one summary string for cycle 5's input" | Compressed findings lose the surgical specificity Stage A needs to fix them. Pass the full findings through verbatim. |
-| "Cycle 7 exhausted and I'll just call it greenlit to keep the pass moving" | `blocked-cycle-exhausted` is the correct terminal. Marking it greenlit when it isn't corrupts the state file and the next pass's trigger-4 input. |
-| "Reviewer disagrees with itself between cycles 1 and 2; I'll pick the more lenient one" | Each cycle's reviewer is fresh and independent. Take each cycle's output as-is; the retry-loop logic handles divergence via the stalled/exhausted checks. |
-
----
+- **Both stages, every journey, every pass.** A `review_status` written without a Stage B dispatch is fabricated state and breaks resume.
+- **Stage B is fresh-eyes per cycle.** Each cycle dispatches a new reviewer with a new context and a new `playwright-cli` session. State carried across cycles defeats the design.
+- **Cap of 7 A↔B cycles per journey per pass.** Stalled (3 consecutive identical must-fix lists, OR reviewer-flagged stalled) wins over exhausted when both apply on cycle 7.
+- **Dual-stage no-skip extension** to the no-skip contract: every journey gets both stages every pass.
 
 ## Prerequisites
 
@@ -410,63 +300,14 @@ The declaration also serves as the auditable record of *why* a partial run, if a
 
 ## Authoritative state file — read first, always
 
-The skill's **first action on entry**, before anything else, is to read `tests/e2e/docs/coverage-expansion-state.json`. Resumption is a contract, not a convention.
+The skill's first action on entry is to read `tests/e2e/docs/coverage-expansion-state.json`. The full schema (top-level fields, per-journey `dispatches[]` entry shape including dual-stage fields, journey-roster mutability rules, and the corrupt-state-refusal protocol) is specified in [`references/state-file-schema.md`](references/state-file-schema.md). Resumption is a contract, not a convention — read it before authoring or modifying any state-file-touching code.
 
-```
-1. Read tests/e2e/docs/coverage-expansion-state.json.
-2. If the file is absent, or status == "complete", start Pass 1 from scratch.
-3. If currentPass is set, resume from that pass's journey roster.
-4. Skip journeys already marked complete in the state file for the current pass.
-5. Only when all 5 passes + cleanup show complete, return "coverage-expansion finished".
-```
+Key invariants kept here:
 
-The state file is authoritative. The orchestrator must not reason about "where did we leave off" from chat history, commit log, or journey-map deltas — those are diagnostic, not authoritative. If the file says currentPass=3 with 22 of 45 journeys complete, Pass 3 resumes with the remaining 23 journeys and Pass 4/5/cleanup run afterwards.
-
-State file shape (minimum fields):
-
-```json
-{
-  "status": "in-progress",
-  "currentPass": 3,
-  "journeyRoster": ["j-...", ...],
-  "completedJourneys": ["j-...", ...],
-  "inFlightJourneys": ["j-...", ...],
-  "dispatches": [
-    {
-      "journey": "j-<slug>",
-      "stage_a_cycles": 2,
-      "stage_b_cycles": 2,
-      "review_status": "greenlight",
-      "final_must_fix": [],
-      "result": "new-tests-landed",
-      "authorizer": null
-    }
-  ],
-  "adversarialTotals": { ... },
-  "updatedAt": "2026-04-24T..."
-}
-```
-
-**Per-journey dispatch entry fields (dual-stage).** Each entry in `dispatches[]` carries:
-
-- `journey` — the journey ID (`j-<slug>`).
-- `stage_a_cycles` — integer; number of Stage A dispatches for this journey in this pass (1..7).
-- `stage_b_cycles` — integer; number of Stage B dispatches for this journey in this pass (equal to or one less than stage_a_cycles depending on whether cycle 7 exhausted or greenlit early).
-- `review_status` — one of `greenlight | blocked-cycle-stalled | blocked-cycle-exhausted | blocked-dispatch-failure`.
-- `final_must_fix` — array of finding-IDs. Empty for `greenlight`; populated for blocked statuses with the list Stage A failed to resolve (carried to next pass's Stage A brief as trigger 4).
-- `result` — the no-skip contract enum value (`new-tests-landed | covered-exhaustively | blocked | skipped`). `result` describes Stage A's outcome alongside the no-skip enum; `review_status` describes Stage B's judgement; together they describe both stages' outcomes.
-- `authorizer` — only non-null for `skipped` (requires user authorisation).
-- `batch_id` — nullable string. Non-null when this journey was part of a batched Stage A dispatch (per §"Batched dispatch for P3 peripheral journeys"); the `batch_id` value is shared across every journey in the same batch so resume logic can reconstruct the batch grouping. Null for individually-dispatched journeys. When a journey breaks out of a batch mid-cycle (any cycle ≥ 2 after its Stage B returned `improvements-needed`), `batch_id` becomes null from cycle 2 onward — the cycle-1 batched entry retains the original `batch_id`, the cycle-2+ individual entry does not. `stage_a_cycles` is recorded per-journey in both cases.
-
-A state file missing `stage_a_cycles`, `stage_b_cycles`, or `review_status` for any journey that has run this pass is incomplete — resume logic treats it as corrupt per the existing §"State-file lifecycle" rule.
-
-The state file is rewritten after every per-pass commit (and whenever auto-compaction triggers — see §"Auto-compaction between passes" below).
-
-**Journey-roster mutability.** The roster for a given pass is frozen at the start of that pass — it is a snapshot of the journey IDs the orchestrator intends to dispatch *this pass*. If a compositional pass discovers and promotes a new journey or sub-journey mid-pass, the new entry is appended to the **next** pass's roster, not retroactively to the current pass's. This prevents the "did I cover everything?" ambiguity where `journeyRoster` and `completedJourneys` diverge because the roster keeps growing. Reconciliation commits (Pass 2/3) write the new roster to the state file at the same commit that appends the new map blocks, so the post-compact resume reads a consistent roster-to-map alignment.
-
-**Corrupted or stale state file.** If the state file is present but references journeys that no longer appear in `journey-map.md`, or if `currentPass` is set but `completedJourneys` is a superset of `journeyRoster`, the orchestrator stops and reports the mismatch to the caller rather than guessing. Self-repair is out of scope — a corrupted state file is a manual-triage signal, not a silent reset.
-
----
+- **Read first, before anything else.** If currentPass is set, resume from that pass; if absent or `status == "complete"`, start Pass 1 from scratch.
+- **The file is authoritative.** Do not reason about "where did we leave off" from chat history, commit log, or journey-map deltas — they are diagnostic, not authoritative.
+- **State-file lifecycle.** Write after every per-pass commit + every auto-compaction trigger. Delete after successful 5-pass + cleanup completion (otherwise the next invocation mistakes a completed run for a resume).
+- **Corrupt-state stops the run.** Self-repair is out of scope — surface the mismatch to the caller.
 
 ## Modes
 
@@ -479,268 +320,15 @@ The state file is rewritten after every per-pass commit (and whenever auto-compa
 
 ## Depth mode — five-pass pipeline (3 compositional + 2 adversarial) + cleanup
 
-Each pass runs a journey-by-journey pipeline with parallel dispatch where independent. The map grows between compositional passes; the adversarial ledger grows during adversarial passes. After pass 5, a single cleanup subagent dedupes the ledger.
-
-### Per-pass pipeline
-
-Every pass in depth mode runs this pipeline; steps 4 and 7 differ between compositional (1–3) and adversarial (4–5) passes.
-
-1. **Read the map** (sentinel-verified). Build an in-memory index: `[(j-id, priority, pages-touched, test-expectations)]`. Read **only** these fields per journey — not full step lists, branches, or state variations.
-2. **Recompute priority ordering.** Honour the map's priorities, but if a journey's `Test expectations` or pages touched have changed since the last pass, adjust position.
-3. **Build the journey independence graph.** The graph is the same across compositional and adversarial passes.
-4. **Emit the per-pass scope preview** (see §"Per-pass scope preview"). Declarative only; no confirmation prompt. The scope preview names the dual-stage dispatch band (see that section).
-5. **Run the per-journey dual-stage retry loop** for every journey in the map — parallel for independent journeys, sequential for dependent ones, per §"Parallelism". Each journey's A↔B loop follows §"Retry loop (orchestrator, per journey per pass)". The loop terminates when the journey has one of the four terminal `review_status` values.
-   - Model selection per §"Model selection" — default opus for both stages.
-   - P3 batching narrowed per §"Batched dispatch for P3 peripheral journeys" — Stage A may be batched; Stage B never is.
-6. **Collect all journey outputs.** Each journey contributes: its committed test files (from the final greenlit or blocked-with-tests-landed Stage A cycle), its `review_status`, its cycle counts, and (if blocked) its final `must-fix` list. The orchestrator does NOT hold Stage A test source or Stage B review bodies — only structured summaries and the on-disk file paths.
-7. **Reconcile artefacts.**
-   - **Compositional passes:** reconcile the map. Append new branches to existing journey blocks. Add new `j-<slug>` or `sj-<slug>` blocks for newly-discovered journeys or sub-journeys. Append new pages/elements to `app-context.md`. Run a mini Phase 3.5 revision (see `journey-mapping`) if the pass introduced new overlaps.
-   - **Adversarial passes:** the map is NOT reconciled. The ledger file is authoritative; its content is already written by the subagents during their append step. Aggregate the return summaries into the orchestrator's running adversarial-totals counter (journeys probed, boundaries verified, suspected-bug count by severity, regression tests added).
-8. **Commit, then update state file.** One commit per journey (compositional passes) or per journey per pass (adversarial passes). See §"Commit-message conventions" below for the exact templates. After the commit lands, rewrite `tests/e2e/docs/coverage-expansion-state.json` with the new pass counter, per-journey `dispatches[]` entries (including `stage_a_cycles`, `stage_b_cycles`, `review_status`, `final_must_fix`), and adversarial totals. Then run the auto-compaction check (§"Auto-compaction between passes") before the next pass's dispatch.
-
-### Pass differences
-
-| Pass | Kind | Purpose |
-|---|---|---|
-| 1 — initial perception | compositional | Cover the map as produced by `journey-mapping`. Priorities as written. Each journey gets its full variant set (per `Test expectations:`). Map grows with whatever surfaces. Dispatches `test-composer` per journey. |
-| 2 — map-growth widening | compositional | Re-read the enriched map. Promote newly-discovered branches and sub-journeys to first-class journeys where they warrant it. Re-evaluate priorities. Re-attempt any journey where pass 1 deferred stabilization or returned coverage gaps. Dispatches `test-composer` per journey. |
-| 3 — consolidation | compositional | Final sweep on the refined map. Focus on cross-journey interactions, residual gaps, data-lifecycle variants that require wiring multiple journeys together, and any journey whose map block was materially refined in pass 2. Dispatches `test-composer` per journey. |
-| 4 — adversarial probing | adversarial | One adversarial turn per journey. Dispatches a probe subagent (see `references/adversarial-subagent-contract.md`) that invokes `bug-discovery` scoped to the journey. The probe covers the full QA-engineer test matrix for the journey — a deterministic negative-case complement for every positive `Test expectations:` entry plus cross-cutting negatives (auth tamper, tenant isolation, idempotency, session boundary, input boundaries) — in addition to `bug-discovery`'s open-ended categories. Findings are appended to `tests/e2e/docs/adversarial-findings.md` — no tests are written in pass 4. |
-| 5 — adversarial consolidation | adversarial + regression | Second adversarial turn. Each subagent reads its journey's pass-4 ledger section, re-probes any negative-case-matrix entries that returned `Ambiguous`, attempts compound probes that combine matrix entries (e.g., auth-tamper × idempotency, tenant-isolation × session-boundary), and writes **passing** regression tests for every verified boundary (pass 4 + pass 5 combined) into `j-<slug>-regression.spec.ts`. Suspected bugs remain ledger-only — never committed as `test.fail()`. |
-
-After pass 5: one single-dispatch cleanup subagent dedupes the ledger. See §"Ledger dedup" below.
-
-### Commit-message conventions
-
-One journey per commit, one template per pass kind. Agents MUST NOT reinvent the format — the git log has to be filterable by `<j-slug>` and by pass kind.
-
-| Pass / phase | Commit-message template | Notes |
-|---|---|---|
-| Compositional passes (1–3) | `test(<j-slug>): <variant>` | One journey per commit, always. `<variant>` names the variant added (e.g. `happy-path`, `error-states`, `mobile`, `data-lifecycle`). If a single composer invocation adds multiple variants, produce one commit per variant. |
-| Adversarial pass 4 | `docs(ledger): <j-slug> — N probes, M boundaries, K suspected bugs` | One commit per journey. Commit diff is the ledger file only. `N`, `M`, `K` come from the subagent return's structured summary. |
-| Adversarial pass 5 — regression | `test(<j-slug>-regression): lock <boundary-description>` | One commit per verified-boundary regression test authored. `<boundary-description>` is a short phrase naming the boundary being locked (e.g. `empty-cart-checkout-rejected`, `nav-cart-badge-clears-after-checkout`). |
-| Cleanup (post-pass-5 dedup) | `docs(ledger): dedupe cross-cutting findings` | Single commit from the one cleanup subagent. |
-
-**Stage B returns do NOT produce their own commits.** Reviewer judgements are captured in the state file's per-journey `review_status` and `final_must_fix` fields — never as commits. The git log records what landed (Stage A's tests, ledger entries, regression locks) but not the review trail; the state file records the review trail. Mixing reviews into commits creates a diff-noisy log that obscures the actual change history.
-
-Anti-patterns — do NOT use:
-- `test(pass5): j-xxx — <summary>` (pass number goes in the `-regression` suffix, not the scope)
-- `feat(e2e): …` (coverage expansion is never `feat`)
-- `test(j-xxx, j-yyy): …` (one journey per commit — no multi-journey commits even when batched)
-- `review(j-xxx): …` or any review-tagged commit (Stage B never commits — see above)
-- `fix(…): …` for new tests (use `test(…)`; `fix` is for fixing existing code)
-
-### Per-pass completion criteria
-
-A pass is complete only when **every** criterion for that pass is met. "Ran some journeys, ran out of budget" is not complete — see §"Non-negotiables for depth mode" for the resume-state contract.
-
-- **Pass 1** complete = `test-composer` has been dispatched for and has returned on **every** journey in the map. Not "enough journeys", not "the P0/P1 tier", not "the journeys that fit the budget". Every journey.
-- **Pass 2** complete = `test-composer` has been re-dispatched and returned for every journey, AND the map has been reconciled with any newly-promoted branches or sub-journeys surfaced in pass 1 or 2, AND — if the reconciliation produced map edits — the reconciliation commit has landed. If no map edits were needed, the pass still completes, but the orchestrator records `"pass 2 reconciliation — no map edits required"` in the state file / progress log rather than silently skipping the commit.
-- **Pass 3** complete = cross-journey and data-lifecycle variants have been dispatched for every journey whose `Test expectations:` calls for them, AND any journey that returned residual coverage gaps in passes 1 or 2 has been re-attempted, AND the pass commit has landed (if tests were added in this pass).
-- **Pass 4** complete = the adversarial-probe subagent has run per journey with `pass=4`, and each subagent's findings have been appended to `tests/e2e/docs/adversarial-findings.md`. If no probes landed for a given journey (e.g., the subagent found nothing to probe or was gated), the orchestrator records `"no boundaries probed — <reason>"` for that journey in the ledger — it does NOT silently skip the journey. An empty ledger section for a journey is a bug, not a pass-4 completion state.
-- **Pass 5** complete = every verified pass-4 finding has either a committed regression test in `j-<slug>-regression.spec.ts` OR an explicit decline-with-reason line in the ledger ("no regression written — finding classified as suspected bug / ambiguous / duplicate of cross-cutting #N"). Regression-test files are committed per journey.
-- **Cleanup** complete = one cleanup subagent has run once, cross-cutting findings are consolidated into the top-level section with backrefs in each journey's section, and the commit `docs: adversarial-findings — dedupe cross-cutting findings` has landed.
-
-Only when **all** of the above are true may the orchestrator report depth-mode coverage-expansion complete to its caller. Anything less is a partial run and must be reported as such (see the resume-state contract).
-
-**Dual-stage extension.** On top of the per-pass criteria above, a pass is complete only when **every journey has a terminal `review_status`** (`greenlight`, `blocked-cycle-stalled`, `blocked-cycle-exhausted`, or `blocked-dispatch-failure`) recorded in the state file's `dispatches[]` array. A pass where every journey's Stage A returned but some journeys have no `review_status` is **incomplete**, even if the per-pass criteria above appear satisfied. Stage B participation is part of the completion gate, not optional.
-
-### Whole-suite re-run gate (per-pass exit)
-
-After a pass's per-journey subagents return clean and per-pass completion criteria are satisfied, run the whole-suite re-run gate documented in `../element-interactions/references/test-optimization.md` §7.
-
-**Procedure:** identical to the canonical procedure documented in `../element-interactions/references/test-optimization.md` §7. Summary:
-
-1. From the harness root: `npx playwright test --reporter=json > .stage4a-suite.json`.
-2. Parse the JSON. Playwright's reporter writes `{ stats: { expected, unexpected, flaky, skipped, ... }, suites: [...] }`. Refuse to advance to the next pass if:
-   - `stats.unexpected > 0` (includes timed-out, failed, interrupted), OR
-   - `stats.skipped` exceeds the count of explicit `test.skip(` markers across spec files (`grep -rh '^\s*test\.skip\b' tests/e2e --include='*.spec.ts' | wc -l`).
-3. On refusal, return `{ status: 'whole-suite-gate-failed', pass: <N>, stats: {...}, failures: [...], skips_unexplained: <delta> }` and DO NOT invoke the next pass. Resume on this pass once the caller resolves the failures.
-4. Delete `.stage4a-suite.json` after parsing.
-
-**Why it runs here:** per-journey subagent stabilization confirms each journey's tests pass in isolation, but cumulative state across the suite (DB pollution, port collisions, fixture drift, shared-resource depletion) only surfaces when the whole suite runs together. Running this gate at every pass exit catches integration-time regressions at the earliest pass that introduces them, rather than at end-of-pipeline.
-
-### Parallelism
-
-The parallelism model has three layers:
-
-#### Independence graph (unchanged semantics)
-
-Two journeys are **dependent** if they touch a non-universal page in common. Universal pages (login, homepage, global nav) are ignored. Independent journeys can run in parallel; dependent ones must serialize to avoid tab-sharing corruption.
-
-Co-residence on pages is the only dependency signal. Two journeys that both touch `/admin/users` are dependent even if one only reads and one mutates — tab sharing is the bug, not data-layer contention.
-
-#### Intra-group pipelining (dual-stage)
-
-Within an independence group:
-- **Both stages are parallel by default.** Stage B is not a serial follow-up to Stage A — it is dispatched per-journey-as-soon-as-Stage-A-returns, sharing the parallel pool with sibling journeys' Stage A retries. An orchestrator that finishes Stage A for the whole pass and then begins Stage B serially is implementing a different (slower, contract-violating) protocol.
-- All journeys in the group start Stage A concurrently (subject to the parallel cap — see below).
-- Each journey's Stage B fires **as soon as that journey's Stage A returns** and the parallel cap has a slot — not after the whole group's Stage A completes.
-- Each journey's Stage A retry fires **as soon as that journey's Stage B returns with `improvements-needed`** and the cap has a slot.
-- Journeys in the same group ride their own A↔B pipelines in parallel. A journey on cycle 3 and a sibling on cycle 1 coexist.
-
-Across independence groups: groups run in priority order, each group exhausting parallelism before the next group starts.
-
-#### Parallel cap — lifted and jointly applied
-
-Previous: `min(4, credentials-per-role)` with batching for P3.
-New: **`host max`** — the orchestrator uses whatever parallel width the dispatch primitive allows. An explicit user override is accepted (`args: "parallel-cap: 8"`), otherwise no artificial ceiling beyond the shared-resource audit's credential-contention findings (PR #106).
-
-**The cap counts Stage A and Stage B dispatches jointly.** There is one pool of in-flight subagent slots; A and B compete for the same slots within a group. A journey's own A and B never overlap (sequential within a journey), but across journeys any A/B interleaving is possible. When the cap is saturated, new dispatches — whether A, B, or A-retry — queue until a slot frees. Queue order is FIFO; the orchestrator does not prioritise A over B or vice versa.
-
-#### Shared-resource audit interaction
-
-The Phase-0 shared-resource audit (PR #106) still caps parallelism where the app genuinely can't tolerate more (single credential per role, rate limits, CSRF serialization). Those caps override the cost-blind default. The audit's constraint tags apply to Stage A AND Stage B equally — reviewers compete for the same credentials.
-
-### Model selection (cost-blind posture)
-
-Default model for every dispatch in every stage in every pass: **opus**.
-
-The prior sonnet-for-P2/P3 heuristic is removed. The prior sonnet-for-small-journey override is removed. Model choice does not vary by priority, journey size, step count, or pass number — opus by default, everywhere.
-
-**Narrow exception — cycle-1 Stage B sonnet confirmation.** For a journey that greenlit in the previous pass AND has no map delta since that pass AND no sibling-bug ledger update pointing at it, the cycle-1 Stage B MAY run sonnet as a fast confirmation. If sonnet returns `greenlight`, accept. If sonnet returns `improvements-needed`, immediately re-run the same review on opus — the opus result is authoritative, sonnet's was indicative. This is a latency optimisation, not a cost-reduction mechanism; it exists because a confirmed-greenlit journey's cycle-1 review is often trivially "still looks good" and a sonnet confirmation is fast.
-
-**Override: promote on failure.** Any journey that returned a stabilization or coverage-verification failure in a prior pass runs on opus for every dispatch (A and B) in every subsequent pass, regardless of cycle. No sonnet exception applies once a journey has failed.
-
-**For adversarial passes (4 and 5):** always opus, both stages. The sonnet exception above does NOT apply to adversarial passes — adversarial review requires judgment that sonnet reliably under-produces.
-
-**Rationalizations to reject:**
-
-| Excuse | Reality |
-|--------|---------|
-| "The journey was attempted last pass and ended at `blocked-cycle-stalled` / `blocked-cycle-exhausted` / `blocked-dispatch-failure` — that counts as 'previously-greenlit' for the sonnet exception" | A blocked journey is not greenlit. The narrow exception requires explicit `greenlight` in the previous pass, not "attempted." Any blocked-* terminal in the prior pass means opus on cycle 1 of the next pass. |
-| "Pass 4 is just probing, sonnet is good enough for cycle-1 of small journeys" | Pass 4 and Pass 5 are always opus, both stages, full stop. The model-selection cost-blind rule has no priority/size carve-outs. |
-| "I ran sonnet for Stage A and opus for Stage B — that's a hybrid we never explicitly forbade" | Stage A is opus for every dispatch in every pass. The narrow sonnet exception is for cycle-1 Stage B only on previously-greenlit journeys. Hybrid Stage A/Stage B model splits beyond that exception are not authorised. |
-
-Before every pass dispatch (step 4 of the per-pass pipeline), emit a declarative scope preview. The preview is informational only — there is no confirmation prompt, no timeout, no abort option, and no reduce-scope offer. The contract is every journey, every pass; the preview makes that contract explicit so any mid-pass rationalisation is visible against the declared scope.
-
-Template (values filled in per pass, from the map index, independence graph, and dispatch heuristic):
-
-```
-[coverage-expansion] Pass <N>/5 — dispatching <test-composer | adversarial probe> per journey
-  Journeys: <count> (<delta-note, e.g., "3 newly promoted in pass <N-1>">)
-  Independence graph: <G> groups, <K>-way parallel dispatch possible (cap <C>)
-  Model mix: opus default for every Stage A and Stage B dispatch; narrow cycle-1 Stage B sonnet-confirmation exception may apply to ~<sonnet-count> previously-greenlit journeys (see §"Model selection").
-  Expected wall-clock: ~<H>h at <K>-parallel
-  Contract: every journey, this pass. No skips. No batching beyond the explicit P3-batching allowance.
-```
-
-The model-mix figures derive from §"Model selection" — opus is the default across A and B, so the `<sonnet-count>` reports only the narrow cycle-1 Stage B confirmation exception (previously-greenlit journeys with no map delta). The wall-clock estimate is a ballpark from the per-subagent run times observed so far this run (or a default of ~20 min per opus dispatch if no prior data exists — sonnet-confirmation cycles don't get their own ballpark because they're a fast-path variant of the normal Stage B dispatch).
-
-Completion check: if a pass starts with N journeys and ends with returns from fewer than N, the orchestrator must re-dispatch the missing journeys before claiming the pass is complete. The preview's journey count is the ground truth for the end-of-pass reconciliation.
-
-### Auto-compaction between passes
-
-Between passes — after the per-pass commit and state-file rewrite (step 8), before the next pass's dispatch — the orchestrator checks its own context usage. Context exhaustion is a transparent seam, not a pipeline-halt.
-
-If the orchestrator's context is **>70% consumed**:
-
-1. Write full state to `tests/e2e/docs/coverage-expansion-state.json` (journey roster, completed IDs, in-flight IDs, pass counter, adversarial totals, AND the dual-stage `dispatches[]` per-journey fields — `stage_a_cycles`, `stage_b_cycles`, `review_status`, `final_must_fix` — the shape documented in §"Authoritative state file — read first, always"). The dual-stage fields MUST be written before the compaction crosses; without them the post-compact resume cannot reconstruct which journeys are mid-A↔B-cycle, which are blocked, or which are greenlit.
-2. Emit exactly one line: `[coverage-expansion] context approaching budget — auto-compacting and resuming from state file`.
-3. Invoke `/compact` (or the platform-equivalent compaction primitive exposed to the orchestrator).
-4. On the post-compact turn, the skill's first action — reading the state file — picks up the run exactly where it left off, including any in-flight A↔B cycles. That's why §"Authoritative state file" is non-negotiable as the first action.
-
-**Mid-cycle compaction.** The 70% threshold is checked between passes by default, but if a single journey's A↔B retry loop pushes context past 70% mid-pass, the same flow applies: write state with the in-progress `stage_a_cycles` / `stage_b_cycles` / latest reviewer findings, then compact.
-
-**In-flight Stage A returns must be persisted before compaction.** §10 of the design spec says the orchestrator never holds Stage A test source or Stage B review bodies in steady state — but during the brief window between Stage A return and Stage B dispatch, the Stage A return body is necessarily in orchestrator memory. If compaction crosses during that window, the return body would be lost. Mitigation: when an A↔B cycle is mid-flight at compaction time, the orchestrator **persists the latest Stage A return to a scratch file** at `tests/e2e/docs/.coverage-expansion-cycle-<journey-slug>-cycle-<N>.json` before compacting. The post-compact resume reads this scratch file as if it were a fresh Stage A return and proceeds to Stage B dispatch. The scratch file is deleted after the cycle terminates (any of the four `review_status` values) and the per-pass commit lands. Mid-cycle restart from Stage A is NOT acceptable — it would re-run a potentially expensive opus dispatch and lose the discipline gain from the prior cycle's reviewer findings.
-
-**Platform note.** If no programmatic compaction primitive is available to the orchestrator, the skill must still make the seam safe for manual compaction: emit an unambiguous `[coverage-expansion] safe to compact — state is durable at tests/e2e/docs/coverage-expansion-state.json, resume with the same invocation args` line between passes whenever the >70% threshold is crossed. The user can then compact manually without losing progress, and the next turn resumes from the state file the same way.
-
-Framing: this is a platform-aware seam for long runs. It is not a cost-reduction mechanism. The optimisation target remains complete coverage; auto-compaction exists so complete coverage doesn't get halved by a context ceiling.
-
-**Rationalizations to reject:**
-
-| Excuse | Reality |
-|--------|---------|
-| "Context is at 75% but I can push one more pass before compacting" | 70% is the floor, not a guideline. Every pass adds subagent-return summaries that grow the state file and the running adversarial totals. One more pass from 75% often lands at 95%+ and forces an in-pass compact that loses roster state not yet committed. |
-| "I'll compact at 50% to be safe" | Preemptive compaction destroys the prompt cache unnecessarily. 70% is the threshold because below it the seam costs more than it saves. |
-| "The state file is small, there's nothing to save before compacting" | The state file is not the point — the orchestrator's own context (subagent returns, map index, reconciliation scratch) is. State is written *so* compaction is safe. Skipping the write because "state is small" is the bug. |
-| "I'll run Pass 4 to finish the compositional-to-adversarial boundary, then compact" | The compositional-to-adversarial boundary is inside the pass loop, not at 70%. If the threshold was crossed before Pass 4, compact before Pass 4. |
-| "Auto-compact failed once so I'll skip it this time" | The fallback is the manual-compaction safe-seam message, not silent progression. If `/compact` errors, emit the safe-compact line and stop; the user compacts and re-invokes. Never continue past 70% without either auto- or manual-compaction. |
-
-### Re-pass mode for compositional passes 2–3
-
-Passes 2 and 3 dispatch `test-composer` with an explicit `mode: re-pass` argument. Pass 1 already composed the journey's full variant set; re-pass work is valuable only as a disciplined audit against three specific triggers.
-
-**Preamble embedded in every pass-2 / pass-3 test-composer brief:**
-
-> You are a re-pass subagent. Pass 1 already composed this journey. Pass 2/3 work is valuable only when:
-> - The journey map was materially enriched since Pass 1 (look for delta markers against the pre-pass journey block).
-> - The journey's Pass-1 return reported `coverage-gaps: [...]` or `stabilization: deferred`.
-> - A sibling journey surfaced a bug that should be regressed here too.
-> - The prior pass's Stage B reviewer flagged `must-fix` items that Stage A did not resolve (the journey's `review_status` was `blocked-cycle-stalled` or `blocked-cycle-exhausted` last pass). Those unresolved findings are embedded in your brief — address them.
->
-> You must perform the full inspection regardless — read the current journey block, read the Pass-1 return, read any sibling-bug ledger entries. Only *after* inspection may you return `status: covered-exhaustively` with:
-> - a per-expectation mapping table showing which test covers which Pass-1 expectation,
-> - an explicit check against each of the four triggers above ("trigger 1: no delta markers since Pass 1", "trigger 2: Pass-1 return reported no gaps or deferred stabilization", "trigger 3: sibling-bug ledger contains no regression candidates for this journey", "trigger 4: no unresolved review findings carried forward from the prior pass"),
-> - no unexplained shorthand.
->
-> **No tool-use budget. No tool-use cap.** Cost is not the optimisation target; signal quality is. The value of a re-pass is disciplined evidence that Pass 1 was exhaustive. An undisciplined cheap no-op is worse than a thorough no-op.
-
-The re-pass mode's contribution is **disciplined justification**, not speed. Every return becomes an auditable artifact — either new tests with their rationale, or `covered-exhaustively` with the full mapping table and the three-trigger check. The orchestrator rejects any pass-2 / pass-3 return that does not include the per-expectation mapping and the three-trigger check, and re-dispatches that journey.
-
-**Rationalizations to reject (subagent side):**
-
-| Excuse | Reality |
-|--------|---------|
-| "Obvious no-op — I'll mark `covered-exhaustively` without reading Pass-1 returns" | The three-trigger check requires evidence. Fabricating "Pass-1 reported no gaps" without reading the return is the exact failure the orchestrator's rejection-and-redispatch step is designed to catch; the redispatch wastes more time than reading the return would have. |
-| "The mapping table is obvious, I'll shorthand it" | Shorthand fails the orchestrator's check. The mapping table enumerates each expectation with the specific test covering it — not "all covered by existing tests". One-line-per-expectation or redispatch. |
-| "Sibling-bug ledger is probably empty for this journey, skip it" | The check is "I read the ledger and found no regression candidates for this journey", not "I assumed there are none". Skipping the read is skipping the trigger. |
-| "No tool-use budget means I can spam tool calls freely" | "No budget" is a signal that signal quality matters more than cost; it is NOT an invitation to over-probe. Use the tools needed to satisfy the three triggers and no more. |
-| "Pass 1 was thorough so Pass 2/3 is always `covered-exhaustively`" | The three triggers explicitly include "map delta since Pass 1" and "sibling-bug regression candidate" — conditions that can only be evaluated at Pass 2/3 time, not inherited from Pass 1's confidence. The returning-it-without-inspection shortcut voids the pass. |
-
-**Orchestrator-side rejection check.** When a pass-2 or pass-3 return arrives, the orchestrator greps the return for (a) the literal strings "trigger 1", "trigger 2", "trigger 3", "trigger 4", (b) a mapping-table header row, and (c) per-expectation entries. If any is missing the orchestrator re-dispatches the journey with a brief explicitly quoting the rejected parts. The orchestrator does NOT accept partial returns as a concession to save re-dispatch cost — the discipline holds on both sides.
-
-### Batched dispatch for P3 peripheral journeys
-
-**Reminder: P3 only. P0/P1/P2 never batch.** Adjacent low-impact journeys — typically P3 smoke or admin-portal siblings sharing one Playwright project — MAY have Stage A batched into a single brief, cap 7 journeys per brief. Every other journey (P0, P1, P2) dispatches one subagent per journey, full stop. If you are tempted to batch a P0/P1/P2 journey because it "shares pages with P3 siblings" or "fits naturally with this group", STOP — that temptation is the failure mode this section's narrowness exists to prevent. Re-read §"Stage A per-journey dispatch is non-negotiable" before continuing.
-
-Dual-stage narrows this:
-
-- **Stage A may still be batched** for eligible P3 journeys (shared project, no pending gap flags, same priority tier, cap 7 per brief — criteria from PR #108).
-- **Stage B is never batched.**
-  Each journey in a batched Stage A still gets its own dedicated Stage B reviewer — never one reviewer judging 7 journeys at once.
-  The reviewer reads only its assigned journey's slice of the batched Stage A return; the reviewer itself is never responsible for multiple journeys.
-- Batching is accepted ONLY when every journey in the batch's cycle-1 Stage B returns `greenlight`.
-- If any journey's cycle-1 Stage B returns `improvements-needed`: split the batch. From cycle 2 onward, the affected journey breaks out and runs its own per-journey Stage A plus its own Stage B. The batched cycle-1 Stage A return is retained as history input to the broken-out cycle-2 Stage A brief. The remaining greenlit journeys in the batch stay accepted at cycle 1 and proceed.
-
-**Rationalizations to reject:**
-
-| Excuse | Reality |
-|--------|---------|
-| "This 8th journey is almost identical to the 7 in the batch, I'll include it" | Cap 7 is not negotiable. Split the batch (5 + 3, etc). The cap bounds brief size and per-journey attention. |
-| "All these journeys are P3 and share a project, and this admin journey *could* be grouped — skip the P1 carve-out" | P0 / P1 always dispatch individually. Priority is load-bearing; a journey at P1 deserves its own brief even if it happens to share pages with P3 siblings. |
-| "The journeys share most pages, same project, roughly P3 — skip the 'shared Playwright project' check" | Different Playwright projects require different `playwright-cli` sessions; batching across projects introduces session-swap complexity that defeats the dispatch optimisation. |
-| "Batching is faster so I'll batch everything that isn't explicitly forbidden" | Batching is allowed, not preferred. P0/P1 individual dispatch is the default; batching is specifically for P3 peripheral sweeps. Defaulting to batch on P2 quietly compresses scope. |
-| "One journey in the batch has a coverage-gap flag from Pass 1, but the gap is trivial" | Any flag in the three re-pass triggers kicks the journey out of the batch into individual dispatch. "Trivial" is the subagent's judgement after reading Pass-1 returns — which cannot happen inside a batched brief. |
-| "All P3 same project, I'll batch Stage B too to save a dispatch" | Stage B per-journey isolation is load-bearing for fresh-eyes review. One reviewer judging 7 journeys is not fresh-eyes; it's batched rubber-stamping. |
-| "Cycle-1 Stage B greenlit 6 of 7 journeys, I'll greenlight the 7th too since it's similar" | The 7th journey's reviewer returned `improvements-needed` for a reason. Split out cycle-2 for that journey; the reason does not carry to the greenlit 6. |
-| "Any flag on any journey kills the whole batch — too expensive, I'll keep batching" | Only the flagged journey breaks out. The greenlit journeys stay batched-and-accepted; no rework for them. |
-| "I'll batch Stage A across P1+P3 journeys if they share a project" | P0/P1 never batch, period. Priority is load-bearing; shared-project is necessary but not sufficient. |
-
----
-
-## Ledger dedup (single cleanup subagent, runs once after pass 5)
-
-After pass 5 commits, the orchestrator dispatches one additional, non-per-journey cleanup subagent.
-
-### Task for the cleanup subagent
-
-1. Read `tests/e2e/docs/adversarial-findings.md` in full.
-2. Identify near-duplicate findings across journey sections (e.g., "nav-cart badge does not clear after checkout" flagged by multiple journeys).
-3. Consolidate duplicates into the top-level `## Cross-cutting findings` section, listing every journey where each finding surfaced. Leave a short "_See cross-cutting: <title>_" backref in each journey's section (one line per moved finding).
-4. Fix obvious formatting / ordering issues (broken lists, inconsistent severity labels).
-5. Do NOT drop or edit substantive finding content. Do NOT re-classify findings. This is a dedup/consolidation step only.
-6. Commit: `docs(ledger): dedupe cross-cutting findings` (per the **Commit-message conventions** table above).
-
-### Cleanup subagent constraints
-
-- Model: **haiku** is sufficient. This is text-only editing with no browser session, no test composition, no probing.
-- Single dispatch — NOT per-journey. Just one subagent, handed the full ledger file path.
-- Isolated context. No prior session content.
-- Does not modify the journey-map, the page-repository, or any test files. Only the ledger.
-
----
+The full per-pass pipeline (steps 1–8), pass differences, commit-message conventions, per-pass completion criteria, the whole-suite re-run gate, the parallelism model, model selection (cost-blind), auto-compaction between passes, re-pass mode for compositional passes 2–3, batched dispatch for P3 peripheral journeys, and the post-pass-5 ledger dedup are specified in [`references/depth-mode-pipeline.md`](references/depth-mode-pipeline.md). Read it before authoring or modifying any depth-mode pass.
+
+Key invariants kept here so this file is still scannable:
+
+- **Five passes + cleanup, in order, every run.** Three compositional (1–3) + two adversarial (4–5) + one ledger-dedup cleanup. "Pass 1 only" is one-fifth of the pipeline, never a valid completion state for `mode: depth` (see §"Non-negotiables for depth mode").
+- **Every journey, every pass.** The no-skip contract (§"No-skip contract") applies inside every pass — Pass 4 with 0 journeys is not Pass 4.
+- **Cost-blind, opus-default model selection.** No P-tier carve-outs; one narrow cycle-1 Stage B sonnet-confirmation exception for previously-greenlit journeys with no map delta. Full rules in `references/depth-mode-pipeline.md` §"Model selection".
+- **Auto-compaction at 70%.** State written first, then `/compact`, then resume from state. Mid-cycle Stage A returns persist to a scratch file before compacting. Full flow in `references/depth-mode-pipeline.md` §"Auto-compaction between passes".
+- **P3 batching is the only batching exception.** P0/P1/P2 never batch. P3 may batch up to 7 in Stage A only — Stage B always per-journey. Full rules in `references/depth-mode-pipeline.md` §"Batched dispatch for P3 peripheral journeys".
 
 ## Breadth mode — one horizontal sweep
 
@@ -759,37 +347,7 @@ In breadth mode, the legacy `passScope` shape may be passed through to `test-com
 
 ## Isolated subagent contract
 
-### Compositional passes (1–3)
-
-Every `test-composer` subagent dispatched by this skill must:
-
-1. Receive an **isolated context window** — no prior session content, no other journey's data.
-2. Receive only: its assigned journey block + any `sj-<slug>` sub-journey blocks it references + the current `page-repository.json` slice for the pages that journey touches.
-3. Have access to an **isolated `playwright-cli` session** named `composer-<journey-slug>-<pass>-c<N>` (e.g. `composer-j-checkout-3-c1`), opened by the subagent at the start of its work and closed at the end. Sessions are OS-isolated by construction — one browser process per `-s=<name> open` — so there is no isolation-prerequisite check to run before dispatching. The subagent's brief includes a pointer to [`../element-interactions/references/playwright-cli-protocol.md`](../element-interactions/references/playwright-cli-protocol.md) §3 + §8 (the dispatch-brief template). The parent does **not** call `close-all` while subagents are working; it runs `close-all` once the pass completes as belt-and-suspenders cleanup.
-4. Not return until stabilization green, API compliance review clean, and coverage verified exhaustive (enforced inside `test-composer`).
-5. Return a structured discovery report only — no pasted test source, no DOM snapshots, no CLI transcripts. Returns follow the canonical return schema in [`../element-interactions/references/subagent-return-schema.md`](../element-interactions/references/subagent-return-schema.md); the dispatch brief includes a pointer to the file rather than re-pasting the schema.
-
-### Adversarial passes (4–5)
-
-Every adversarial probe subagent dispatched by this skill must:
-
-1. Receive the same isolated context window as compositional-pass subagents, with its own `playwright-cli` session named `probe-<journey-slug>-<pass>` (pass = 4 or 5). Same isolation guarantee as the compositional case (per-session browser process; see `playwright-cli-protocol.md` §1).
-2. Additionally receive: the pass number (4 or 5), the ledger file path (`tests/e2e/docs/adversarial-findings.md`), the lockfile path (`tests/e2e/docs/.adversarial-findings.lock`), and a pointer to the canonical schema at `skills/element-interactions/references/subagent-return-schema.md`.
-3. Receive a pre-built **negative-case matrix** for the journey — one negative-case complement per `Test expectations:` entry, plus the standard cross-cutting negatives (auth tamper, tenant isolation, idempotency, session boundary, input boundaries) — derived per `references/adversarial-subagent-contract.md` §"Negative-case matrix — full QA scope". The matrix is the deterministic floor for the probe; `bug-discovery`'s open-ended categories extend above it. The orchestrator builds the matrix from the journey block before dispatch and includes it verbatim in the brief — the subagent does not re-derive it.
-4. For pass 5 specifically: also receive the journey's pass-4 ledger section (read from the ledger file before dispatch and passed along — the orchestrator's single exception to the "never hold findings content" rule, bounded to one journey's section for one subagent), so the subagent can re-probe matrix entries that returned `Ambiguous` in pass 4 and run compound probes across matrix entries.
-5. Follow the adversarial subagent contract in `references/adversarial-subagent-contract.md` exactly, which mandates conformance to the canonical return + ledger schema.
-6. Return a structured summary only, matching the return shape in that contract. No probe transcripts, no DOM snapshots, no test source. Any per-finding detail inside the return follows the canonical finding-return format.
-
-### Cleanup subagent (post-pass-5)
-
-1. Single dispatch, NOT per-journey.
-2. Isolated context. Receives only the ledger file path.
-3. No browser session. Text-only work.
-4. Returns a one-line summary of how many cross-cutting findings were consolidated and how many journeys' sections were backref'd.
-
-The orchestrator does not paste any probe transcripts, DOM snapshots, test source, or stabilization output into its own context at any point.
-
----
+Every subagent dispatched by this skill — compositional `test-composer`, adversarial probe, Stage B reviewer, post-pass-5 cleanup — receives an isolated context window, an isolated `playwright-cli` session named per the role-prefix convention (`composer-j-<slug>-<pass>-c<N>`, `reviewer-j-<slug>-<pass>-c<N>`, `probe-j-<slug>-<pass>`, `cleanup-<scope>`), and only the inputs the contract names. The orchestrator never holds subagent payload content (test source, DOM snapshots, CLI transcripts, ledger bodies — modulo the bounded pass-5 ledger-section exception). Full per-role contracts in [`references/subagent-isolation.md`](references/subagent-isolation.md).
 
 ## Progress output
 

--- a/skills/coverage-expansion/SKILL.md
+++ b/skills/coverage-expansion/SKILL.md
@@ -256,12 +256,15 @@ This subsection extends §"Per-pass completion criteria" (see below). A pass's c
 
 Every one of the 5 passes runs **per journey** as two sequential stages — Stage A (compose / probe) and Stage B (adversarial review). They alternate in a bounded 7-cycle retry loop until the journey reaches one of four terminal `review_status` values: `greenlight`, `blocked-cycle-stalled`, `blocked-cycle-exhausted`, or `blocked-dispatch-failure`. The full retry-loop pseudocode, termination conditions, the "fresh reviewer every cycle" invariant, and dual-stage-specific anti-rationalizations are specified in [`references/dual-stage-retry-loop.md`](references/dual-stage-retry-loop.md).
 
-Key invariants kept here:
+### Hard rules — kernel-resident
 
-- **Both stages, every journey, every pass.** A `review_status` written without a Stage B dispatch is fabricated state and breaks resume.
-- **Stage B is fresh-eyes per cycle.** Each cycle dispatches a new reviewer with a new context and a new `playwright-cli` session. State carried across cycles defeats the design.
-- **Cap of 7 A↔B cycles per journey per pass.** Stalled (3 consecutive identical must-fix lists, OR reviewer-flagged stalled) wins over exhausted when both apply on cycle 7.
-- **Dual-stage no-skip extension** to the no-skip contract: every journey gets both stages every pass.
+- **Both stages, every journey, every pass.** A `review_status` written without a Stage B dispatch having occurred is fabricated state — corrupts the state file, breaks resume, lies to telemetry.
+- **Stage B is fresh-eyes per cycle.** Each cycle dispatches a new reviewer with a new context and a new `playwright-cli` session. No state carried across cycles, no inheritance from the paired Stage A. The fresh-eyes property is load-bearing — a stateful reviewer starts agreeing with Stage A.
+- **Stage B never writes tests, never appends to the ledger, never modifies files.** Pure review subagent. Findings come back in the return; the orchestrator (not Stage B) decides what to do with them.
+- **Cap of 7 A↔B cycles per journey per pass.** Stalled (3 consecutive identical must-fix lists OR reviewer-flagged `stalled: true`) takes precedence over exhausted when both apply on cycle 7 — different downstream signal.
+- **Cycle 7 reached without greenlight → `blocked-cycle-exhausted`.** Marking it greenlit when it isn't corrupts state. `blocked-cycle-exhausted` is a valid terminal, not a pass failure.
+- **Empty findings on `improvements-needed` → coerce to greenlight after one re-dispatch.** Empty findings = no changes needed; the status was malformed.
+- **Pass full findings through verbatim.** Compressed findings lose the surgical specificity Stage A needs. No "summary string" inputs to the next cycle.
 
 ## Prerequisites
 
@@ -302,12 +305,15 @@ The declaration also serves as the auditable record of *why* a partial run, if a
 
 The skill's first action on entry is to read `tests/e2e/docs/coverage-expansion-state.json`. The full schema (top-level fields, per-journey `dispatches[]` entry shape including dual-stage fields, journey-roster mutability rules, and the corrupt-state-refusal protocol) is specified in [`references/state-file-schema.md`](references/state-file-schema.md). Resumption is a contract, not a convention — read it before authoring or modifying any state-file-touching code.
 
-Key invariants kept here:
+### Hard rules — kernel-resident
 
 - **Read first, before anything else.** If currentPass is set, resume from that pass; if absent or `status == "complete"`, start Pass 1 from scratch.
-- **The file is authoritative.** Do not reason about "where did we leave off" from chat history, commit log, or journey-map deltas — they are diagnostic, not authoritative.
-- **State-file lifecycle.** Write after every per-pass commit + every auto-compaction trigger. Delete after successful 5-pass + cleanup completion (otherwise the next invocation mistakes a completed run for a resume).
-- **Corrupt-state stops the run.** Self-repair is out of scope — surface the mismatch to the caller.
+- **The file is authoritative.** Do not reason about "where did we leave off" from chat history, commit log, or journey-map deltas — those are diagnostic, not authoritative. If the file says currentPass=3 with 22 of 45 journeys complete, Pass 3 resumes with the remaining 23.
+- **Write after every per-pass commit AND every auto-compaction trigger.** A state file written without the dual-stage fields (`stage_a_cycles`, `stage_b_cycles`, `review_status`, `final_must_fix`) is incomplete — resume cannot reconstruct mid-A↔B-cycle journeys.
+- **Delete after successful 5-pass + cleanup completion.** Otherwise the next invocation mistakes a completed run for a resume.
+- **Roster is frozen at the start of each pass.** Journeys discovered mid-pass go to the NEXT pass's roster, not retroactively to the current pass's. Reconciliation commits write the new roster at the same commit that appends new map blocks.
+- **Missing dual-stage fields = corrupt state.** A state file lacking `stage_a_cycles`, `stage_b_cycles`, or `review_status` for any journey that ran this pass is corrupt — stop and report; never silently proceed.
+- **Corrupt-state stops the run.** Self-repair is out of scope — surface the mismatch to the caller. State referencing journeys not in `journey-map.md`, or `completedJourneys` ⊋ `journeyRoster`, both qualify.
 
 ## Modes
 
@@ -322,13 +328,20 @@ Key invariants kept here:
 
 The full per-pass pipeline (steps 1–8), pass differences, commit-message conventions, per-pass completion criteria, the whole-suite re-run gate, the parallelism model, model selection (cost-blind), auto-compaction between passes, re-pass mode for compositional passes 2–3, batched dispatch for P3 peripheral journeys, and the post-pass-5 ledger dedup are specified in [`references/depth-mode-pipeline.md`](references/depth-mode-pipeline.md). Read it before authoring or modifying any depth-mode pass.
 
-Key invariants kept here so this file is still scannable:
+### Hard rules — kernel-resident (never violate, even without loading the reference)
 
-- **Five passes + cleanup, in order, every run.** Three compositional (1–3) + two adversarial (4–5) + one ledger-dedup cleanup. "Pass 1 only" is one-fifth of the pipeline, never a valid completion state for `mode: depth` (see §"Non-negotiables for depth mode").
-- **Every journey, every pass.** The no-skip contract (§"No-skip contract") applies inside every pass — Pass 4 with 0 journeys is not Pass 4.
-- **Cost-blind, opus-default model selection.** No P-tier carve-outs; one narrow cycle-1 Stage B sonnet-confirmation exception for previously-greenlit journeys with no map delta. Full rules in `references/depth-mode-pipeline.md` §"Model selection".
-- **Auto-compaction at 70%.** State written first, then `/compact`, then resume from state. Mid-cycle Stage A returns persist to a scratch file before compacting. Full flow in `references/depth-mode-pipeline.md` §"Auto-compaction between passes".
-- **P3 batching is the only batching exception.** P0/P1/P2 never batch. P3 may batch up to 7 in Stage A only — Stage B always per-journey. Full rules in `references/depth-mode-pipeline.md` §"Batched dispatch for P3 peripheral journeys".
+These are restated here so they're in working memory even when `references/depth-mode-pipeline.md` is not loaded. Canonical text in the reference; this list is the no-load-required floor.
+
+- **Five passes + cleanup, in order, every run.** Three compositional (1–3) + two adversarial (4–5) + one ledger-dedup cleanup. "Pass 1 only" is one-fifth of the pipeline, never a valid completion state for `mode: depth`.
+- **Every journey, every pass.** Pass N is complete only when every journey in the map has been dispatched AND returned. Not "enough journeys", not "the P0/P1 tier", not "the journeys that fit the budget" — every journey. Pass 4 with 0 journeys is not Pass 4.
+- **One journey per commit, per pass kind.** Commit-message templates are fixed per pass (`test(<j-slug>)`, `docs(ledger): <j-slug> — …`, `test(<j-slug>-regression)`, `docs(ledger): dedupe cross-cutting findings`). Agents MUST NOT reinvent the format — the git log has to be filterable by `<j-slug>` and pass kind.
+- **Stage B never commits.** Reviewer judgements live in the state file's `review_status` and `final_must_fix` fields, never as commits. `review(j-…)` and any review-tagged commit form is forbidden.
+- **Stage A and B are parallel by default.** A journey's Stage B fires as soon as that journey's Stage A returns and the cap has a slot — not after every Stage A in the pass completes. Finishing all Stage A first then starting all Stage B is contract-violating.
+- **Parallel cap counts A and B jointly.** One pool of in-flight slots; A, B, and A-retry compete. A journey's own A and B never overlap (sequential within a journey); across journeys any A/B interleaving is possible. Queue order is FIFO.
+- **Cost-blind, opus-default model selection.** Default is opus for every dispatch in every stage in every pass. Two narrow exceptions: (a) cycle-1 Stage B sonnet-confirmation for previously-greenlit journeys with no map delta and no sibling-bug ledger update — sonnet's `improvements-needed` always re-runs on opus. **Pass 4 and Pass 5 are always opus, both stages, full stop** — the sonnet exception does NOT apply to adversarial passes. (b) Cleanup subagent (single post-pass-5 dispatch) may use haiku — text-only editing.
+- **P0/P1/P2 NEVER batch.** P3-only batching, capped at 7 per brief, Stage A only — Stage B always per-journey. Sharing pages with P3 siblings is not authorisation; priority is load-bearing.
+- **Auto-compaction at 70%.** State written first, then `/compact`, then resume from state. Mid-cycle Stage A returns persist to a scratch file (`tests/e2e/docs/.coverage-expansion-cycle-<slug>-cycle-<N>.json`) before compacting; mid-cycle restart from a fresh Stage A dispatch is NOT acceptable.
+- **`blocked-cycle-stalled`, `blocked-cycle-exhausted`, `blocked-dispatch-failure` are valid terminals**, not pass failures. Mark them faithfully — calling cycle-7-exhausted "greenlit" corrupts the state file and the next pass's trigger-4 input.
 
 ## Breadth mode — one horizontal sweep
 
@@ -347,7 +360,14 @@ In breadth mode, the legacy `passScope` shape may be passed through to `test-com
 
 ## Isolated subagent contract
 
-Every subagent dispatched by this skill — compositional `test-composer`, adversarial probe, Stage B reviewer, post-pass-5 cleanup — receives an isolated context window, an isolated `playwright-cli` session named per the role-prefix convention (`composer-j-<slug>-<pass>-c<N>`, `reviewer-j-<slug>-<pass>-c<N>`, `probe-j-<slug>-<pass>`, `cleanup-<scope>`), and only the inputs the contract names. The orchestrator never holds subagent payload content (test source, DOM snapshots, CLI transcripts, ledger bodies — modulo the bounded pass-5 ledger-section exception). Full per-role contracts in [`references/subagent-isolation.md`](references/subagent-isolation.md).
+Every subagent dispatched by this skill — compositional `test-composer`, adversarial probe, Stage B reviewer, post-pass-5 cleanup — runs against an isolation contract. Full per-role detail in [`references/subagent-isolation.md`](references/subagent-isolation.md).
+
+### Hard rules — kernel-resident
+
+- **Every subagent has an isolated context window.** No prior session content, no other journey's data, no orchestrator scratch.
+- **Every browser-using subagent has its own `playwright-cli` session** named per the role-prefix convention (`composer-j-<slug>-<pass>-c<N>`, `reviewer-j-<slug>-<pass>-c<N>`, `probe-j-<slug>-<pass>`, `cleanup-<scope>`). Sessions are OS-isolated; the subagent opens at start and closes at end.
+- **The orchestrator NEVER holds subagent payload content.** Not in steady state, not at dispatch boundaries, not during reconciliation. Forbidden in orchestrator context: full journey blocks (only the indexed fields), DOM snapshots, test source, stabilization transcripts, ledger bodies — modulo the **single bounded exception**: when dispatching a pass-5 subagent, the orchestrator reads that journey's pass-4 ledger section into the brief and releases it from context immediately after dispatch.
+- **Returns are structured summaries only.** No pasted test source, no DOM snapshots, no CLI transcripts. All returns conform to `subagent-return-schema.md` (and are validated by `hooks/subagent-return-schema-guard.sh`, issue #127).
 
 ## Progress output
 

--- a/skills/coverage-expansion/references/anti-rationalizations.md
+++ b/skills/coverage-expansion/references/anti-rationalizations.md
@@ -1,0 +1,284 @@
+# Consolidated Anti-Rationalization Registry
+
+**Status:** single source of truth for failure-mode patterns the orchestrator and its subagents must recognise. Cited from `coverage-expansion/SKILL.md` and the depth-mode / dual-stage / model-selection reference files.
+**Scope:** patterns are keyed by **failure-mode category**, not by surface phrasing. Each entry names the pattern, lists symptoms (phrasings that signal it), states the reality, names the enforcing hook (or tags `markdown-only`), and links to where the pattern was first observed.
+
+Why categories, not symptoms: enumerating tactical excuses can't keep up with new framings. New phrasings appear constantly; the failure mode underneath is a small set. A reader who has the category internalised can match a novel framing to a known pattern instead of needing the table to grow yet another row.
+
+---
+
+## Pattern: Pre-emptive scope reduction
+
+The orchestrator decides — before dispatching — that running fewer than the contracted set of passes / journeys is the "responsible" choice given inferred constraints (session length, context budget, perceived user preference).
+
+**Symptoms** (phrasings that signal this pattern):
+- "pragmatic Pass 1 only" / "honest Pass 1 only" / "transparent Pass 1 only"
+- "given session / context constraints, I'll run a subset"
+- "I'll be honest with the user that I'm reducing scope"
+- "the user clearly wants results, not hours of subagent dispatch"
+- "running all 5 passes is excessive for this app"
+- "I'll run [subset] and report state — that's resume-friendly"
+
+**Reality:** Budget pressure is not scope authorisation. Tone does not change the contract: a "transparent" scope reduction is still a scope reduction. The valid mid-run response to actual budget pressure is exit #2 (commit + state-file + stop), NOT pre-emptive reduction. Pre-emptive reduction is forbidden.
+
+**Hooks that catch this:**
+- `commit-message-gate.sh` (PR #125) — blocks commits with phase-progression messages on pre-emptively-reduced runs.
+- (markdown-only) — the framing itself is not mechanically detectable; the orchestrator must recognise the pattern in self-talk.
+
+**Origin:** Recurring failure across multiple onboarding runs (BookHive, others). Codified as the §"Two valid exits" rule and the dual-stage no-skip extension.
+
+---
+
+## Pattern: Self-authorised batching (Stage A grouping)
+
+The orchestrator decides — before dispatching — to batch P0/P1/P2 journeys into multi-journey composer briefs ("composer-auth covering 4 journeys", "composer-cart-orders covering 3"), citing efficiency or natural clustering.
+
+**Symptoms:**
+- "16 individual Stage A composer dispatches is too many — I'll group them by area"
+- "these 4 journeys naturally cluster — 1 agent can handle them efficiently"
+- "the journeys share most pages, same project, roughly P3 — skip the 'shared Playwright project' check"
+- "batching is faster so I'll batch everything that isn't explicitly forbidden"
+
+**Reality:** Stage A is one composer per journey, in parallel up to host max — never N composer agents each covering N/k journeys sequentially. The only batching exception is P3 peripheral journeys, capped at 7 per brief, with cycle-1 split-out semantics. P0/P1/P2 NEVER batch. The diagnostic for getting this wrong: every Stage B reviewer for batched journeys returns `improvements-needed` because the batched composer rationed attention across siblings.
+
+**Hooks that catch this:**
+- `coverage-expansion-dispatch-guard.sh` (PR #125, issue #126) — denies dispatches whose prompt references 2+ distinct `j-<slug>` IDs without a `[P3-batch]` description prefix.
+
+**Origin:** PR #105 (no-skip contract) + issue #126 (role-prefix tightening). Reinforced by issue #132 (brief-cleanup BLOCK promotion).
+
+---
+
+## Pattern: Self-certifying greenlight
+
+A subagent (composer, reviewer, or probe) skips the work and self-certifies success — composer returns `covered-exhaustively` without inspecting, reviewer self-greenlights a journey it didn't review, probe skips boundaries it judged "trivial".
+
+**Symptoms:**
+- "obvious no-op — I'll mark `covered-exhaustively` without reading Pass-1 returns"
+- "Stage A returned `covered-exhaustively` — no need to dispatch Stage B"
+- "cycle 1 Stage B will obviously greenlight this trivial journey, I'll skip it"
+- "the journey was greenlit last pass — skip the whole A↔B for this pass"
+- "the mapping table is obvious, I'll shorthand it"
+
+**Reality:** `covered-exhaustively` requires evidence — a per-expectation mapping table, not a self-assessment. Stage B is the verification, not Stage A's self-certification. Every journey gets both stages every pass. A `review_status` written without a Stage B dispatch having occurred is fabricated state.
+
+**Hooks that catch this:**
+- `subagent-return-schema-guard.sh` (issue #127) — warns (will block) when a `covered-exhaustively` return lacks the per-expectation mapping table; warns when banned tokens (`no-new-tests-by-rationalisation`) appear.
+
+**Origin:** PR #105 + the dual-stage contract (issue #122 era). Re-pass mode triggers (1–4) exist precisely to force evidence into the certifying-greenlight return.
+
+---
+
+## Pattern: Spirit-vs-letter argument
+
+The orchestrator argues that the rule's spirit is satisfied even though the letter is not — typically used to rationalise a small contract violation as "consistent with the intent".
+
+**Symptoms:**
+- "spirit of the contract is satisfied"
+- "we're effectively running the full pipeline"
+- "this is a different scenario the rule doesn't cover"
+- "the rule was written for situation X; this is situation Y"
+
+**Reality:** The contract's letter IS its spirit. If a rule covers situation X and you find yourself in situation Y, that's either a real gap to surface to the user (open an issue, propose an extension) or the rule actually does cover Y and you're trying to wriggle out. Tone does not change the contract.
+
+**Hooks that catch this:**
+- (markdown-only) — the framing is not mechanically detectable.
+
+**Origin:** Recurring across discipline-failure incidents.
+
+---
+
+## Pattern: Compress findings into summary
+
+A subagent or orchestrator compresses Stage B findings into a "summary string" before passing to the next Stage A retry, losing the surgical specificity Stage A needs to fix them.
+
+**Symptoms:**
+- "I'll compact findings from cycles 1–4 into one summary string for cycle 5's input"
+- "the must-fix list is small — I'll skip the retry"
+- "compressed findings are easier to read"
+
+**Reality:** Pass full findings through verbatim. Compressed findings lose the surgical specificity. A single `must-fix` item is enough to block greenlight; "small list" is not authorisation to skip.
+
+**Hooks that catch this:**
+- (markdown-only) — finding compression happens inside orchestrator briefs, not at the dispatch boundary.
+
+**Origin:** Dual-stage retry-loop design (issue #122 era).
+
+---
+
+## Pattern: Stale-budget rationalisation
+
+The orchestrator infers from earlier-in-the-run telemetry that a given pass / journey will be cheap or no-op, and skips re-reading the state file or the journey block before dispatch.
+
+**Symptoms:**
+- "Pass 4 finished cleanly — Pass 5 will be a no-op, I'll skip the re-dispatch check"
+- "this journey was greenlit last pass with no map delta — skip the inspection"
+- "no point reading state — I remember where we are"
+
+**Reality:** Re-read the state file at every pass boundary. The orchestrator must not reason about "where did we leave off" from chat history. Memory is diagnostic, not authoritative.
+
+**Hooks that catch this:**
+- `coverage-state-schema-guard.sh` (PR #125) — validates state-file shape on every Write/Edit, catching stale-state writes.
+
+**Origin:** PR #105 + auto-compaction design (issue #122 era).
+
+---
+
+## Pattern: "MCP tool was in my list, so it must be allowed"
+
+A subagent reaches for an MCP browser tool surfaced by the harness, on the implicit reasoning that "if the tool list contains it, the harness sanctions it".
+
+**Symptoms:**
+- "the MCP browser tool is in my available tool list, I'll use it"
+- "playwright-cli isn't installed yet, I'll use the MCP fallback"
+- "the harness still surfaces these tools, so they're an option"
+
+**Reality:** The harness surfaces tools the consumer's environment has registered, not tools the skill suite sanctions. The MCP browser tools are explicitly forbidden — `playwright-cli` is the only sanctioned channel. A subagent that reaches for an MCP browser tool has a malformed dispatch brief, not a permitted alternative.
+
+**Hooks that catch this:**
+- `mcp-browser-tool-redirect.sh` (PR #125) — denies the MCP browser tool calls and emits the playwright-cli equivalent in the redirect message.
+
+**Origin:** PR #122 (MCP→playwright-cli migration). Reinforced by issue #126.
+
+---
+
+## Pattern: Subagent fan-out anti-pattern
+
+A subagent's brief asks it to "dispatch N parallel subagents", "spawn workers", "fan out", or "use the Agent tool to coordinate". Subagents in this environment cannot recursively dispatch other subagents — the Agent / Task tool is parent-only.
+
+**Symptoms (in subagent briefs, not subagent self-talk):**
+- "you are an orchestrator — dispatch 4 parallel composers"
+- "fan out the work to N subagents"
+- "use the Agent tool to spawn workers"
+- "coordinate the wave by dispatching its constituents"
+
+**Reality:** Two valid patterns: (a) parent dispatches the wave directly (default for composer / reviewer / probe waves); (b) sub-orchestrator returns a manifest (the parent reads the manifest and dispatches). The sub-orchestrator NEVER tries to fire its own children — see `process-validator-workflow.md`.
+
+**Hooks that catch this:**
+- `coverage-expansion-dispatch-guard.sh` (PR #125, issue #126) — anti-pattern A: blocks subagent briefs whose body contains "dispatch N parallel subagents", "fan out", "use the Agent tool to dispatch".
+
+**Origin:** Environment constraint surfaced during PR #122 era. Codified as the recursive-dispatch impossibility in `coverage-expansion/SKILL.md` §"Recursive dispatch is impossible".
+
+---
+
+## Pattern: Sonnet cost-down rationalisation
+
+The orchestrator argues for sonnet over opus on dispatches the cost-blind posture says should be opus.
+
+**Symptoms:**
+- "the journey was attempted last pass and ended at `blocked-cycle-stalled` — that counts as previously-greenlit"
+- "Pass 4 is just probing, sonnet is good enough for cycle-1 of small journeys"
+- "I ran sonnet for Stage A and opus for Stage B — that's a hybrid we never explicitly forbade"
+- "small journey, sonnet is fine"
+
+**Reality:** Default model for every dispatch in every stage in every pass is opus. The narrow cycle-1 Stage B sonnet-confirmation exception applies ONLY to journeys with `greenlight` (not blocked-*) in the previous pass, no map delta, and no sibling-bug ledger update. Pass 4 + Pass 5 are ALWAYS opus, both stages, full stop. Hybrid Stage A/Stage B model splits beyond the narrow exception are not authorised.
+
+**Hooks that catch this:**
+- (markdown-only) — model selection is not yet mechanically detectable at the dispatch boundary.
+
+**Origin:** Cost-blind posture codified in §"Model selection" of `references/depth-mode-pipeline.md`.
+
+---
+
+## Pattern: Trivial-journey-skip / cycle-1-Stage-B-greenlight self-certification
+
+The orchestrator decides a journey is "trivial enough" to skip its cycle-1 Stage B reviewer dispatch entirely, recording `greenlight` in the state file without a reviewer dispatch having occurred.
+
+**Symptoms:**
+- "this journey is trivial — Stage B will obviously greenlight, skip it"
+- "previous pass greenlit, this pass will too — record greenlight directly"
+- "saving a dispatch on the trivial cases is fine"
+
+**Reality:** Self-certifying greenlights without a reviewer dispatch is the failure mode the dual-stage design exists to close. The fast path for trivial journeys is the cycle-1 Stage B sonnet-confirmation exception (`references/depth-mode-pipeline.md` §"Model selection") — NOT skipping the dispatch.
+
+**Hooks that catch this:**
+- `coverage-state-schema-guard.sh` — flags `review_status: greenlight` entries with `stage_b_cycles: 0` (the minimum for an actually-dispatched Stage B is 1).
+
+**Origin:** Dual-stage no-skip extension (issue #122 era).
+
+---
+
+## Pattern: Cycle-7 exhausted → call-it-greenlit
+
+When the 7-cycle Stage A↔B retry loop reaches cycle 7 without greenlight, the orchestrator marks the journey greenlit anyway "to keep the pass moving".
+
+**Symptoms:**
+- "cycle 7 exhausted and I'll just call it greenlit to keep the pass moving"
+- "the must-fix list at cycle 7 is small, close enough to greenlit"
+- "we're out of cycles, the journey is good enough"
+
+**Reality:** `blocked-cycle-exhausted` is the correct terminal state. Marking exhausted journeys greenlit corrupts the state file, lies to telemetry, and breaks the next pass's trigger-4 input (which depends on the unresolved must-fix list being faithfully recorded).
+
+**Hooks that catch this:**
+- `coverage-state-schema-guard.sh` — flags malformed `review_status` values; the four valid values are `greenlight | blocked-cycle-stalled | blocked-cycle-exhausted | blocked-dispatch-failure`.
+
+**Origin:** Dual-stage retry-loop design.
+
+---
+
+## Pattern: Reviewer-disagreement cherry-picking
+
+Two consecutive reviewers in cycles N and N+1 disagree about what's must-fix; the orchestrator picks the more lenient one to "make progress".
+
+**Symptoms:**
+- "reviewer disagrees with itself between cycles 1 and 2; I'll pick the more lenient one"
+- "cycle 2's reviewer was more thorough — I'll discard cycle 1's findings"
+- "consensus across cycles is what matters"
+
+**Reality:** Each cycle's reviewer is fresh and independent. Take each cycle's output as-is; the retry-loop logic handles divergence via the stalled/exhausted checks. Cherry-picking defeats the fresh-eyes property.
+
+**Hooks that catch this:**
+- (markdown-only) — cherry-picking happens inside orchestrator briefs.
+
+**Origin:** Dual-stage retry-loop design.
+
+---
+
+## Pattern: Brief-leak — orchestrator meta-content in subagent brief
+
+The parent orchestrator's brief to a subagent contains pipeline meta-content (depth mode, 5-pass pipeline, "Pass 4/5", adversarial pass, etc.) that bloats the subagent's context and risks consulting parts of the skill outside its scope.
+
+**Symptoms:**
+- subagent brief mentions "depth mode" / "breadth mode"
+- subagent brief mentions "5-pass pipeline" or specific pass numbers it doesn't need to know
+- subagent brief mentions "adversarial pass" inside a composer brief
+- subagent brief mentions the broader pipeline structure unnecessarily
+
+**Reality:** A composer / reviewer / probe brief only needs: journey block + must-fix list + slug + return-shape pointer. The pipeline structure belongs to the parent orchestrator's context, not the subagent's.
+
+**Hooks that catch this:**
+- `coverage-expansion-dispatch-guard.sh` anti-pattern B (PR #125) + issue #132 — promoted from WARN to BLOCK for `composer-`, `reviewer-`, `probe-` prefixes; soft WARN preserved for `cleanup-`/`phase1-`/`phase2-`/`stage2-`.
+
+**Origin:** PR #125, hardened by issue #132.
+
+---
+
+## Pattern: Auto-compact threshold creep
+
+The orchestrator pushes past the 70% auto-compaction threshold ("one more pass before compacting") or compacts pre-emptively at 50% ("to be safe").
+
+**Symptoms:**
+- "context is at 75% but I can push one more pass before compacting"
+- "I'll compact at 50% to be safe"
+- "the state file is small, there's nothing to save before compacting"
+- "I'll run Pass 4 to finish the boundary, then compact"
+- "auto-compact failed once so I'll skip it this time"
+
+**Reality:** 70% is a floor, not a guideline. Below it the seam costs more than it saves; above it the next pass often lands at 95%+ and forces an in-pass compact that loses roster state. State-file write happens BEFORE compaction, not after. Auto-compact failure → fall back to manual-compaction safe-seam, never silent progression.
+
+**Hooks that catch this:**
+- (markdown-only) — context-percentage decisions are inside the orchestrator's reasoning loop.
+
+**Origin:** §"Auto-compaction between passes" in `references/depth-mode-pipeline.md`.
+
+---
+
+## Adding a new pattern
+
+When a novel rationalisation framing appears that doesn't fit an existing pattern:
+
+1. Match it to an existing pattern first (90% of the time it does fit — the categories are deliberately broad).
+2. If genuinely new, add a new section to this file with the same shape (name, symptoms, reality, hooks, origin).
+3. Update SKILL.md only if the new pattern needs surfacing in the kernel (rare — most patterns belong here).
+4. Open a follow-up issue if the pattern is markdown-only and a hook would close the loophole.
+
+The registry succeeds when readers can match novel framings to known patterns instead of needing this file to grow yet another row. Anti-rationalization is a category problem, not a phrasing problem.

--- a/skills/coverage-expansion/references/depth-mode-pipeline.md
+++ b/skills/coverage-expansion/references/depth-mode-pipeline.md
@@ -1,0 +1,275 @@
+# Depth-Mode Pipeline — Per-Pass Detail, Parallelism, Model Selection
+
+**Status:** authoritative spec for the 5-pass depth-mode pipeline. Cited from `coverage-expansion/SKILL.md` §"Modes".
+**Scope:** the full per-pass pipeline (steps 1–8), pass differences, commit-message conventions, per-pass completion criteria, the whole-suite re-run gate, the parallelism model, model selection, auto-compaction, re-pass mode for compositional passes 2–3, and batched dispatch for P3 peripheral journeys.
+
+For the dual-stage retry loop (Stage A↔B per journey per pass), see `references/dual-stage-retry-loop.md` (also cited from `SKILL.md`).
+For the state-file schema and per-journey dispatch entry fields, see `references/state-file-schema.md`.
+For the isolated-subagent contracts, see `references/subagent-isolation.md`.
+For consolidated anti-rationalization patterns referenced throughout this doc, see `references/anti-rationalizations.md`.
+
+---
+
+## Depth mode — five-pass pipeline (3 compositional + 2 adversarial) + cleanup
+
+Each pass runs a journey-by-journey pipeline with parallel dispatch where independent. The map grows between compositional passes; the adversarial ledger grows during adversarial passes. After pass 5, a single cleanup subagent dedupes the ledger.
+
+### Per-pass pipeline
+
+Every pass in depth mode runs this pipeline; steps 4 and 7 differ between compositional (1–3) and adversarial (4–5) passes.
+
+1. **Read the map** (sentinel-verified). Build an in-memory index: `[(j-id, priority, pages-touched, test-expectations)]`. Read **only** these fields per journey — not full step lists, branches, or state variations.
+2. **Recompute priority ordering.** Honour the map's priorities, but if a journey's `Test expectations` or pages touched have changed since the last pass, adjust position.
+3. **Build the journey independence graph.** The graph is the same across compositional and adversarial passes.
+4. **Emit the per-pass scope preview** (see §"Per-pass scope preview"). Declarative only; no confirmation prompt. The scope preview names the dual-stage dispatch band (see that section).
+5. **Run the per-journey dual-stage retry loop** for every journey in the map — parallel for independent journeys, sequential for dependent ones, per §"Parallelism". Each journey's A↔B loop follows §"Retry loop (orchestrator, per journey per pass)". The loop terminates when the journey has one of the four terminal `review_status` values.
+   - Model selection per §"Model selection" — default opus for both stages.
+   - P3 batching narrowed per §"Batched dispatch for P3 peripheral journeys" — Stage A may be batched; Stage B never is.
+6. **Collect all journey outputs.** Each journey contributes: its committed test files (from the final greenlit or blocked-with-tests-landed Stage A cycle), its `review_status`, its cycle counts, and (if blocked) its final `must-fix` list. The orchestrator does NOT hold Stage A test source or Stage B review bodies — only structured summaries and the on-disk file paths.
+7. **Reconcile artefacts.**
+   - **Compositional passes:** reconcile the map. Append new branches to existing journey blocks. Add new `j-<slug>` or `sj-<slug>` blocks for newly-discovered journeys or sub-journeys. Append new pages/elements to `app-context.md`. Run a mini Phase 3.5 revision (see `journey-mapping`) if the pass introduced new overlaps.
+   - **Adversarial passes:** the map is NOT reconciled. The ledger file is authoritative; its content is already written by the subagents during their append step. Aggregate the return summaries into the orchestrator's running adversarial-totals counter (journeys probed, boundaries verified, suspected-bug count by severity, regression tests added).
+8. **Commit, then update state file.** One commit per journey (compositional passes) or per journey per pass (adversarial passes). See §"Commit-message conventions" below for the exact templates. After the commit lands, rewrite `tests/e2e/docs/coverage-expansion-state.json` with the new pass counter, per-journey `dispatches[]` entries (including `stage_a_cycles`, `stage_b_cycles`, `review_status`, `final_must_fix`), and adversarial totals. Then run the auto-compaction check (§"Auto-compaction between passes") before the next pass's dispatch.
+
+### Pass differences
+
+| Pass | Kind | Purpose |
+|---|---|---|
+| 1 — initial perception | compositional | Cover the map as produced by `journey-mapping`. Priorities as written. Each journey gets its full variant set (per `Test expectations:`). Map grows with whatever surfaces. Dispatches `test-composer` per journey. |
+| 2 — map-growth widening | compositional | Re-read the enriched map. Promote newly-discovered branches and sub-journeys to first-class journeys where they warrant it. Re-evaluate priorities. Re-attempt any journey where pass 1 deferred stabilization or returned coverage gaps. Dispatches `test-composer` per journey. |
+| 3 — consolidation | compositional | Final sweep on the refined map. Focus on cross-journey interactions, residual gaps, data-lifecycle variants that require wiring multiple journeys together, and any journey whose map block was materially refined in pass 2. Dispatches `test-composer` per journey. |
+| 4 — adversarial probing | adversarial | One adversarial turn per journey. Dispatches a probe subagent (see `references/adversarial-subagent-contract.md`) that invokes `bug-discovery` scoped to the journey. The probe covers the full QA-engineer test matrix for the journey — a deterministic negative-case complement for every positive `Test expectations:` entry plus cross-cutting negatives (auth tamper, tenant isolation, idempotency, session boundary, input boundaries) — in addition to `bug-discovery`'s open-ended categories. Findings are appended to `tests/e2e/docs/adversarial-findings.md` — no tests are written in pass 4. |
+| 5 — adversarial consolidation | adversarial + regression | Second adversarial turn. Each subagent reads its journey's pass-4 ledger section, re-probes any negative-case-matrix entries that returned `Ambiguous`, attempts compound probes that combine matrix entries (e.g., auth-tamper × idempotency, tenant-isolation × session-boundary), and writes **passing** regression tests for every verified boundary (pass 4 + pass 5 combined) into `j-<slug>-regression.spec.ts`. Suspected bugs remain ledger-only — never committed as `test.fail()`. |
+
+After pass 5: one single-dispatch cleanup subagent dedupes the ledger. See §"Ledger dedup" below.
+
+### Commit-message conventions
+
+One journey per commit, one template per pass kind. Agents MUST NOT reinvent the format — the git log has to be filterable by `<j-slug>` and by pass kind.
+
+| Pass / phase | Commit-message template | Notes |
+|---|---|---|
+| Compositional passes (1–3) | `test(<j-slug>): <variant>` | One journey per commit, always. `<variant>` names the variant added (e.g. `happy-path`, `error-states`, `mobile`, `data-lifecycle`). If a single composer invocation adds multiple variants, produce one commit per variant. |
+| Adversarial pass 4 | `docs(ledger): <j-slug> — N probes, M boundaries, K suspected bugs` | One commit per journey. Commit diff is the ledger file only. `N`, `M`, `K` come from the subagent return's structured summary. |
+| Adversarial pass 5 — regression | `test(<j-slug>-regression): lock <boundary-description>` | One commit per verified-boundary regression test authored. `<boundary-description>` is a short phrase naming the boundary being locked (e.g. `empty-cart-checkout-rejected`, `nav-cart-badge-clears-after-checkout`). |
+| Cleanup (post-pass-5 dedup) | `docs(ledger): dedupe cross-cutting findings` | Single commit from the one cleanup subagent. |
+
+**Stage B returns do NOT produce their own commits.** Reviewer judgements are captured in the state file's per-journey `review_status` and `final_must_fix` fields — never as commits. The git log records what landed (Stage A's tests, ledger entries, regression locks) but not the review trail; the state file records the review trail. Mixing reviews into commits creates a diff-noisy log that obscures the actual change history.
+
+Anti-patterns — do NOT use:
+- `test(pass5): j-xxx — <summary>` (pass number goes in the `-regression` suffix, not the scope)
+- `feat(e2e): …` (coverage expansion is never `feat`)
+- `test(j-xxx, j-yyy): …` (one journey per commit — no multi-journey commits even when batched)
+- `review(j-xxx): …` or any review-tagged commit (Stage B never commits — see above)
+- `fix(…): …` for new tests (use `test(…)`; `fix` is for fixing existing code)
+
+### Per-pass completion criteria
+
+A pass is complete only when **every** criterion for that pass is met. "Ran some journeys, ran out of budget" is not complete — see §"Non-negotiables for depth mode" for the resume-state contract.
+
+- **Pass 1** complete = `test-composer` has been dispatched for and has returned on **every** journey in the map. Not "enough journeys", not "the P0/P1 tier", not "the journeys that fit the budget". Every journey.
+- **Pass 2** complete = `test-composer` has been re-dispatched and returned for every journey, AND the map has been reconciled with any newly-promoted branches or sub-journeys surfaced in pass 1 or 2, AND — if the reconciliation produced map edits — the reconciliation commit has landed. If no map edits were needed, the pass still completes, but the orchestrator records `"pass 2 reconciliation — no map edits required"` in the state file / progress log rather than silently skipping the commit.
+- **Pass 3** complete = cross-journey and data-lifecycle variants have been dispatched for every journey whose `Test expectations:` calls for them, AND any journey that returned residual coverage gaps in passes 1 or 2 has been re-attempted, AND the pass commit has landed (if tests were added in this pass).
+- **Pass 4** complete = the adversarial-probe subagent has run per journey with `pass=4`, and each subagent's findings have been appended to `tests/e2e/docs/adversarial-findings.md`. If no probes landed for a given journey (e.g., the subagent found nothing to probe or was gated), the orchestrator records `"no boundaries probed — <reason>"` for that journey in the ledger — it does NOT silently skip the journey. An empty ledger section for a journey is a bug, not a pass-4 completion state.
+- **Pass 5** complete = every verified pass-4 finding has either a committed regression test in `j-<slug>-regression.spec.ts` OR an explicit decline-with-reason line in the ledger ("no regression written — finding classified as suspected bug / ambiguous / duplicate of cross-cutting #N"). Regression-test files are committed per journey.
+- **Cleanup** complete = one cleanup subagent has run once, cross-cutting findings are consolidated into the top-level section with backrefs in each journey's section, and the commit `docs: adversarial-findings — dedupe cross-cutting findings` has landed.
+
+Only when **all** of the above are true may the orchestrator report depth-mode coverage-expansion complete to its caller. Anything less is a partial run and must be reported as such (see the resume-state contract).
+
+**Dual-stage extension.** On top of the per-pass criteria above, a pass is complete only when **every journey has a terminal `review_status`** (`greenlight`, `blocked-cycle-stalled`, `blocked-cycle-exhausted`, or `blocked-dispatch-failure`) recorded in the state file's `dispatches[]` array. A pass where every journey's Stage A returned but some journeys have no `review_status` is **incomplete**, even if the per-pass criteria above appear satisfied. Stage B participation is part of the completion gate, not optional.
+
+### Whole-suite re-run gate (per-pass exit)
+
+After a pass's per-journey subagents return clean and per-pass completion criteria are satisfied, run the whole-suite re-run gate documented in `../element-interactions/references/test-optimization.md` §7.
+
+**Procedure:** identical to the canonical procedure documented in `../element-interactions/references/test-optimization.md` §7. Summary:
+
+1. From the harness root: `npx playwright test --reporter=json > .stage4a-suite.json`.
+2. Parse the JSON. Playwright's reporter writes `{ stats: { expected, unexpected, flaky, skipped, ... }, suites: [...] }`. Refuse to advance to the next pass if:
+   - `stats.unexpected > 0` (includes timed-out, failed, interrupted), OR
+   - `stats.skipped` exceeds the count of explicit `test.skip(` markers across spec files (`grep -rh '^\s*test\.skip\b' tests/e2e --include='*.spec.ts' | wc -l`).
+3. On refusal, return `{ status: 'whole-suite-gate-failed', pass: <N>, stats: {...}, failures: [...], skips_unexplained: <delta> }` and DO NOT invoke the next pass. Resume on this pass once the caller resolves the failures.
+4. Delete `.stage4a-suite.json` after parsing.
+
+**Why it runs here:** per-journey subagent stabilization confirms each journey's tests pass in isolation, but cumulative state across the suite (DB pollution, port collisions, fixture drift, shared-resource depletion) only surfaces when the whole suite runs together. Running this gate at every pass exit catches integration-time regressions at the earliest pass that introduces them, rather than at end-of-pipeline.
+
+### Parallelism
+
+The parallelism model has three layers:
+
+#### Independence graph (unchanged semantics)
+
+Two journeys are **dependent** if they touch a non-universal page in common. Universal pages (login, homepage, global nav) are ignored. Independent journeys can run in parallel; dependent ones must serialize to avoid tab-sharing corruption.
+
+Co-residence on pages is the only dependency signal. Two journeys that both touch `/admin/users` are dependent even if one only reads and one mutates — tab sharing is the bug, not data-layer contention.
+
+#### Intra-group pipelining (dual-stage)
+
+Within an independence group:
+- **Both stages are parallel by default.** Stage B is not a serial follow-up to Stage A — it is dispatched per-journey-as-soon-as-Stage-A-returns, sharing the parallel pool with sibling journeys' Stage A retries. An orchestrator that finishes Stage A for the whole pass and then begins Stage B serially is implementing a different (slower, contract-violating) protocol.
+- All journeys in the group start Stage A concurrently (subject to the parallel cap — see below).
+- Each journey's Stage B fires **as soon as that journey's Stage A returns** and the parallel cap has a slot — not after the whole group's Stage A completes.
+- Each journey's Stage A retry fires **as soon as that journey's Stage B returns with `improvements-needed`** and the cap has a slot.
+- Journeys in the same group ride their own A↔B pipelines in parallel. A journey on cycle 3 and a sibling on cycle 1 coexist.
+
+Across independence groups: groups run in priority order, each group exhausting parallelism before the next group starts.
+
+#### Parallel cap — lifted and jointly applied
+
+Previous: `min(4, credentials-per-role)` with batching for P3.
+New: **`host max`** — the orchestrator uses whatever parallel width the dispatch primitive allows. An explicit user override is accepted (`args: "parallel-cap: 8"`), otherwise no artificial ceiling beyond the shared-resource audit's credential-contention findings (PR #106).
+
+**The cap counts Stage A and Stage B dispatches jointly.** There is one pool of in-flight subagent slots; A and B compete for the same slots within a group. A journey's own A and B never overlap (sequential within a journey), but across journeys any A/B interleaving is possible. When the cap is saturated, new dispatches — whether A, B, or A-retry — queue until a slot frees. Queue order is FIFO; the orchestrator does not prioritise A over B or vice versa.
+
+#### Shared-resource audit interaction
+
+The Phase-0 shared-resource audit (PR #106) still caps parallelism where the app genuinely can't tolerate more (single credential per role, rate limits, CSRF serialization). Those caps override the cost-blind default. The audit's constraint tags apply to Stage A AND Stage B equally — reviewers compete for the same credentials.
+
+### Model selection (cost-blind posture)
+
+Default model for every dispatch in every stage in every pass: **opus**.
+
+The prior sonnet-for-P2/P3 heuristic is removed. The prior sonnet-for-small-journey override is removed. Model choice does not vary by priority, journey size, step count, or pass number — opus by default, everywhere.
+
+**Narrow exception — cycle-1 Stage B sonnet confirmation.** For a journey that greenlit in the previous pass AND has no map delta since that pass AND no sibling-bug ledger update pointing at it, the cycle-1 Stage B MAY run sonnet as a fast confirmation. If sonnet returns `greenlight`, accept. If sonnet returns `improvements-needed`, immediately re-run the same review on opus — the opus result is authoritative, sonnet's was indicative. This is a latency optimisation, not a cost-reduction mechanism; it exists because a confirmed-greenlit journey's cycle-1 review is often trivially "still looks good" and a sonnet confirmation is fast.
+
+**Override: promote on failure.** Any journey that returned a stabilization or coverage-verification failure in a prior pass runs on opus for every dispatch (A and B) in every subsequent pass, regardless of cycle. No sonnet exception applies once a journey has failed.
+
+**For adversarial passes (4 and 5):** always opus, both stages. The sonnet exception above does NOT apply to adversarial passes — adversarial review requires judgment that sonnet reliably under-produces.
+
+**Rationalizations to reject:**
+
+| Excuse | Reality |
+|--------|---------|
+| "The journey was attempted last pass and ended at `blocked-cycle-stalled` / `blocked-cycle-exhausted` / `blocked-dispatch-failure` — that counts as 'previously-greenlit' for the sonnet exception" | A blocked journey is not greenlit. The narrow exception requires explicit `greenlight` in the previous pass, not "attempted." Any blocked-* terminal in the prior pass means opus on cycle 1 of the next pass. |
+| "Pass 4 is just probing, sonnet is good enough for cycle-1 of small journeys" | Pass 4 and Pass 5 are always opus, both stages, full stop. The model-selection cost-blind rule has no priority/size carve-outs. |
+| "I ran sonnet for Stage A and opus for Stage B — that's a hybrid we never explicitly forbade" | Stage A is opus for every dispatch in every pass. The narrow sonnet exception is for cycle-1 Stage B only on previously-greenlit journeys. Hybrid Stage A/Stage B model splits beyond that exception are not authorised. |
+
+Before every pass dispatch (step 4 of the per-pass pipeline), emit a declarative scope preview. The preview is informational only — there is no confirmation prompt, no timeout, no abort option, and no reduce-scope offer. The contract is every journey, every pass; the preview makes that contract explicit so any mid-pass rationalisation is visible against the declared scope.
+
+Template (values filled in per pass, from the map index, independence graph, and dispatch heuristic):
+
+```
+[coverage-expansion] Pass <N>/5 — dispatching <test-composer | adversarial probe> per journey
+  Journeys: <count> (<delta-note, e.g., "3 newly promoted in pass <N-1>">)
+  Independence graph: <G> groups, <K>-way parallel dispatch possible (cap <C>)
+  Model mix: opus default for every Stage A and Stage B dispatch; narrow cycle-1 Stage B sonnet-confirmation exception may apply to ~<sonnet-count> previously-greenlit journeys (see §"Model selection").
+  Expected wall-clock: ~<H>h at <K>-parallel
+  Contract: every journey, this pass. No skips. No batching beyond the explicit P3-batching allowance.
+```
+
+The model-mix figures derive from §"Model selection" — opus is the default across A and B, so the `<sonnet-count>` reports only the narrow cycle-1 Stage B confirmation exception (previously-greenlit journeys with no map delta). The wall-clock estimate is a ballpark from the per-subagent run times observed so far this run (or a default of ~20 min per opus dispatch if no prior data exists — sonnet-confirmation cycles don't get their own ballpark because they're a fast-path variant of the normal Stage B dispatch).
+
+Completion check: if a pass starts with N journeys and ends with returns from fewer than N, the orchestrator must re-dispatch the missing journeys before claiming the pass is complete. The preview's journey count is the ground truth for the end-of-pass reconciliation.
+
+### Auto-compaction between passes
+
+Between passes — after the per-pass commit and state-file rewrite (step 8), before the next pass's dispatch — the orchestrator checks its own context usage. Context exhaustion is a transparent seam, not a pipeline-halt.
+
+If the orchestrator's context is **>70% consumed**:
+
+1. Write full state to `tests/e2e/docs/coverage-expansion-state.json` (journey roster, completed IDs, in-flight IDs, pass counter, adversarial totals, AND the dual-stage `dispatches[]` per-journey fields — `stage_a_cycles`, `stage_b_cycles`, `review_status`, `final_must_fix` — the shape documented in §"Authoritative state file — read first, always"). The dual-stage fields MUST be written before the compaction crosses; without them the post-compact resume cannot reconstruct which journeys are mid-A↔B-cycle, which are blocked, or which are greenlit.
+2. Emit exactly one line: `[coverage-expansion] context approaching budget — auto-compacting and resuming from state file`.
+3. Invoke `/compact` (or the platform-equivalent compaction primitive exposed to the orchestrator).
+4. On the post-compact turn, the skill's first action — reading the state file — picks up the run exactly where it left off, including any in-flight A↔B cycles. That's why §"Authoritative state file" is non-negotiable as the first action.
+
+**Mid-cycle compaction.** The 70% threshold is checked between passes by default, but if a single journey's A↔B retry loop pushes context past 70% mid-pass, the same flow applies: write state with the in-progress `stage_a_cycles` / `stage_b_cycles` / latest reviewer findings, then compact.
+
+**In-flight Stage A returns must be persisted before compaction.** §10 of the design spec says the orchestrator never holds Stage A test source or Stage B review bodies in steady state — but during the brief window between Stage A return and Stage B dispatch, the Stage A return body is necessarily in orchestrator memory. If compaction crosses during that window, the return body would be lost. Mitigation: when an A↔B cycle is mid-flight at compaction time, the orchestrator **persists the latest Stage A return to a scratch file** at `tests/e2e/docs/.coverage-expansion-cycle-<journey-slug>-cycle-<N>.json` before compacting. The post-compact resume reads this scratch file as if it were a fresh Stage A return and proceeds to Stage B dispatch. The scratch file is deleted after the cycle terminates (any of the four `review_status` values) and the per-pass commit lands. Mid-cycle restart from Stage A is NOT acceptable — it would re-run a potentially expensive opus dispatch and lose the discipline gain from the prior cycle's reviewer findings.
+
+**Platform note.** If no programmatic compaction primitive is available to the orchestrator, the skill must still make the seam safe for manual compaction: emit an unambiguous `[coverage-expansion] safe to compact — state is durable at tests/e2e/docs/coverage-expansion-state.json, resume with the same invocation args` line between passes whenever the >70% threshold is crossed. The user can then compact manually without losing progress, and the next turn resumes from the state file the same way.
+
+Framing: this is a platform-aware seam for long runs. It is not a cost-reduction mechanism. The optimisation target remains complete coverage; auto-compaction exists so complete coverage doesn't get halved by a context ceiling.
+
+**Rationalizations to reject:**
+
+| Excuse | Reality |
+|--------|---------|
+| "Context is at 75% but I can push one more pass before compacting" | 70% is the floor, not a guideline. Every pass adds subagent-return summaries that grow the state file and the running adversarial totals. One more pass from 75% often lands at 95%+ and forces an in-pass compact that loses roster state not yet committed. |
+| "I'll compact at 50% to be safe" | Preemptive compaction destroys the prompt cache unnecessarily. 70% is the threshold because below it the seam costs more than it saves. |
+| "The state file is small, there's nothing to save before compacting" | The state file is not the point — the orchestrator's own context (subagent returns, map index, reconciliation scratch) is. State is written *so* compaction is safe. Skipping the write because "state is small" is the bug. |
+| "I'll run Pass 4 to finish the compositional-to-adversarial boundary, then compact" | The compositional-to-adversarial boundary is inside the pass loop, not at 70%. If the threshold was crossed before Pass 4, compact before Pass 4. |
+| "Auto-compact failed once so I'll skip it this time" | The fallback is the manual-compaction safe-seam message, not silent progression. If `/compact` errors, emit the safe-compact line and stop; the user compacts and re-invokes. Never continue past 70% without either auto- or manual-compaction. |
+
+### Re-pass mode for compositional passes 2–3
+
+Passes 2 and 3 dispatch `test-composer` with an explicit `mode: re-pass` argument. Pass 1 already composed the journey's full variant set; re-pass work is valuable only as a disciplined audit against three specific triggers.
+
+**Preamble embedded in every pass-2 / pass-3 test-composer brief:**
+
+> You are a re-pass subagent. Pass 1 already composed this journey. Pass 2/3 work is valuable only when:
+> - The journey map was materially enriched since Pass 1 (look for delta markers against the pre-pass journey block).
+> - The journey's Pass-1 return reported `coverage-gaps: [...]` or `stabilization: deferred`.
+> - A sibling journey surfaced a bug that should be regressed here too.
+> - The prior pass's Stage B reviewer flagged `must-fix` items that Stage A did not resolve (the journey's `review_status` was `blocked-cycle-stalled` or `blocked-cycle-exhausted` last pass). Those unresolved findings are embedded in your brief — address them.
+>
+> You must perform the full inspection regardless — read the current journey block, read the Pass-1 return, read any sibling-bug ledger entries. Only *after* inspection may you return `status: covered-exhaustively` with:
+> - a per-expectation mapping table showing which test covers which Pass-1 expectation,
+> - an explicit check against each of the four triggers above ("trigger 1: no delta markers since Pass 1", "trigger 2: Pass-1 return reported no gaps or deferred stabilization", "trigger 3: sibling-bug ledger contains no regression candidates for this journey", "trigger 4: no unresolved review findings carried forward from the prior pass"),
+> - no unexplained shorthand.
+>
+> **No tool-use budget. No tool-use cap.** Cost is not the optimisation target; signal quality is. The value of a re-pass is disciplined evidence that Pass 1 was exhaustive. An undisciplined cheap no-op is worse than a thorough no-op.
+
+The re-pass mode's contribution is **disciplined justification**, not speed. Every return becomes an auditable artifact — either new tests with their rationale, or `covered-exhaustively` with the full mapping table and the three-trigger check. The orchestrator rejects any pass-2 / pass-3 return that does not include the per-expectation mapping and the three-trigger check, and re-dispatches that journey.
+
+**Rationalizations to reject (subagent side):**
+
+| Excuse | Reality |
+|--------|---------|
+| "Obvious no-op — I'll mark `covered-exhaustively` without reading Pass-1 returns" | The three-trigger check requires evidence. Fabricating "Pass-1 reported no gaps" without reading the return is the exact failure the orchestrator's rejection-and-redispatch step is designed to catch; the redispatch wastes more time than reading the return would have. |
+| "The mapping table is obvious, I'll shorthand it" | Shorthand fails the orchestrator's check. The mapping table enumerates each expectation with the specific test covering it — not "all covered by existing tests". One-line-per-expectation or redispatch. |
+| "Sibling-bug ledger is probably empty for this journey, skip it" | The check is "I read the ledger and found no regression candidates for this journey", not "I assumed there are none". Skipping the read is skipping the trigger. |
+| "No tool-use budget means I can spam tool calls freely" | "No budget" is a signal that signal quality matters more than cost; it is NOT an invitation to over-probe. Use the tools needed to satisfy the three triggers and no more. |
+| "Pass 1 was thorough so Pass 2/3 is always `covered-exhaustively`" | The three triggers explicitly include "map delta since Pass 1" and "sibling-bug regression candidate" — conditions that can only be evaluated at Pass 2/3 time, not inherited from Pass 1's confidence. The returning-it-without-inspection shortcut voids the pass. |
+
+**Orchestrator-side rejection check.** When a pass-2 or pass-3 return arrives, the orchestrator greps the return for (a) the literal strings "trigger 1", "trigger 2", "trigger 3", "trigger 4", (b) a mapping-table header row, and (c) per-expectation entries. If any is missing the orchestrator re-dispatches the journey with a brief explicitly quoting the rejected parts. The orchestrator does NOT accept partial returns as a concession to save re-dispatch cost — the discipline holds on both sides.
+
+### Batched dispatch for P3 peripheral journeys
+
+**Reminder: P3 only. P0/P1/P2 never batch.** Adjacent low-impact journeys — typically P3 smoke or admin-portal siblings sharing one Playwright project — MAY have Stage A batched into a single brief, cap 7 journeys per brief. Every other journey (P0, P1, P2) dispatches one subagent per journey, full stop. If you are tempted to batch a P0/P1/P2 journey because it "shares pages with P3 siblings" or "fits naturally with this group", STOP — that temptation is the failure mode this section's narrowness exists to prevent. Re-read §"Stage A per-journey dispatch is non-negotiable" before continuing.
+
+Dual-stage narrows this:
+
+- **Stage A may still be batched** for eligible P3 journeys (shared project, no pending gap flags, same priority tier, cap 7 per brief — criteria from PR #108).
+- **Stage B is never batched.**
+  Each journey in a batched Stage A still gets its own dedicated Stage B reviewer — never one reviewer judging 7 journeys at once.
+  The reviewer reads only its assigned journey's slice of the batched Stage A return; the reviewer itself is never responsible for multiple journeys.
+- Batching is accepted ONLY when every journey in the batch's cycle-1 Stage B returns `greenlight`.
+- If any journey's cycle-1 Stage B returns `improvements-needed`: split the batch. From cycle 2 onward, the affected journey breaks out and runs its own per-journey Stage A plus its own Stage B. The batched cycle-1 Stage A return is retained as history input to the broken-out cycle-2 Stage A brief. The remaining greenlit journeys in the batch stay accepted at cycle 1 and proceed.
+
+**Rationalizations to reject:**
+
+| Excuse | Reality |
+|--------|---------|
+| "This 8th journey is almost identical to the 7 in the batch, I'll include it" | Cap 7 is not negotiable. Split the batch (5 + 3, etc). The cap bounds brief size and per-journey attention. |
+| "All these journeys are P3 and share a project, and this admin journey *could* be grouped — skip the P1 carve-out" | P0 / P1 always dispatch individually. Priority is load-bearing; a journey at P1 deserves its own brief even if it happens to share pages with P3 siblings. |
+| "The journeys share most pages, same project, roughly P3 — skip the 'shared Playwright project' check" | Different Playwright projects require different `playwright-cli` sessions; batching across projects introduces session-swap complexity that defeats the dispatch optimisation. |
+| "Batching is faster so I'll batch everything that isn't explicitly forbidden" | Batching is allowed, not preferred. P0/P1 individual dispatch is the default; batching is specifically for P3 peripheral sweeps. Defaulting to batch on P2 quietly compresses scope. |
+| "One journey in the batch has a coverage-gap flag from Pass 1, but the gap is trivial" | Any flag in the three re-pass triggers kicks the journey out of the batch into individual dispatch. "Trivial" is the subagent's judgement after reading Pass-1 returns — which cannot happen inside a batched brief. |
+| "All P3 same project, I'll batch Stage B too to save a dispatch" | Stage B per-journey isolation is load-bearing for fresh-eyes review. One reviewer judging 7 journeys is not fresh-eyes; it's batched rubber-stamping. |
+| "Cycle-1 Stage B greenlit 6 of 7 journeys, I'll greenlight the 7th too since it's similar" | The 7th journey's reviewer returned `improvements-needed` for a reason. Split out cycle-2 for that journey; the reason does not carry to the greenlit 6. |
+| "Any flag on any journey kills the whole batch — too expensive, I'll keep batching" | Only the flagged journey breaks out. The greenlit journeys stay batched-and-accepted; no rework for them. |
+| "I'll batch Stage A across P1+P3 journeys if they share a project" | P0/P1 never batch, period. Priority is load-bearing; shared-project is necessary but not sufficient. |
+
+---
+
+## Ledger dedup (single cleanup subagent, runs once after pass 5)
+
+After pass 5 commits, the orchestrator dispatches one additional, non-per-journey cleanup subagent.
+
+### Task for the cleanup subagent
+
+1. Read `tests/e2e/docs/adversarial-findings.md` in full.
+2. Identify near-duplicate findings across journey sections (e.g., "nav-cart badge does not clear after checkout" flagged by multiple journeys).
+3. Consolidate duplicates into the top-level `## Cross-cutting findings` section, listing every journey where each finding surfaced. Leave a short "_See cross-cutting: <title>_" backref in each journey's section (one line per moved finding).
+4. Fix obvious formatting / ordering issues (broken lists, inconsistent severity labels).
+5. Do NOT drop or edit substantive finding content. Do NOT re-classify findings. This is a dedup/consolidation step only.
+6. Commit: `docs(ledger): dedupe cross-cutting findings` (per the **Commit-message conventions** table above).
+
+### Cleanup subagent constraints
+
+- Model: **haiku** is sufficient. This is text-only editing with no browser session, no test composition, no probing.
+- Single dispatch — NOT per-journey. Just one subagent, handed the full ledger file path.
+- Isolated context. No prior session content.
+- Does not modify the journey-map, the page-repository, or any test files. Only the ledger.
+

--- a/skills/coverage-expansion/references/dual-stage-retry-loop.md
+++ b/skills/coverage-expansion/references/dual-stage-retry-loop.md
@@ -1,0 +1,138 @@
+# Dual-Stage Retry Loop — Stage A↔B Per Journey Per Pass
+
+**Status:** authoritative spec for the per-journey dual-stage pipeline. Cited from `coverage-expansion/SKILL.md`.
+**Scope:** the bounded 7-cycle Stage A↔B retry loop, termination conditions, the "fresh reviewer every cycle" invariant, and dual-stage-specific anti-rationalizations.
+
+For the per-pass dispatch pipeline that drives one cycle into this loop, see `references/depth-mode-pipeline.md` §"Per-pass pipeline".
+For the canonical Stage A and Stage B return shapes, see `../element-interactions/references/subagent-return-schema.md` §1, §2, §2.4.
+For the Stage B reviewer's brief and must-fix calibration, see `reviewer-subagent-contract.md`.
+For the adversarial Stage A contract, see `adversarial-subagent-contract.md`.
+
+---
+
+## Dual-stage per-pass contract
+
+Every one of the 5 passes runs **per journey** as two sequential stages:
+
+- **Stage A — Compose / Probe.** The existing `test-composer` (passes 1–3) or adversarial probe subagent (passes 4–5). Dispatch contract unchanged from the single-stage era.
+- **Stage B — Adversarial Review.** A fresh staff-level-QA reviewer subagent, per journey, with its own isolated context and its own isolated `playwright-cli` session (`-s=<journey-slug>-stage-b`). Reads Stage A's output and the live app; returns `greenlight` or `improvements-needed`. Never writes tests, never appends to the ledger, never modifies files.
+
+The dual-stage design addresses a concrete failure mode: a single subagent that both does the work AND self-certifies it misses scenarios a fresh independent reviewer would catch. Stage B is that independent reviewer. It exists to catch what Stage A missed.
+
+**Per journey per pass**, Stage A and Stage B alternate in a bounded retry loop up to 7 A↔B cycles (see §"Retry loop" below). Worst case: 7 A dispatches + 7 B dispatches = 14 per journey per pass.
+
+**Contracts:**
+- Stage A: unchanged from its skill (see `test-composer` for compositional passes, `references/adversarial-subagent-contract.md` for adversarial passes).
+- Stage B: see `references/reviewer-subagent-contract.md` for the full contract and dispatch-brief template.
+- Return shape: both stages use the canonical subagent-return-schema. Stage B's return states (`greenlight`, `improvements-needed`) are additions; Stage A's existing states are unchanged.
+
+**Cost posture.** This skill is **cost-blind**. The optimisation targets are completeness and speed, not dispatch cost. Default opus for every dispatch in every stage. The sonnet-for-P2/P3 heuristic from the prior design is removed; a narrow sonnet exception for cycle-1 Stage B confirmation on previously-greenlit journeys is documented in §"Model selection".
+
+**No-skip extension.** Under dual-stage, the no-skip contract (PR #105) extends: every journey must receive both Stage A and Stage B in every pass. A journey with Stage A but no Stage B is incomplete. The terminal `review_status` set gains three subagent-evidenced blocked values — `blocked-cycle-stalled`, `blocked-cycle-exhausted`, and `blocked-dispatch-failure` — per §"Retry loop" termination conditions. (These hyphenated forms are the canonical `review_status` enum used in the state file's `dispatches[]` array; the no-skip `result` field's `blocked (reason)` shape may carry these strings as the reason text, but `review_status` itself is the bare hyphenated form.)
+
+**Dual-stage no-skip rationalizations to reject:**
+
+| Excuse | Reality |
+|--------|---------|
+| "Stage A returned `covered-exhaustively` with full mapping evidence — no need to dispatch Stage B for this journey" | Stage A's `covered-exhaustively` is one of four valid Stage A returns; it does not authorise skipping Stage B. The reviewer is the verification, not Stage A's self-certification. Dispatch B. |
+| "Cycle 1 Stage B will obviously greenlight this trivial journey, I'll skip it and record `greenlight` in the state file" | Self-certifying greenlights without a reviewer dispatch is exactly the failure mode dual-stage was introduced to close. Dispatch the reviewer; if it really is trivial, sonnet-confirmation is the fast path documented in §"Model selection". |
+| "The journey was greenlit last pass with no map delta — skip the whole A↔B for this pass" | Every journey gets both stages every pass, full stop. Sonnet-confirmation reduces the cost of the trivial-greenlight case but does not eliminate the dispatch. |
+| "The pass is otherwise clean — leaving one journey without a Stage B return is fine, I'll record review_status anyway" | A `review_status` written without a Stage B dispatch having occurred is fabricated state — corrupts the state file, breaks resume, and lies to telemetry. Dispatch B or surface the gap. |
+
+### Retry loop (orchestrator, per journey per pass)
+
+For each journey in the current pass's roster, the orchestrator runs:
+
+```
+stage_a_input = base_brief                             # initial cycle-1 input
+history = []
+
+for cycle in 1..7:
+  try:
+    a_return = dispatch Stage A with stage_a_input
+  except DispatchFailure:                              # transport / timeout / malformed
+    review_status = "blocked-dispatch-failure"
+    break
+
+  if not validates(a_return, schema_§4.1):             # malformed content
+    re-dispatch once with same brief; if it fails again:
+      review_status = "blocked-dispatch-failure"
+      break
+
+  b_return = dispatch Stage B (fresh ctx, fresh playwright-cli session) to review a_return
+
+  if b_return.status == "greenlight":
+    review_status = "greenlight"
+    break
+
+  must_fix = b_return.findings  # every reviewer finding is must-fix; no other priority exists
+
+  if must_fix is empty:                               # status was "improvements-needed" but findings empty
+    re-dispatch reviewer once with stricter brief; if same shape returns:
+      coerce to "greenlight" (no findings = no changes needed)
+      review_status = "greenlight"
+      break
+
+  # Stall detection — fires on either signal:
+  #   (a) reviewer's self-flagged stalled: true (per reviewer-contract step 7), OR
+  #   (b) three cycles in a row with identical must-fix lists (i.e., the
+  #       current cycle and the two immediately-prior cycles all share the
+  #       same must-fix list, meaning Stage A failed to address it across
+  #       two consecutive retry attempts).
+  # One match (current == prior-1) is NOT enough: a reviewer in cycle N+1 may
+  # legitimately catch a finding the cycle-N reviewer missed, then cycle N+2's
+  # reviewer matches N+1's — cycle N+1 was real progress, not stall. Require
+  # current == prior-1 == prior-2 (two consecutive matches, three identical
+  # lists in total). identical_run counts current + each prior that matches,
+  # so the threshold is >= 3.
+  identical_run = 1
+  for prior in reversed(history):
+    if prior.must_fix == must_fix:
+      identical_run += 1
+    else:
+      break
+  if b_return.stalled == true or identical_run >= 3:
+    review_status = "blocked-cycle-stalled"
+    break
+
+  history.append({"cycle": cycle, "must_fix": must_fix})
+  stage_a_input = base_brief + b_return.findings
+
+if cycle == 7 and review_status is unset:
+  review_status = "blocked-cycle-exhausted"
+
+# Precedence note: if cycle 7's must_fix matches a stalled run, the loop breaks
+# on blocked-cycle-stalled BEFORE the post-loop check. Stalled wins over exhausted
+# when both apply — different downstream signal (re-pass trigger 4 wording,
+# telemetry calibration). This is intentional.
+
+record journey review_status + cycle count + final must_fix list in state file
+```
+
+**Termination conditions:**
+
+| Condition | `review_status` | Action |
+|---|---|---|
+| Reviewer returns `greenlight` | `greenlight` | Accept, commit this journey's work this pass. |
+| Reviewer returns `improvements-needed` with **empty** findings, twice in a row | `greenlight` (coerced) | Empty findings = no changes needed; the `improvements-needed` status was malformed. Coerce after one re-dispatch. |
+| Reviewer's `must-fix` list identical for **3+ cycles in a row** (current == prior-1 == prior-2) OR reviewer sets `stalled: true` | `blocked-cycle-stalled` | Escalate — Stage A failed to address this list across two consecutive retries. Commit whatever Stage A landed; log the unresolved list. **Takes precedence over exhausted** when cycle 7's list satisfies the same condition. |
+| Cycle 7 reached without greenlight (and not stalled) | `blocked-cycle-exhausted` | Escalate — retry budget spent. Commit whatever Stage A landed; log the unresolved list. |
+| Stage A dispatch fails (transport / timeout / malformed schema), re-dispatch also fails | `blocked-dispatch-failure` | Escalate — infrastructure issue, not a discipline issue. Commit nothing for this journey this pass; carries to next pass with the failure noted in trigger-4 input. |
+
+Both blocked statuses are valid terminal values under the no-skip contract (PR #105). They are **not** pass failures — they are visible deferrals. The orchestrator records the `must-fix` list to the state file and carries it forward to the next pass as an explicit Stage A input (see §"Re-pass mode" trigger 4).
+
+**Why 7 cycles.** Gives genuine room for adversarial iteration: first review catches obvious gaps, second fills subtler ones, third addresses what the reviewer missed the first read. The bounded cap prevents runaway loops while leaving enough slack that exhaustion is the exception rather than the common case. The same numeric value (7) appears as the P3 batch cap in §"Batched dispatch for P3 peripheral journeys" — these two 7s are **independent design choices** that happen to share a number. Changing one does not require changing the other; the rationales are unrelated (cycle cap = adversarial-iteration-budget; batch cap = brief-size-and-per-journey-attention-budget).
+
+**Fresh reviewer every cycle.** Every Stage B dispatch is a fresh subagent with a fresh `playwright-cli` session — no context inheritance from the prior cycle's reviewer, no context inheritance from the paired Stage A. The fresh-eyes property is load-bearing; if the reviewer carries state across cycles, it will start agreeing with Stage A.
+
+**Rationalizations to reject:**
+
+| Excuse | Reality |
+|--------|---------|
+| "Cycle 3 has the same must-fix list but I think Stage A could fix them with one more try" | If the list is identical, Stage A has already failed to address these items with the same inputs twice. `blocked-cycle-stalled` is the correct terminal state; human or follow-up-pass attention is the next step. |
+| "Reviewer returned improvements-needed but the must-fix list is small; I'll skip the retry" | A single `must-fix` item is enough to block greenlight. Retry with the findings appended. |
+| "I'll compact findings from cycles 1–4 into one summary string for cycle 5's input" | Compressed findings lose the surgical specificity Stage A needs to fix them. Pass the full findings through verbatim. |
+| "Cycle 7 exhausted and I'll just call it greenlit to keep the pass moving" | `blocked-cycle-exhausted` is the correct terminal. Marking it greenlit when it isn't corrupts the state file and the next pass's trigger-4 input. |
+| "Reviewer disagrees with itself between cycles 1 and 2; I'll pick the more lenient one" | Each cycle's reviewer is fresh and independent. Take each cycle's output as-is; the retry-loop logic handles divergence via the stalled/exhausted checks. |
+
+---

--- a/skills/coverage-expansion/references/state-file-schema.md
+++ b/skills/coverage-expansion/references/state-file-schema.md
@@ -1,0 +1,69 @@
+# Coverage-Expansion State File — Schema and Lifecycle
+
+**Status:** authoritative spec for `tests/e2e/docs/coverage-expansion-state.json`. Cited from `coverage-expansion/SKILL.md`.
+**Scope:** what the file contains, when it is written, how to resume from it, and when to refuse a state file as corrupt.
+
+For the auto-compaction flow that triggers state-file writes mid-pipeline, see `references/depth-mode-pipeline.md` §"Auto-compaction between passes".
+For the dual-stage `dispatches[]` per-journey fields' meaning, see `references/dual-stage-retry-loop.md`.
+
+---
+
+## Authoritative state file — read first, always
+
+The skill's **first action on entry**, before anything else, is to read `tests/e2e/docs/coverage-expansion-state.json`. Resumption is a contract, not a convention.
+
+```
+1. Read tests/e2e/docs/coverage-expansion-state.json.
+2. If the file is absent, or status == "complete", start Pass 1 from scratch.
+3. If currentPass is set, resume from that pass's journey roster.
+4. Skip journeys already marked complete in the state file for the current pass.
+5. Only when all 5 passes + cleanup show complete, return "coverage-expansion finished".
+```
+
+The state file is authoritative. The orchestrator must not reason about "where did we leave off" from chat history, commit log, or journey-map deltas — those are diagnostic, not authoritative. If the file says currentPass=3 with 22 of 45 journeys complete, Pass 3 resumes with the remaining 23 journeys and Pass 4/5/cleanup run afterwards.
+
+State file shape (minimum fields):
+
+```json
+{
+  "status": "in-progress",
+  "currentPass": 3,
+  "journeyRoster": ["j-...", ...],
+  "completedJourneys": ["j-...", ...],
+  "inFlightJourneys": ["j-...", ...],
+  "dispatches": [
+    {
+      "journey": "j-<slug>",
+      "stage_a_cycles": 2,
+      "stage_b_cycles": 2,
+      "review_status": "greenlight",
+      "final_must_fix": [],
+      "result": "new-tests-landed",
+      "authorizer": null
+    }
+  ],
+  "adversarialTotals": { ... },
+  "updatedAt": "2026-04-24T..."
+}
+```
+
+**Per-journey dispatch entry fields (dual-stage).** Each entry in `dispatches[]` carries:
+
+- `journey` — the journey ID (`j-<slug>`).
+- `stage_a_cycles` — integer; number of Stage A dispatches for this journey in this pass (1..7).
+- `stage_b_cycles` — integer; number of Stage B dispatches for this journey in this pass (equal to or one less than stage_a_cycles depending on whether cycle 7 exhausted or greenlit early).
+- `review_status` — one of `greenlight | blocked-cycle-stalled | blocked-cycle-exhausted | blocked-dispatch-failure`.
+- `final_must_fix` — array of finding-IDs. Empty for `greenlight`; populated for blocked statuses with the list Stage A failed to resolve (carried to next pass's Stage A brief as trigger 4).
+- `result` — the no-skip contract enum value (`new-tests-landed | covered-exhaustively | blocked | skipped`). `result` describes Stage A's outcome alongside the no-skip enum; `review_status` describes Stage B's judgement; together they describe both stages' outcomes.
+- `authorizer` — only non-null for `skipped` (requires user authorisation).
+- `batch_id` — nullable string. Non-null when this journey was part of a batched Stage A dispatch (per §"Batched dispatch for P3 peripheral journeys"); the `batch_id` value is shared across every journey in the same batch so resume logic can reconstruct the batch grouping. Null for individually-dispatched journeys. When a journey breaks out of a batch mid-cycle (any cycle ≥ 2 after its Stage B returned `improvements-needed`), `batch_id` becomes null from cycle 2 onward — the cycle-1 batched entry retains the original `batch_id`, the cycle-2+ individual entry does not. `stage_a_cycles` is recorded per-journey in both cases.
+
+A state file missing `stage_a_cycles`, `stage_b_cycles`, or `review_status` for any journey that has run this pass is incomplete — resume logic treats it as corrupt per the existing §"State-file lifecycle" rule.
+
+The state file is rewritten after every per-pass commit (and whenever auto-compaction triggers — see §"Auto-compaction between passes" below).
+
+**Journey-roster mutability.** The roster for a given pass is frozen at the start of that pass — it is a snapshot of the journey IDs the orchestrator intends to dispatch *this pass*. If a compositional pass discovers and promotes a new journey or sub-journey mid-pass, the new entry is appended to the **next** pass's roster, not retroactively to the current pass's. This prevents the "did I cover everything?" ambiguity where `journeyRoster` and `completedJourneys` diverge because the roster keeps growing. Reconciliation commits (Pass 2/3) write the new roster to the state file at the same commit that appends the new map blocks, so the post-compact resume reads a consistent roster-to-map alignment.
+
+**Corrupted or stale state file.** If the state file is present but references journeys that no longer appear in `journey-map.md`, or if `currentPass` is set but `completedJourneys` is a superset of `journeyRoster`, the orchestrator stops and reports the mismatch to the caller rather than guessing. Self-repair is out of scope — a corrupted state file is a manual-triage signal, not a silent reset.
+
+---

--- a/skills/coverage-expansion/references/subagent-isolation.md
+++ b/skills/coverage-expansion/references/subagent-isolation.md
@@ -1,0 +1,42 @@
+# Isolated Subagent Contract — Coverage-Expansion
+
+**Status:** authoritative spec for the dispatch contract every coverage-expansion subagent must satisfy. Cited from `coverage-expansion/SKILL.md`.
+**Scope:** isolation guarantees, the brief inputs each subagent receives, the `playwright-cli` session naming convention, and the orchestrator's "never hold subagent payload content" rule.
+
+For the canonical return shape every subagent uses, see `../element-interactions/references/subagent-return-schema.md`.
+For the role-prefix routing convention used on description prefixes and CLI session slugs, see `coverage-expansion/SKILL.md` §"Role prefixes".
+
+---
+
+## Isolated subagent contract
+
+### Compositional passes (1–3)
+
+Every `test-composer` subagent dispatched by this skill must:
+
+1. Receive an **isolated context window** — no prior session content, no other journey's data.
+2. Receive only: its assigned journey block + any `sj-<slug>` sub-journey blocks it references + the current `page-repository.json` slice for the pages that journey touches.
+3. Have access to an **isolated `playwright-cli` session** named `composer-<journey-slug>-<pass>-c<N>` (e.g. `composer-j-checkout-3-c1`), opened by the subagent at the start of its work and closed at the end. Sessions are OS-isolated by construction — one browser process per `-s=<name> open` — so there is no isolation-prerequisite check to run before dispatching. The subagent's brief includes a pointer to [`../element-interactions/references/playwright-cli-protocol.md`](../element-interactions/references/playwright-cli-protocol.md) §3 + §8 (the dispatch-brief template). The parent does **not** call `close-all` while subagents are working; it runs `close-all` once the pass completes as belt-and-suspenders cleanup.
+4. Not return until stabilization green, API compliance review clean, and coverage verified exhaustive (enforced inside `test-composer`).
+5. Return a structured discovery report only — no pasted test source, no DOM snapshots, no CLI transcripts. Returns follow the canonical return schema in [`../element-interactions/references/subagent-return-schema.md`](../element-interactions/references/subagent-return-schema.md); the dispatch brief includes a pointer to the file rather than re-pasting the schema.
+
+### Adversarial passes (4–5)
+
+Every adversarial probe subagent dispatched by this skill must:
+
+1. Receive the same isolated context window as compositional-pass subagents, with its own `playwright-cli` session named `probe-<journey-slug>-<pass>` (pass = 4 or 5). Same isolation guarantee as the compositional case (per-session browser process; see `playwright-cli-protocol.md` §1).
+2. Additionally receive: the pass number (4 or 5), the ledger file path (`tests/e2e/docs/adversarial-findings.md`), the lockfile path (`tests/e2e/docs/.adversarial-findings.lock`), and a pointer to the canonical schema at `skills/element-interactions/references/subagent-return-schema.md`.
+3. Receive a pre-built **negative-case matrix** for the journey — one negative-case complement per `Test expectations:` entry, plus the standard cross-cutting negatives (auth tamper, tenant isolation, idempotency, session boundary, input boundaries) — derived per `references/adversarial-subagent-contract.md` §"Negative-case matrix — full QA scope". The matrix is the deterministic floor for the probe; `bug-discovery`'s open-ended categories extend above it. The orchestrator builds the matrix from the journey block before dispatch and includes it verbatim in the brief — the subagent does not re-derive it.
+4. For pass 5 specifically: also receive the journey's pass-4 ledger section (read from the ledger file before dispatch and passed along — the orchestrator's single exception to the "never hold findings content" rule, bounded to one journey's section for one subagent), so the subagent can re-probe matrix entries that returned `Ambiguous` in pass 4 and run compound probes across matrix entries.
+5. Follow the adversarial subagent contract in `references/adversarial-subagent-contract.md` exactly, which mandates conformance to the canonical return + ledger schema.
+6. Return a structured summary only, matching the return shape in that contract. No probe transcripts, no DOM snapshots, no test source. Any per-finding detail inside the return follows the canonical finding-return format.
+
+### Cleanup subagent (post-pass-5)
+
+1. Single dispatch, NOT per-journey.
+2. Isolated context. Receives only the ledger file path.
+3. No browser session. Text-only work.
+4. Returns a one-line summary of how many cross-cutting findings were consolidated and how many journeys' sections were backref'd.
+
+The orchestrator does not paste any probe transcripts, DOM snapshots, test source, or stabilization output into its own context at any point.
+

--- a/skills/element-interactions/SKILL.md
+++ b/skills/element-interactions/SKILL.md
@@ -446,11 +446,14 @@ Full per-entry-point contracts live in [`references/autonomous-mode-callers.md`]
 
 The four-stage pipeline (Stage 1 Scenario Discovery → Stage 2 Element Inspection → Stage 3 Write Automation → Stage 4a Test Optimization + Stage 4b API Compliance Review) is specified in [`references/stages-protocol.md`](references/stages-protocol.md). Read it before authoring or modifying any test under this skill.
 
-Key invariants kept here:
+### Hard rules — kernel-resident
 
-- **Run stages in order, no skipping.** Skip-to-Stage-3 mode (Stage 3 only, scope= one named test, no new selectors) is the lone exception, narrowly scoped per `references/stages-protocol.md` §"Skip-to-Stage-3".
+- **Run stages in order, no skipping.** Skip-to-Stage-3 mode (Stage 3 only, scope = one named test, no new selectors) is the lone exception, narrowly scoped.
 - **Hard gates between stages.** Stage 1 → 2: scenario list + page coverage explicit. Stage 2 → 3: every selector lives in `page-repository.json`. Stage 3 → 4a: test passes 3× green in isolation. Stage 4a → 4b: optimization checklist clean. Stage 4b → done: API compliance checklist clean.
-- **Stage 4b reviews against `references/api-reference.md` exclusively.** No raw Playwright APIs that have a Steps equivalent.
+- **Stage 4b reviews against `references/api-reference.md` exclusively.** Raw Playwright APIs that have a Steps equivalent are rejected.
+- **Every test MUST end with a verification proving the action's effect.** A test that performs actions (click, fill, drag, hover, check, upload, setSliderValue, etc.) and never asserts a resulting state is not a test — it's a smoke call that only catches thrown exceptions. The final meaningful statement must be a `verify*`, a matcher-tree assertion (`.text.toBe`, `.visible.toBeTrue`, `.satisfy`, …), or a typed `expect(extractedValue)` reflecting what the action was supposed to change.
+- **Selectors are NEVER invented.** Every selector is either inspected from the live site (Stage 2) or reuses an existing entry in `page-repository.json`. Inline selectors in test code are a hard rule violation.
+- **Application bugs are reported, not worked around.** If a bug blocks the test, surface the bug — don't write a test that pretends the bug isn't there.
 
 ## API Reference
 

--- a/skills/element-interactions/SKILL.md
+++ b/skills/element-interactions/SKILL.md
@@ -23,6 +23,21 @@ A two-package Playwright framework that decouples **element acquisition** (`@civ
 
 > **Skill names: see `references/skill-registry.md`.** Copy skill names from the registry verbatim. Never reconstruct a skill name from memory or recase it.
 
+## Reference index
+
+This file is the rules-and-pointers kernel. The heavy spec lives in `references/`:
+
+| Reference file | What's in it |
+|---|---|
+| [`references/api-reference.md`](references/api-reference.md) | The Steps API surface — what to read before writing or modifying any test. |
+| [`references/playwright-cli-protocol.md`](references/playwright-cli-protocol.md) | The canonical browser-automation primitive: session model, slug naming, snapshots, auth state, dispatch-brief template. |
+| [`references/stages-protocol.md`](references/stages-protocol.md) | Stages 1–4 protocol: scenario discovery, element inspection, write automation, post-stabilization review (4a + 4b). |
+| [`references/subagent-return-schema.md`](references/subagent-return-schema.md) | Canonical return + ledger schema for every dispatched subagent. §4.1 grep-based conformance check; §4.2 harness validator (issue #127). |
+| [`references/test-optimization.md`](references/test-optimization.md) | Stage 4a optimization checklist + the whole-suite re-run gate. |
+| [`references/cascade-detector.md`](references/cascade-detector.md) | Cascade detector — orchestrator that picks the right entry skill from project state. |
+| [`references/autonomous-mode-callers.md`](references/autonomous-mode-callers.md) | Per-caller `autonomousMode: true` contracts. |
+| [`references/skill-registry.md`](references/skill-registry.md) | Canonical skill name registry. |
+
 ## Autonomous-mode invocation cheat-sheet
 
 Companion skills (`onboarding`, `coverage-expansion`, `test-composer`, `companion-mode`) invoke this orchestrator with `autonomousMode: true` to disable the interactive hard gates. Each caller has its own required-args contract — they are NOT interchangeable.
@@ -427,248 +442,15 @@ Full per-entry-point contracts live in [`references/autonomous-mode-callers.md`]
 
 ---
 
-## Stage 1: Scenario Discovery
+## Stages 1–4 protocol
 
-**Goal:** Understand the application and produce a clear, conventional scenario that the user approves.
+The four-stage pipeline (Stage 1 Scenario Discovery → Stage 2 Element Inspection → Stage 3 Write Automation → Stage 4a Test Optimization + Stage 4b API Compliance Review) is specified in [`references/stages-protocol.md`](references/stages-protocol.md). Read it before authoring or modifying any test under this skill.
 
-### Fast Path
+Key invariants kept here:
 
-If the user provides a complete scenario or detailed acceptance criteria upfront, do NOT ask unnecessary discovery questions. Instead:
-
-1. Reformat their scenario into the Given/When/Then structure below, favouring clear, discrete steps.
-2. Ask only about anything that is genuinely unclear or ambiguous.
-3. Present the formatted scenario for approval.
-
-### Full Discovery Process
-
-When the user provides a URL, a vague idea, or needs help figuring out what to test:
-
-1. **Get the app URL or acceptance criteria.** The user may provide a URL, a description of the scenario, or both. If they provide a URL, use `playwright-cli` (see [`references/playwright-cli-protocol.md`](references/playwright-cli-protocol.md)) to navigate and explore.
-2. **Discover the app.** Use `playwright-cli` to navigate to the app, take snapshots (`playwright-cli snapshot`), and understand what the application does. Explore the pages relevant to the scenario.
-3. **Ask clarifying questions — one at a time.** Focus on understanding:
-   - What is the user flow being tested?
-   - What are the preconditions (logged in? specific data state?)
-   - What constitutes success vs failure?
-   - Are there edge cases to cover?
-4. **Present the scenario** in conventional Given/When/Then format:
-
-```
-Scenario: [Descriptive name]
-  Given [precondition]
-  And [additional precondition if needed]
-  When [action the user takes]
-  And [additional action if needed]
-  Then [expected outcome]
-  And [additional verification if needed]
-```
-
-For complex flows, break into multiple scenarios.
-
-### Hard Gate
-
-> "Here's the scenario I've drafted. Does this accurately capture what you want to automate? Any changes before I move on to inspecting the page elements?"
-
-**Wait for explicit approval.** If the user wants changes, revise and re-present. Do NOT proceed to Stage 2 until the scenario is approved.
-
----
-
-## Stage 2: Element Inspection
-
-**Goal:** Identify all elements needed for the approved scenario and propose page-repository entries.
-
-### With `playwright-cli`
-
-1. **Open a session and navigate** to each page involved in the scenario:
-   - `npx playwright-cli -s=stage2-<scenario-slug> open --browser=chromium <URL>`
-   - subsequent `goto` / `click` / `fill` calls reuse the same `-s=` session.
-2. **Take snapshots** (`npx playwright-cli -s=stage2-<scenario-slug> snapshot`) and inspect the DOM to find reliable selectors for each element referenced in the scenario.
-3. **Prefer selectors in this order:** `data-test` / `data-testid` attributes > `id` > stable CSS selectors > text > XPath.
-4. **Build the page-repository entries.** For each element, determine the best selector strategy.
-5. **Check existing `page-repository.json`** — if some elements already exist, note which ones are new vs already covered.
-6. **Close the session** when done: `npx playwright-cli -s=stage2-<scenario-slug> close`.
-
-### When `playwright-cli` cannot reach the live app
-
-The CLI is always installed (hard dep), but the browser binary may be missing or the live app may be unreachable from this environment. In either case, fall back to user-supplied selectors:
-
-> "I can't reach the live app to inspect selectors (browser binary missing — run `npx playwright-cli install-browser chromium` — or app URL unreachable from this environment). Could you provide the selectors for the elements in the scenario? I need entries for: [list elements from the approved scenario]. You can give me CSS selectors, IDs, text values, or full page-repository JSON entries."
-
-Use whatever the user provides to build the page-repository entries. Do NOT guess or infer selectors.
-
-### Present Proposed Selectors
-
-Show the user the exact JSON entries you want to add:
-
-```json
-{
-  "pages": [
-    {
-      "name": "LoginPage",
-      "elements": [
-        { "elementName": "usernameInput", "selector": { "css": "input[data-test='username']" } },
-        { "elementName": "passwordInput", "selector": { "css": "input[data-test='password']" } },
-        { "elementName": "submitButton", "selector": { "css": "button[type='submit']", "text": "Log In" } }
-      ]
-    }
-  ]
-}
-```
-
-### Hard Gate
-
-> "These are the selectors I've identified for the scenario. Should I add them to `page-repository.json`? Let me know if any need adjusting."
-
-**Wait for explicit approval.** Do NOT edit `page-repository.json` until the user says yes. If changes are requested, re-inspect and re-present.
-
----
-
-## Stage 3: Write Automation
-
-**Goal:** Write the Playwright test using the Steps API and approved page-repository entries.
-
-### Writing Process
-
-1. **Check project setup.** Read `tests/fixtures/base.ts` and `playwright.config.ts` — create or update only if missing or broken. Also verify that `.gitignore` includes `.claude/` and `CLAUDE.md` to prevent Claude Code configuration from being pushed to the repository — add them if missing.
-2. **Add approved selectors** to `page-repository.json` (if not already done).
-3. **Read `references/api-reference.md`** — load the full API reference before writing any test code. Do not write from memory.
-4. **Write the test file** using the Steps API. Every interaction goes through `steps.*` methods — no raw `page.locator()` calls.
-5. **Every test MUST end with a verification that proves the ACTION's EFFECT.** A test that performs actions (click, fill, drag, hover, check, upload, setSliderValue, etc.) and never asserts a resulting state is not a test — it's a smoke call that only catches thrown exceptions. Before declaring a test done, confirm the final meaningful statement is a `verify*`, a matcher-tree assertion (`.text.toBe`, `.visible.toBeTrue`, `.satisfy`, …), or a typed `expect(extractedValue)` that reflects what the action was supposed to change.
-
-   **The verification must be causally tied to the action, not a tautology.** An assertion that would pass whether the action ran or not is not a verification — it's noise. Common anti-patterns to catch:
-   - **Clicking a list item and asserting the list is still present.** `clickListedElement('rows', {text:'Alice'})` followed by `verifyPresence('rows')` proves nothing — the rows were present before the click too. Instead: verify the specific effect (navigation, selected-state change, status update, row-specific `data-selected` attribute, `stateSummary` text, etc.).
-   - **Hovering an element and asserting it's still visible.** The element was visible to be hovered. Verify hover feedback (tooltip text, popover visibility, CSS color change, aria-expanded toggle).
-   - **Filling an input and asserting the input exists.** Inputs don't disappear when filled. Verify `verifyInputValue(expected)` or a dependent element that reflects the filled value (error/success message, submit-button enabled state).
-   - **Clicking a button and asserting the button is enabled/visible.** Verify the button's ACTION — a result element updating, a modal opening, a URL change, a disabled state after submission.
-   - **Filter by text `{regex: 'A|B|C'}` then assert the parent collection is present.** Verify the FILTERED RESULT reflects the regex: extract text via `getListedElementData` and match the same pattern, or navigate to one of N alternatives and assert URL/state matches one of N expected outcomes.
-
-   When picking a verification, ask: **"If the action had silently done nothing, would this assertion still pass?"** If yes, the assertion is tautological — find one that would fail under a no-op.
-
-   Only in rare, explicitly documented cases where the action genuinely has no observable effect at any layer (e.g. a framework-level smoke exercise of an API's call shape) may you fall back to `verifyState('visible')` on the target element — and the reason must be stated in a one-line comment. Never leave a test trailing on an action.
-6. **Run the test** with `npx playwright test <test-file>`.
-7. **If the test fails:** invoke the `failure-diagnosis` protocol — collect evidence (screenshot, DOM, error context), group failures by root cause, classify (test issue vs app bug vs ambiguous), check edge cases, then fix test issues autonomously with stability validation (3-5 passing runs) or report app bugs with full evidence. If the fix requires new selectors, use `playwright-cli` to inspect the DOM, propose the new entry, and get approval before editing.
-8. **If the test passes:** commit immediately.
-
-### Skip-to-Stage-3 (Fix/Edit Mode)
-
-When the user asks to fix or edit an existing test, skip Stages 1 and 2. Read `references/api-reference.md`, then read the existing test, understand the issue, and proceed directly to fixing and running. If fixing requires new selectors, use the mini-inspection flow described above — do NOT silently add selectors.
-
----
-
-## Stage 4: Post-Stabilization Review (split into 4a + 4b)
-
-**Stage 4a runs first, Stage 4b runs second.** Both run automatically after a test reaches passing state in Stage 3, before commit.
-
-### Stage 4a: Test Optimization
-
-**Goal:** enforce test-isolation, speed, and DRY best practices on freshly-written tests.
-
-**Process:**
-
-1. Read `references/test-optimization.md` — load the full protocol (8 sections).
-2. Read every test file written or modified in this session, plus `tests/fixtures/base.ts` and `tests/e2e/docs/app-context.md`'s `## Test Infrastructure` section.
-3. Run the 6 checks against each spec.
-4. Apply auto-fixes (per-test patterns, §1–§5 with auto-fix). Write proactive helpers into `base.ts` (cross-test patterns) only when both gates apply (UI-covered + API discovered, see §4). Re-run the affected tests; confirm they still pass.
-5. Emit the structured return per `references/test-optimization.md` §8.
-6. Proceed to Stage 4b.
-
-If Stage 4a's auto-fixes cause a previously-passing test to fail, follow Rule 7 (failure-diagnosis protocol) — inspect the screenshot, classify, fix or revert. Do not advance to Stage 4b until Stage 4a's tests are green again.
-
-### Stage 4b: API Compliance Review
-
-**Goal:** Review test code against the API Reference to ensure correct usage of the `@civitas-cerebrum/element-interactions` package.
-
-**This stage triggers automatically every time Stage 4a returns clean.** Do NOT batch — review each test case immediately after Stage 4a clears, before moving on to the next scenario. Even if the tests pass, they may be using the API incorrectly (wrong argument order, deprecated methods, missing options, incorrect types). Catching issues early prevents the same mistake from propagating into subsequent test cases.
-
-### Review Checklist
-
-For each test file, verify:
-
-1. **Method signatures** — every `steps.*` call matches the exact signature in the API Reference (correct argument count, correct argument order, correct types).
-2. **Imports** — all types used (`DropdownSelectType`, `EmailFilterType`, `FillFormValue`, etc.) are imported from `@civitas-cerebrum/element-interactions` (or `@civitas-cerebrum/email-client` for email types). No invented imports.
-3. **Page/element naming** — `pageName` uses PascalCase, `elementName` uses camelCase, and both match entries in `page-repository.json`.
-4. **Listed element options** — `child` uses `{ pageName, elementName }` repo references where possible instead of inline selectors (per Rule 5).
-5. **Dropdown select usage** — `DropdownSelectType.RANDOM`, `.VALUE`, or `.INDEX` with the correct companion field (`value` or `index`).
-6. **Email API usage** — `steps.sendEmail` / `steps.receiveEmail` / `steps.receiveAllEmails` / `steps.cleanEmails` match the documented signatures. Filter types use `EmailFilterType` enum.
-7. **No raw Playwright calls** — no `page.locator()`, `page.click()`, `page.fill()`, or other raw Playwright methods where a `steps.*` equivalent exists.
-8. **Fixture usage** — the test destructures only fixtures provided by `baseFixture` (`steps`, `repo`, `interactions`, `contextStore`, `page`) plus any custom fixtures defined in the project's `base.ts`.
-9. **Waiting methods** — correct state strings (`'visible'`, `'hidden'`, `'attached'`, `'detached'`) and correct usage of `waitForResponse` callback pattern.
-10. **Verification methods** — correct option shapes (`{ exactly }`, `{ greaterThan }`, `{ lessThan }` for `verifyCount`; `verifyText()` with no args asserts not empty). The 4-arg form `verifyText(el, page, undefined, { notEmpty: true })` and the `TextVerifyOptions.notEmpty` flag are deprecated — use `verifyText(el, page)` (or `.on(el, page).verifyText()` fluent) instead.
-11. **Every test ends with a verification — and that verification proves the action's effect, not a tautology.** Two sub-checks:
-   - **Presence.** No test may finish on an action with no trailing assertion. If the last meaningful statement is `click`, `fill`, `drag`, `hover`, `check`, `upload`, `setSliderValue`, etc., flag it.
-   - **Causal meaning.** Even with a trailing assertion, flag it if it would pass whether the action ran or not. Examples to catch: `verifyPresence('rows')` after `clickListedElement('rows', {text:'X'})` (the list was there before the click); `verifyState('visible')` on the hovered element (it was visible to be hovered); `verifyInputValue('anything')` where no causal link to the fill exists.
-
-   When reviewing, ask: *"If the action had silently done nothing, would this assertion still pass?"* If yes, the verification is tautological — replace it with one that reflects the action's specific observable effect (navigation, text update, state-summary change, attribute flip, modal open, URL change, dependent-element reaction). Pure framework-smoke cases may fall back to a weak check but require a one-line comment justifying it. "The action didn't throw" is not a verification.
-
-### Process
-
-1. **Read `references/api-reference.md`** — load the full API reference. Do not review from memory.
-2. **Read each test file** written or modified in this session.
-3. **Cross-reference every API call** against the API Reference.
-4. **Report findings** to the user — list any issues found with the specific line, what's wrong, and the correct usage.
-5. **If issues are found:** investigate *why* the non-compliant code was written — was the API misunderstood? Was a method signature wrong in the scenario? Did a previous stage produce incorrect assumptions? Understanding the root cause prevents the same mistake from recurring in the next scenario. Then fix, re-run the tests, and confirm they still pass.
-6. **If fixes cause a test failure:** follow Rule 6 — inspect the failure screenshot first before attempting any further fix. Do NOT guess from the error message alone.
-7. **If no issues are found:** confirm compliance and proceed to commit.
-
-### Output Format
-
-Present the review as:
-
-> **API Compliance Review**
->
-> Reviewed: `tests/example.spec.ts`, `tests/login.spec.ts`
->
-> - **`example.spec.ts:15`** — `steps.backOrForward('back')` should be `steps.backOrForward('BACKWARDS')` (uses uppercase enum-style strings)
-> - **`login.spec.ts:8`** — missing import for `DropdownSelectType`
->
-> [number] issue(s) found. Fixing now.
-
-Or if clean:
-
-> **API Compliance Review**
->
-> Reviewed: `tests/example.spec.ts`
->
-> All API calls match the documented signatures. No issues found.
-
----
-
-## Onboarding Completion Gate
-
-**Goal:** When the user signals they have no more individual scenarios to add (the "onboarding cycle" — Stages 1-4 — is complete), explicitly offer Stage 5 (Coverage Expansion) instead of silently ending the session.
-
-### When this gate triggers
-
-After any Stage 4 commit, when the user indicates they are done adding individual scenarios — for example by saying "that's all", "we're done", "no more for now", or by simply not requesting another scenario after a reasonable pause.
-
-### What to do
-
-1. **Summarize what was built in the onboarding cycle.** Briefly list the scenarios committed, the pages covered, and the page-repository entries added. Keep it to 3-5 lines.
-2. **Run a readiness check** before offering Stage 5:
-   - All committed tests pass on a clean re-run
-   - `page-repository.json` is valid JSON and matches the tests
-   - `tests/e2e/docs/app-context.md` exists and reflects the pages discovered so far
-   - No open API compliance issues from Stage 4
-   - If any check fails, fix it first — do NOT offer Stage 5 with a broken baseline
-3. **Present the offer to the user verbatim:**
-
-> **Onboarding cycle complete.**
->
-> You now have an initial test suite that covers the scenarios you described. The next stage is **Coverage Expansion** — I would systematically probe the rest of the application, identify uncovered pages and flows, and build out the suite until every page and interactive element has test coverage. This typically takes multiple iteration cycles and runs more autonomously than the staged onboarding flow.
->
-> Would you like me to proceed to **Stage 5: Coverage Expansion**? I can also:
-> - **Pause here** — I'll stop and you can resume any time by asking
-> - **Jump straight to Bug Discovery (Stage 6)** — only recommended if you already have comprehensive coverage from a previous session
-> - **Generate a work summary deck** — produce a stakeholder-facing report of what was built so far
-
-4. **Wait for explicit user choice.** Do NOT auto-proceed. Do NOT assume yes.
-5. **On user approval of Stage 5:** invoke the `test-composer` skill via the Skill tool. Pass along the readiness check results and the list of pages already covered so test-composer's Step 1 (Inventory) starts from a known baseline.
-6. **On user pause:** confirm the session is at a clean stopping point and end gracefully. Remind the user how to resume ("just say 'expand coverage' or 'add more tests' next time").
-
-### Hard rule
-
-Do NOT silently end the session after Stage 4. The onboarding cycle was an entry point — the user may not realize Stage 5 exists. Always surface it.
-
----
+- **Run stages in order, no skipping.** Skip-to-Stage-3 mode (Stage 3 only, scope= one named test, no new selectors) is the lone exception, narrowly scoped per `references/stages-protocol.md` §"Skip-to-Stage-3".
+- **Hard gates between stages.** Stage 1 → 2: scenario list + page coverage explicit. Stage 2 → 3: every selector lives in `page-repository.json`. Stage 3 → 4a: test passes 3× green in isolation. Stage 4a → 4b: optimization checklist clean. Stage 4b → done: API compliance checklist clean.
+- **Stage 4b reviews against `references/api-reference.md` exclusively.** No raw Playwright APIs that have a Steps equivalent.
 
 ## API Reference
 

--- a/skills/element-interactions/references/stages-protocol.md
+++ b/skills/element-interactions/references/stages-protocol.md
@@ -1,0 +1,253 @@
+# Stages Protocol — Element-Interactions Pipeline (Stages 1–4)
+
+**Status:** authoritative spec for the four-stage element-interactions test-authoring pipeline. Cited from `element-interactions/SKILL.md`.
+**Scope:** Stage 1 (Scenario Discovery), Stage 2 (Element Inspection), Stage 3 (Write Automation), Stage 4a (Test Optimization), Stage 4b (API Compliance Review). For each stage: process, hard gates, output format, and skip-to-Stage-3 (fix/edit) mode.
+
+For the canonical browser-automation primitive used in Stage 2 / 3, see `playwright-cli-protocol.md`.
+For the API surface Stage 3 writes against, see `api-reference.md`.
+
+---
+
+## Stage 1: Scenario Discovery
+
+**Goal:** Understand the application and produce a clear, conventional scenario that the user approves.
+
+### Fast Path
+
+If the user provides a complete scenario or detailed acceptance criteria upfront, do NOT ask unnecessary discovery questions. Instead:
+
+1. Reformat their scenario into the Given/When/Then structure below, favouring clear, discrete steps.
+2. Ask only about anything that is genuinely unclear or ambiguous.
+3. Present the formatted scenario for approval.
+
+### Full Discovery Process
+
+When the user provides a URL, a vague idea, or needs help figuring out what to test:
+
+1. **Get the app URL or acceptance criteria.** The user may provide a URL, a description of the scenario, or both. If they provide a URL, use `playwright-cli` (see [`references/playwright-cli-protocol.md`](references/playwright-cli-protocol.md)) to navigate and explore.
+2. **Discover the app.** Use `playwright-cli` to navigate to the app, take snapshots (`playwright-cli snapshot`), and understand what the application does. Explore the pages relevant to the scenario.
+3. **Ask clarifying questions — one at a time.** Focus on understanding:
+   - What is the user flow being tested?
+   - What are the preconditions (logged in? specific data state?)
+   - What constitutes success vs failure?
+   - Are there edge cases to cover?
+4. **Present the scenario** in conventional Given/When/Then format:
+
+```
+Scenario: [Descriptive name]
+  Given [precondition]
+  And [additional precondition if needed]
+  When [action the user takes]
+  And [additional action if needed]
+  Then [expected outcome]
+  And [additional verification if needed]
+```
+
+For complex flows, break into multiple scenarios.
+
+### Hard Gate
+
+> "Here's the scenario I've drafted. Does this accurately capture what you want to automate? Any changes before I move on to inspecting the page elements?"
+
+**Wait for explicit approval.** If the user wants changes, revise and re-present. Do NOT proceed to Stage 2 until the scenario is approved.
+
+---
+
+## Stage 2: Element Inspection
+
+**Goal:** Identify all elements needed for the approved scenario and propose page-repository entries.
+
+### With `playwright-cli`
+
+1. **Open a session and navigate** to each page involved in the scenario:
+   - `npx playwright-cli -s=stage2-<scenario-slug> open --browser=chromium <URL>`
+   - subsequent `goto` / `click` / `fill` calls reuse the same `-s=` session.
+2. **Take snapshots** (`npx playwright-cli -s=stage2-<scenario-slug> snapshot`) and inspect the DOM to find reliable selectors for each element referenced in the scenario.
+3. **Prefer selectors in this order:** `data-test` / `data-testid` attributes > `id` > stable CSS selectors > text > XPath.
+4. **Build the page-repository entries.** For each element, determine the best selector strategy.
+5. **Check existing `page-repository.json`** — if some elements already exist, note which ones are new vs already covered.
+6. **Close the session** when done: `npx playwright-cli -s=stage2-<scenario-slug> close`.
+
+### When `playwright-cli` cannot reach the live app
+
+The CLI is always installed (hard dep), but the browser binary may be missing or the live app may be unreachable from this environment. In either case, fall back to user-supplied selectors:
+
+> "I can't reach the live app to inspect selectors (browser binary missing — run `npx playwright-cli install-browser chromium` — or app URL unreachable from this environment). Could you provide the selectors for the elements in the scenario? I need entries for: [list elements from the approved scenario]. You can give me CSS selectors, IDs, text values, or full page-repository JSON entries."
+
+Use whatever the user provides to build the page-repository entries. Do NOT guess or infer selectors.
+
+### Present Proposed Selectors
+
+Show the user the exact JSON entries you want to add:
+
+```json
+{
+  "pages": [
+    {
+      "name": "LoginPage",
+      "elements": [
+        { "elementName": "usernameInput", "selector": { "css": "input[data-test='username']" } },
+        { "elementName": "passwordInput", "selector": { "css": "input[data-test='password']" } },
+        { "elementName": "submitButton", "selector": { "css": "button[type='submit']", "text": "Log In" } }
+      ]
+    }
+  ]
+}
+```
+
+### Hard Gate
+
+> "These are the selectors I've identified for the scenario. Should I add them to `page-repository.json`? Let me know if any need adjusting."
+
+**Wait for explicit approval.** Do NOT edit `page-repository.json` until the user says yes. If changes are requested, re-inspect and re-present.
+
+---
+
+## Stage 3: Write Automation
+
+**Goal:** Write the Playwright test using the Steps API and approved page-repository entries.
+
+### Writing Process
+
+1. **Check project setup.** Read `tests/fixtures/base.ts` and `playwright.config.ts` — create or update only if missing or broken. Also verify that `.gitignore` includes `.claude/` and `CLAUDE.md` to prevent Claude Code configuration from being pushed to the repository — add them if missing.
+2. **Add approved selectors** to `page-repository.json` (if not already done).
+3. **Read `references/api-reference.md`** — load the full API reference before writing any test code. Do not write from memory.
+4. **Write the test file** using the Steps API. Every interaction goes through `steps.*` methods — no raw `page.locator()` calls.
+5. **Every test MUST end with a verification that proves the ACTION's EFFECT.** A test that performs actions (click, fill, drag, hover, check, upload, setSliderValue, etc.) and never asserts a resulting state is not a test — it's a smoke call that only catches thrown exceptions. Before declaring a test done, confirm the final meaningful statement is a `verify*`, a matcher-tree assertion (`.text.toBe`, `.visible.toBeTrue`, `.satisfy`, …), or a typed `expect(extractedValue)` that reflects what the action was supposed to change.
+
+   **The verification must be causally tied to the action, not a tautology.** An assertion that would pass whether the action ran or not is not a verification — it's noise. Common anti-patterns to catch:
+   - **Clicking a list item and asserting the list is still present.** `clickListedElement('rows', {text:'Alice'})` followed by `verifyPresence('rows')` proves nothing — the rows were present before the click too. Instead: verify the specific effect (navigation, selected-state change, status update, row-specific `data-selected` attribute, `stateSummary` text, etc.).
+   - **Hovering an element and asserting it's still visible.** The element was visible to be hovered. Verify hover feedback (tooltip text, popover visibility, CSS color change, aria-expanded toggle).
+   - **Filling an input and asserting the input exists.** Inputs don't disappear when filled. Verify `verifyInputValue(expected)` or a dependent element that reflects the filled value (error/success message, submit-button enabled state).
+   - **Clicking a button and asserting the button is enabled/visible.** Verify the button's ACTION — a result element updating, a modal opening, a URL change, a disabled state after submission.
+   - **Filter by text `{regex: 'A|B|C'}` then assert the parent collection is present.** Verify the FILTERED RESULT reflects the regex: extract text via `getListedElementData` and match the same pattern, or navigate to one of N alternatives and assert URL/state matches one of N expected outcomes.
+
+   When picking a verification, ask: **"If the action had silently done nothing, would this assertion still pass?"** If yes, the assertion is tautological — find one that would fail under a no-op.
+
+   Only in rare, explicitly documented cases where the action genuinely has no observable effect at any layer (e.g. a framework-level smoke exercise of an API's call shape) may you fall back to `verifyState('visible')` on the target element — and the reason must be stated in a one-line comment. Never leave a test trailing on an action.
+6. **Run the test** with `npx playwright test <test-file>`.
+7. **If the test fails:** invoke the `failure-diagnosis` protocol — collect evidence (screenshot, DOM, error context), group failures by root cause, classify (test issue vs app bug vs ambiguous), check edge cases, then fix test issues autonomously with stability validation (3-5 passing runs) or report app bugs with full evidence. If the fix requires new selectors, use `playwright-cli` to inspect the DOM, propose the new entry, and get approval before editing.
+8. **If the test passes:** commit immediately.
+
+### Skip-to-Stage-3 (Fix/Edit Mode)
+
+When the user asks to fix or edit an existing test, skip Stages 1 and 2. Read `references/api-reference.md`, then read the existing test, understand the issue, and proceed directly to fixing and running. If fixing requires new selectors, use the mini-inspection flow described above — do NOT silently add selectors.
+
+---
+
+## Stage 4: Post-Stabilization Review (split into 4a + 4b)
+
+**Stage 4a runs first, Stage 4b runs second.** Both run automatically after a test reaches passing state in Stage 3, before commit.
+
+### Stage 4a: Test Optimization
+
+**Goal:** enforce test-isolation, speed, and DRY best practices on freshly-written tests.
+
+**Process:**
+
+1. Read `references/test-optimization.md` — load the full protocol (8 sections).
+2. Read every test file written or modified in this session, plus `tests/fixtures/base.ts` and `tests/e2e/docs/app-context.md`'s `## Test Infrastructure` section.
+3. Run the 6 checks against each spec.
+4. Apply auto-fixes (per-test patterns, §1–§5 with auto-fix). Write proactive helpers into `base.ts` (cross-test patterns) only when both gates apply (UI-covered + API discovered, see §4). Re-run the affected tests; confirm they still pass.
+5. Emit the structured return per `references/test-optimization.md` §8.
+6. Proceed to Stage 4b.
+
+If Stage 4a's auto-fixes cause a previously-passing test to fail, follow Rule 7 (failure-diagnosis protocol) — inspect the screenshot, classify, fix or revert. Do not advance to Stage 4b until Stage 4a's tests are green again.
+
+### Stage 4b: API Compliance Review
+
+**Goal:** Review test code against the API Reference to ensure correct usage of the `@civitas-cerebrum/element-interactions` package.
+
+**This stage triggers automatically every time Stage 4a returns clean.** Do NOT batch — review each test case immediately after Stage 4a clears, before moving on to the next scenario. Even if the tests pass, they may be using the API incorrectly (wrong argument order, deprecated methods, missing options, incorrect types). Catching issues early prevents the same mistake from propagating into subsequent test cases.
+
+### Review Checklist
+
+For each test file, verify:
+
+1. **Method signatures** — every `steps.*` call matches the exact signature in the API Reference (correct argument count, correct argument order, correct types).
+2. **Imports** — all types used (`DropdownSelectType`, `EmailFilterType`, `FillFormValue`, etc.) are imported from `@civitas-cerebrum/element-interactions` (or `@civitas-cerebrum/email-client` for email types). No invented imports.
+3. **Page/element naming** — `pageName` uses PascalCase, `elementName` uses camelCase, and both match entries in `page-repository.json`.
+4. **Listed element options** — `child` uses `{ pageName, elementName }` repo references where possible instead of inline selectors (per Rule 5).
+5. **Dropdown select usage** — `DropdownSelectType.RANDOM`, `.VALUE`, or `.INDEX` with the correct companion field (`value` or `index`).
+6. **Email API usage** — `steps.sendEmail` / `steps.receiveEmail` / `steps.receiveAllEmails` / `steps.cleanEmails` match the documented signatures. Filter types use `EmailFilterType` enum.
+7. **No raw Playwright calls** — no `page.locator()`, `page.click()`, `page.fill()`, or other raw Playwright methods where a `steps.*` equivalent exists.
+8. **Fixture usage** — the test destructures only fixtures provided by `baseFixture` (`steps`, `repo`, `interactions`, `contextStore`, `page`) plus any custom fixtures defined in the project's `base.ts`.
+9. **Waiting methods** — correct state strings (`'visible'`, `'hidden'`, `'attached'`, `'detached'`) and correct usage of `waitForResponse` callback pattern.
+10. **Verification methods** — correct option shapes (`{ exactly }`, `{ greaterThan }`, `{ lessThan }` for `verifyCount`; `verifyText()` with no args asserts not empty). The 4-arg form `verifyText(el, page, undefined, { notEmpty: true })` and the `TextVerifyOptions.notEmpty` flag are deprecated — use `verifyText(el, page)` (or `.on(el, page).verifyText()` fluent) instead.
+11. **Every test ends with a verification — and that verification proves the action's effect, not a tautology.** Two sub-checks:
+   - **Presence.** No test may finish on an action with no trailing assertion. If the last meaningful statement is `click`, `fill`, `drag`, `hover`, `check`, `upload`, `setSliderValue`, etc., flag it.
+   - **Causal meaning.** Even with a trailing assertion, flag it if it would pass whether the action ran or not. Examples to catch: `verifyPresence('rows')` after `clickListedElement('rows', {text:'X'})` (the list was there before the click); `verifyState('visible')` on the hovered element (it was visible to be hovered); `verifyInputValue('anything')` where no causal link to the fill exists.
+
+   When reviewing, ask: *"If the action had silently done nothing, would this assertion still pass?"* If yes, the verification is tautological — replace it with one that reflects the action's specific observable effect (navigation, text update, state-summary change, attribute flip, modal open, URL change, dependent-element reaction). Pure framework-smoke cases may fall back to a weak check but require a one-line comment justifying it. "The action didn't throw" is not a verification.
+
+### Process
+
+1. **Read `references/api-reference.md`** — load the full API reference. Do not review from memory.
+2. **Read each test file** written or modified in this session.
+3. **Cross-reference every API call** against the API Reference.
+4. **Report findings** to the user — list any issues found with the specific line, what's wrong, and the correct usage.
+5. **If issues are found:** investigate *why* the non-compliant code was written — was the API misunderstood? Was a method signature wrong in the scenario? Did a previous stage produce incorrect assumptions? Understanding the root cause prevents the same mistake from recurring in the next scenario. Then fix, re-run the tests, and confirm they still pass.
+6. **If fixes cause a test failure:** follow Rule 6 — inspect the failure screenshot first before attempting any further fix. Do NOT guess from the error message alone.
+7. **If no issues are found:** confirm compliance and proceed to commit.
+
+### Output Format
+
+Present the review as:
+
+> **API Compliance Review**
+>
+> Reviewed: `tests/example.spec.ts`, `tests/login.spec.ts`
+>
+> - **`example.spec.ts:15`** — `steps.backOrForward('back')` should be `steps.backOrForward('BACKWARDS')` (uses uppercase enum-style strings)
+> - **`login.spec.ts:8`** — missing import for `DropdownSelectType`
+>
+> [number] issue(s) found. Fixing now.
+
+Or if clean:
+
+> **API Compliance Review**
+>
+> Reviewed: `tests/example.spec.ts`
+>
+> All API calls match the documented signatures. No issues found.
+
+---
+
+## Onboarding Completion Gate
+
+**Goal:** When the user signals they have no more individual scenarios to add (the "onboarding cycle" — Stages 1-4 — is complete), explicitly offer Stage 5 (Coverage Expansion) instead of silently ending the session.
+
+### When this gate triggers
+
+After any Stage 4 commit, when the user indicates they are done adding individual scenarios — for example by saying "that's all", "we're done", "no more for now", or by simply not requesting another scenario after a reasonable pause.
+
+### What to do
+
+1. **Summarize what was built in the onboarding cycle.** Briefly list the scenarios committed, the pages covered, and the page-repository entries added. Keep it to 3-5 lines.
+2. **Run a readiness check** before offering Stage 5:
+   - All committed tests pass on a clean re-run
+   - `page-repository.json` is valid JSON and matches the tests
+   - `tests/e2e/docs/app-context.md` exists and reflects the pages discovered so far
+   - No open API compliance issues from Stage 4
+   - If any check fails, fix it first — do NOT offer Stage 5 with a broken baseline
+3. **Present the offer to the user verbatim:**
+
+> **Onboarding cycle complete.**
+>
+> You now have an initial test suite that covers the scenarios you described. The next stage is **Coverage Expansion** — I would systematically probe the rest of the application, identify uncovered pages and flows, and build out the suite until every page and interactive element has test coverage. This typically takes multiple iteration cycles and runs more autonomously than the staged onboarding flow.
+>
+> Would you like me to proceed to **Stage 5: Coverage Expansion**? I can also:
+> - **Pause here** — I'll stop and you can resume any time by asking
+> - **Jump straight to Bug Discovery (Stage 6)** — only recommended if you already have comprehensive coverage from a previous session
+> - **Generate a work summary deck** — produce a stakeholder-facing report of what was built so far
+
+4. **Wait for explicit user choice.** Do NOT auto-proceed. Do NOT assume yes.
+5. **On user approval of Stage 5:** invoke the `test-composer` skill via the Skill tool. Pass along the readiness check results and the list of pages already covered so test-composer's Step 1 (Inventory) starts from a known baseline.
+6. **On user pause:** confirm the session is at a clean stopping point and end gracefully. Remind the user how to resume ("just say 'expand coverage' or 'add more tests' next time").
+
+### Hard rule
+
+Do NOT silently end the session after Stage 4. The onboarding cycle was an entry point — the user may not realize Stage 5 exists. Always surface it.
+
+---
+

--- a/skills/journey-mapping/SKILL.md
+++ b/skills/journey-mapping/SKILL.md
@@ -67,6 +67,14 @@ The five-phase mapping pipeline is split as follows:
 
 Phases 1 → 3.5 detail (process, parallel-discovery model, output formats) is in [`references/phases.md`](references/phases.md). Phase 4 + 5 detail (document structure, sentinel-marker rules, hard gates) stays in this file because it is tightly coupled to the file the consumer commits.
 
+### Hard rules — kernel-resident
+
+- **Discovery via `playwright-cli` only.** Static analysis, MCP browser tools, and "I'll guess from the URL structure" are not acceptable substitutes. Phase 1 hits the live app.
+- **Every journey is a self-contained `### j-<slug>:` block.** Downstream subagents receive ONLY their assigned journey block (plus referenced `sj-` sub-journeys) — cross-section reading is forbidden. Block format must support that isolation.
+- **The `<!-- journey-mapping:generated -->` sentinel is line 1 of `journey-map.md`.** Maps without the sentinel are not valid. Tools (coverage-expansion, test-composer) refuse to consume sentinel-less maps.
+- **Priority is load-bearing.** P0 / P1 / P2 / P3 ordering drives dispatch order in coverage-expansion AND batching eligibility (only P3 may batch). Misclassifying a journey as P3 is a contract violation, not an optimization.
+- **Phase 4 is sentinel-bearing.** Phase 5 re-verifies. A Phase-4 commit without the sentinel re-fires Phase 4.
+
 ## Phase 4: Journey Map Document
 
 Write the complete journey map to `tests/e2e/docs/journey-map.md`. This is the blueprint that test-composer uses to determine what to implement and in what order.

--- a/skills/journey-mapping/SKILL.md
+++ b/skills/journey-mapping/SKILL.md
@@ -14,6 +14,13 @@ Systematic discovery of a web application's structure, pages, and user journeys.
 
 **Core principle:** Understand the app like a user before testing it like an engineer. Discovery comes before inspection. Journeys come before selectors.
 
+## Reference index
+
+| Reference file | What's in it |
+|---|---|
+| [`references/phases.md`](references/phases.md) | Phases 1–3.5 detail: page discovery, flow identification, prioritization, redundancy revision. |
+| [`references/test-infrastructure-probe.md`](references/test-infrastructure-probe.md) | Phase-1 sub-protocol — detect existing fixtures, configs, env files, auth state. |
+
 ---
 
 ## When This Skill Activates
@@ -49,248 +56,16 @@ This sentinel is the single source of truth for "did I generate this?" — do no
 
 ## Phase Structure
 
-```
-Phase 1: Page Discovery          ─── visit every page, build app context
-Phase 2: Flow Identification     ─── trace user paths through discovered pages
-Phase 3: Journey Prioritization  ─── rank by business impact
-Phase 4: Journey Map Document    ─── write the deliverable
-Phase 5: Coverage Checkpoint     ─── compare map vs implemented tests (post-implementation)
-```
-
-Phase 5 runs **after** test-composer completes, not during mapping. It's the verification gate.
-
----
-
-## Phase 1: Page Discovery
-
-Visit every reachable page in the application via `@playwright/cli` (see [`../element-interactions/references/playwright-cli-protocol.md`](../element-interactions/references/playwright-cli-protocol.md)). Build the app context document incrementally as you go.
-
-### Discovery Tool Rule — `playwright-cli` only
-
-Page discovery **must** be performed through `@playwright/cli` from the Bash tool (`playwright-cli open`, `playwright-cli snapshot`, `playwright-cli click`, `playwright-cli eval`, etc.). This is non-negotiable:
-
-- **Do not** infer pages from reading source files, route tables, router configs, sitemaps, or existing tests. Static inspection misses runtime-only routes, feature flags, auth-gated redirects, and client-side navigation state.
-- **Do not** use `fetch`/`curl`/WebFetch to scrape HTML — those bypass client-side rendering and produce a false map.
-- **Do not** substitute a headless Playwright test runner or shell scripts for the CLI. Discovery runs in a live `playwright-cli` session so snapshots, console errors, and navigation timing are observable and recordable.
-- **Every URL in the site map must have a corresponding `playwright-cli` snapshot** taken during this phase. If a page appears in the map without a CLI visit, it was guessed — remove it and visit it, or mark it gated.
-- **Do not** call the `mcp__plugin_playwright_playwright__browser_*` MCP tools, even when the harness lists them as available. They run a separate Chrome process, write to a separate `.playwright-mcp/` directory, and share no state with the CLI's session model — using them at any point in discovery (parent or subagent) silently breaks the per-session OS-isolation guarantee documented in `../element-interactions/references/playwright-cli-protocol.md`. The CLI is the only sanctioned discovery channel.
-
-`@playwright/cli` ships as a hard dependency of `@civitas-cerebrum/element-interactions`, so it is always reachable via `npx playwright-cli` after the package is installed. If the binary is somehow unreachable, the install is corrupted — `npm install` fixes it. If the browser binary is missing on the dev machine, the first `... open` call exits with a clear error; run `npx playwright-cli install-browser chromium` once, then retry. Do not fall back to static analysis.
-
-### Process
-
-1. **Start at the entry point** — usually the homepage or login page
-2. **Take a snapshot** of each page
-3. **Record to app-context.md** immediately (per Rule 9 of element-interactions):
-   - URL pattern
-   - Page purpose (one sentence)
-   - Key sections visible
-   - Interactive elements (buttons, links, forms, tabs)
-   - Where this page links to (outbound navigation)
-   - Where this page is reached from (inbound navigation)
-4. **Follow every link** — navigate breadth-first through the app. Click nav items, CTAs, footer links, card links. Every reachable URL gets visited.
-5. **Note state variations** — does the page look different when empty, loading, errored, or with different data? Document each state.
-6. **Note gated pages** — pages behind login, roles, or paywalls. Document what's gated and what credentials/setup would be needed to access them.
-
-### Parallel discovery
-
-For apps with multiple known entry points, Phase 1 parallelizes. **Parallel is the default** whenever two or more entry points are known. There is no isolation-prerequisite check: every dispatched subagent issues `playwright-cli -s=<unique-slug> open` and gets its own OS-isolated browser process by construction (see Rule 11 in the `element-interactions` orchestrator and `references/playwright-cli-protocol.md` §1).
-
-**Protocol:**
-
-1. Enumerate entry points: homepage (`/`), login page, and any other known top-level URLs (dashboard, known subsystem roots, explicitly user-listed starting points).
-2. Quarantine: run `npx playwright-cli close-all` once at the start of the phase to reap any stale sessions from prior interrupted runs.
-3. For each entry point, dispatch a discovery subagent in parallel. Each subagent gets:
-   - Its assigned entry point URL.
-   - A unique session slug (`phase1-<entry-slug>`, per `playwright-cli-protocol.md` §3.1).
-   - Its own fresh context window — no prior session content.
-   - A terse brief: crawl the subtree breadth-first, capture snapshots, return a structured list of discovered pages + interactive elements.
-4. Parent journey-mapping agent merges each subagent's returned page list into `tests/e2e/docs/app-context.md` and the flat site map. Parent does **not** paste raw DOM snapshots or CLI transcripts into its own context.
-5. Deduplicate pages discovered by multiple subagents (common boundary pages show up twice; keep one entry with merged metadata).
-6. After every subagent has returned and closed its session, the parent runs `npx playwright-cli close-all` as belt-and-suspenders cleanup, then proceeds to Phase 2 with the consolidated site map.
-
-**Concrete dispatch shape:**
-
-For each entry point, the agent dispatches a subagent through whatever subagent-dispatch primitive its environment provides. Example shape:
-
-```
-dispatchSubagent({
-  description: "Discover <subtree>",
-  prompt: `
-    Crawl <entry-point-URL> breadth-first. Capture a snapshot of each page,
-    record URL, purpose, key sections, interactive elements, and outbound links.
-    Return a structured list of discovered pages and interactive elements.
-    Do not paste raw DOM into the return — summarize.
-
-    Browser automation: use @playwright/cli from the Bash tool. Open and close
-    your own session — siblings have their own slugs and sessions are isolated
-    by construction (one browser process per -s= name).
-
-        npx playwright-cli -s=phase1-<entry-slug> open --browser=chromium <entry-point-URL>
-        # ...crawl with snapshot / click / goto...
-        npx playwright-cli -s=phase1-<entry-slug> close
-
-    Snapshot format and command surface:
-    skills/element-interactions/references/playwright-cli-protocol.md §3 + §5.
-    Do NOT call close-all (the parent owns that).
-  `,
-})
-```
-
-Dispatch one subagent per entry point, all in parallel. Each dispatched subagent opens its own browser session via `-s=<slug> open`. The parent does **not** drive its own browser during the parallel phase.
-
-**Parallelism:** dispatch as many subagents in parallel as the independence graph allows — there is no fixed cap and no isolation-driven serialization. In Phase 1, every entry point is an independent root, so dispatch N subagents for N entry points.
-
-### Discovery Scope Rules
-
-- **Follow internal links only.** External links (social media, third-party services) are noted but not followed.
-- **Stop at authentication boundaries.** If a page requires login, document it as gated and move on. Do not guess credentials.
-- **Stop at infinite pagination.** Note that pagination exists and how many pages are accessible, but don't click through 500 pages of results.
-- **Click dropdowns, tabs, and accordions.** These reveal hidden navigation and content that static page views miss.
-- **Check mobile navigation.** Resize to mobile viewport once during discovery to identify mobile-only nav patterns (hamburger menu, bottom tabs).
-
-### Output
-
-An updated `tests/e2e/docs/app-context.md` with every discovered page documented. Plus a **site map** — a flat list of all discovered URLs:
-
-```markdown
-## Site Map
-- / (Homepage)
-- /contact
-- /about-us
-- /services/test-automation
-- /services/performance-testing
-...
-Total: X pages discovered
-Gated: Y pages behind authentication
-```
-
-### Test Infrastructure probe (parallel with crawl)
-
-Phase 1 also captures the application's test-infrastructure surface — auth model, reset endpoint, persistent banners, mutation endpoints, stable seed resources — for downstream consumption by Stage 4a of the test-composition pipeline.
-
-Load `references/test-infrastructure-probe.md` and run the protocol described there. The probe runs in parallel with the breadth-first page crawl: observations from network traffic and DOM snapshots accumulate during the crawl; the deliberate reset-endpoint probe runs once the crawl completes.
-
-**Output:** a `## Test Infrastructure` section appended to `tests/e2e/docs/app-context.md`, in the canonical format documented in `references/test-infrastructure-probe.md`.
-
-**Safety:** the reset-endpoint probe respects the host allowlist defined in the probe protocol. Hosts outside the allowlist short-circuit with `reset-endpoint: skipped`.
-
----
-
-## Phase 2: Flow Identification
-
-Read the completed app-context.md and trace every path a user can take through the application. A flow is a sequence of pages connected by navigation actions.
-
-### How to Identify Flows
-
-1. **Start from every entry point.** Entry points are: homepage, direct URLs shared in marketing/email, login page, any page indexed by search engines.
-2. **For each entry point, ask: "What does a user want to accomplish?"** Each answer is a potential journey.
-3. **Trace the path.** From entry to goal, what pages does the user visit? What actions do they take on each page?
-4. **Identify branches.** Where can the user go off-path? What happens if they navigate backwards, skip a step, or take an alternative route?
-
-### Flow Categories
-
-| Category | Description | Example |
-|---|---|---|
-| **Conversion flows** | Paths that lead to business outcomes — signups, purchases, contact submissions, bookings | Homepage → Services → Contact → Book meeting |
-| **Content consumption flows** | Paths through informational content — reading articles, case studies, guides | Homepage → Guides → Read article → Related articles |
-| **Navigation flows** | How users move between major sections — top nav, footer, breadcrumbs, CTAs | Nav dropdown → Service page → CTA → Contact |
-| **Account flows** | Authentication, profile management, settings | Login → Dashboard → Settings → Change password |
-| **Error recovery flows** | What happens when things go wrong — 404, expired sessions, invalid input | Submit invalid form → Error state → Correct input → Success |
-| **Return visitor flows** | Users who come back — bookmarks, email links, saved state | Email link → Deep page → Navigate to related content |
-
-### Output
-
-A list of identified flows, each described as a sequence of steps:
-
-```markdown
-### Flow: Visitor to Contact
-**Category:** Conversion
-**Entry:** Homepage (/)
-**Steps:**
-1. User reads hero section
-2. User clicks "Test Automation" pillar link → /test-automation
-3. User reads service description
-4. User clicks "Talk To Our Team" CTA → /contact
-5. User views contact info and calendar
-6. User selects meeting date and time
-**Exit:** Meeting booked (HubSpot confirmation)
-**Branches:**
-- From step 2: user could click any of 3 pillar links
-- From step 3: user could click case study instead of CTA
-- From step 5: user could email or call instead of booking
-```
-
----
-
-## Phase 3: Journey Prioritization
-
-Assign a priority to each identified flow based on business impact. Priority determines coverage depth.
-
-### Priority Framework
-
-| Priority | Criteria | Coverage expectation |
-|---|---|---|
-| **P0 — Revenue / Core conversion** | Directly leads to business outcomes: purchases, signups, bookings, lead submissions. If this flow breaks, the business loses money or customers. | Full journey test, error states, edge cases, mobile viewport, performance baseline |
-| **P1 — Core experience** | Features most users interact with. Defines what the product is. If broken, users leave. | Full journey test, key error states, data verification |
-| **P2 — Supporting content** | Resources, guides, blog, about pages, informational flows. Enhances experience but not critical path. | Page loads, links work, content present, one journey test |
-| **P3 — Peripheral** | Legal pages, footer links, settings that rarely change, admin tools used internally. | Smoke test: page loads, no broken links |
-
-### Prioritization Questions
-
-For each flow, ask:
-1. **Revenue impact:** Does this flow directly lead to a transaction or conversion? → P0
-2. **User frequency:** Do most users go through this flow? → P1 minimum
-3. **Failure impact:** If this flow breaks, do users notice? Can they work around it? → Raises priority
-4. **Business context:** Is there a deadline, compliance requirement, or recent incident related to this flow? → Raises priority
-
-If the app's business purpose is unclear, ask the user:
-> "What is the primary goal of this application? What action do you most want users to complete?"
-
-### Output
-
-The flow list from Phase 2, now with priorities assigned:
-
-```markdown
-| Priority | Flow | Category | Entry → Exit |
-|----------|------|----------|-------------|
-| P0 | Visitor to Contact | Conversion | / → /contact → booking |
-| P1 | Service browsing | Core experience | / → /services/* → /contact |
-| P2 | Content discovery | Content | / → /guides → /guides/* |
-| P3 | Legal review | Peripheral | footer → /terms-conditions |
-```
-
----
-
-## Phase 3.5: Redundancy Revision
-
-Before writing the journey map, scan the prioritised journey list for redundancy. Overlap between journeys is expected — real users traverse shared pages — but unmanaged overlap bloats the map and makes downstream parallel test composition harder. Revision rebalances the list.
-
-### Checks
-
-1. **Shared-segment extraction.** Any two journeys that share three or more consecutive steps on the same pages: extract the shared segment as a named sub-journey (`sj-<slug>`) and reference it from both parent journeys.
-2. **Variant collapse.** Any two journeys that differ only in their final step or final page: consider merging as one journey with labelled variant exits.
-3. **Decomposition.** Any single journey that chains multiple distinct user goals (e.g., "browse → purchase → manage account"): split into smaller journeys and record the cross-journey entry points explicitly.
-4. **Explicit overlap annotation.** Where two journeys legitimately pass through the same page for different goals, annotate the page's role per journey on the journey blocks rather than silently.
-
-### Process
-
-1. Build a page × journey matrix from the Phase 2 flow list.
-2. Scan row-by-row and column-by-column for the patterns above.
-3. For each match, propose a revision and apply it to the journey list.
-4. Emit a one-line revision log entry per change (e.g., "extracted sj-login from j-book-demo and j-request-quote").
-
-### Output
-
-A revised journey list where:
-- Shared segments live as reusable sub-journeys (`sj-<slug>`).
-- Each remaining journey has a stable ID (`j-<slug>`).
-- Each journey's `Pages touched:` list is concrete.
-- Every overlap between journeys is either routed through a sub-journey or explicitly annotated.
-
-This revised list feeds Phase 4.
-
----
+The five-phase mapping pipeline is split as follows:
+
+- **Phase 1** — Page discovery (parallel `playwright-cli` crawl) + Test Infrastructure probe.
+- **Phase 2** — Flow identification: derive user flows from the discovered pages.
+- **Phase 3** — Journey prioritization: P0 / P1 / P2 / P3 tier.
+- **Phase 3.5** — Redundancy revision: deduplicate overlapping flows; promote sub-journeys.
+- **Phase 4** — Journey-map document authoring (sentinel-bearing).
+- **Phase 5** — Coverage checkpoint (sentinel re-verification + roster snapshot).
+
+Phases 1 → 3.5 detail (process, parallel-discovery model, output formats) is in [`references/phases.md`](references/phases.md). Phase 4 + 5 detail (document structure, sentinel-marker rules, hard gates) stays in this file because it is tightly coupled to the file the consumer commits.
 
 ## Phase 4: Journey Map Document
 

--- a/skills/journey-mapping/references/phases.md
+++ b/skills/journey-mapping/references/phases.md
@@ -1,0 +1,241 @@
+# Journey-Mapping Phase Protocols — Phases 1–3.5
+
+**Status:** authoritative spec for the discovery → identification → prioritization → redundancy-revision phases of journey-mapping. Cited from `journey-mapping/SKILL.md`.
+**Scope:** Phase 1 (Page Discovery + Test Infrastructure probe), Phase 2 (Flow Identification), Phase 3 (Journey Prioritization), Phase 3.5 (Redundancy Revision). Per-phase process, parallel-discovery model, output formats.
+
+For Phase 4 (Journey Map document) and Phase 5 (Coverage Checkpoint), see `journey-mapping/SKILL.md` directly — those phases' outputs are tightly coupled to the SKILL.md's signature-marker and hard-gate rules.
+For the canonical browser-automation primitive used in Phase 1 discovery, see `../element-interactions/references/playwright-cli-protocol.md`.
+
+---
+
+## Phase 1: Page Discovery
+
+Visit every reachable page in the application via `@playwright/cli` (see [`../element-interactions/references/playwright-cli-protocol.md`](../element-interactions/references/playwright-cli-protocol.md)). Build the app context document incrementally as you go.
+
+### Discovery Tool Rule — `playwright-cli` only
+
+Page discovery **must** be performed through `@playwright/cli` from the Bash tool (`playwright-cli open`, `playwright-cli snapshot`, `playwright-cli click`, `playwright-cli eval`, etc.). This is non-negotiable:
+
+- **Do not** infer pages from reading source files, route tables, router configs, sitemaps, or existing tests. Static inspection misses runtime-only routes, feature flags, auth-gated redirects, and client-side navigation state.
+- **Do not** use `fetch`/`curl`/WebFetch to scrape HTML — those bypass client-side rendering and produce a false map.
+- **Do not** substitute a headless Playwright test runner or shell scripts for the CLI. Discovery runs in a live `playwright-cli` session so snapshots, console errors, and navigation timing are observable and recordable.
+- **Every URL in the site map must have a corresponding `playwright-cli` snapshot** taken during this phase. If a page appears in the map without a CLI visit, it was guessed — remove it and visit it, or mark it gated.
+- **Do not** call the `mcp__plugin_playwright_playwright__browser_*` MCP tools, even when the harness lists them as available. They run a separate Chrome process, write to a separate `.playwright-mcp/` directory, and share no state with the CLI's session model — using them at any point in discovery (parent or subagent) silently breaks the per-session OS-isolation guarantee documented in `../element-interactions/references/playwright-cli-protocol.md`. The CLI is the only sanctioned discovery channel.
+
+`@playwright/cli` ships as a hard dependency of `@civitas-cerebrum/element-interactions`, so it is always reachable via `npx playwright-cli` after the package is installed. If the binary is somehow unreachable, the install is corrupted — `npm install` fixes it. If the browser binary is missing on the dev machine, the first `... open` call exits with a clear error; run `npx playwright-cli install-browser chromium` once, then retry. Do not fall back to static analysis.
+
+### Process
+
+1. **Start at the entry point** — usually the homepage or login page
+2. **Take a snapshot** of each page
+3. **Record to app-context.md** immediately (per Rule 9 of element-interactions):
+   - URL pattern
+   - Page purpose (one sentence)
+   - Key sections visible
+   - Interactive elements (buttons, links, forms, tabs)
+   - Where this page links to (outbound navigation)
+   - Where this page is reached from (inbound navigation)
+4. **Follow every link** — navigate breadth-first through the app. Click nav items, CTAs, footer links, card links. Every reachable URL gets visited.
+5. **Note state variations** — does the page look different when empty, loading, errored, or with different data? Document each state.
+6. **Note gated pages** — pages behind login, roles, or paywalls. Document what's gated and what credentials/setup would be needed to access them.
+
+### Parallel discovery
+
+For apps with multiple known entry points, Phase 1 parallelizes. **Parallel is the default** whenever two or more entry points are known. There is no isolation-prerequisite check: every dispatched subagent issues `playwright-cli -s=<unique-slug> open` and gets its own OS-isolated browser process by construction (see Rule 11 in the `element-interactions` orchestrator and `references/playwright-cli-protocol.md` §1).
+
+**Protocol:**
+
+1. Enumerate entry points: homepage (`/`), login page, and any other known top-level URLs (dashboard, known subsystem roots, explicitly user-listed starting points).
+2. Quarantine: run `npx playwright-cli close-all` once at the start of the phase to reap any stale sessions from prior interrupted runs.
+3. For each entry point, dispatch a discovery subagent in parallel. Each subagent gets:
+   - Its assigned entry point URL.
+   - A unique session slug (`phase1-<entry-slug>`, per `playwright-cli-protocol.md` §3.1).
+   - Its own fresh context window — no prior session content.
+   - A terse brief: crawl the subtree breadth-first, capture snapshots, return a structured list of discovered pages + interactive elements.
+4. Parent journey-mapping agent merges each subagent's returned page list into `tests/e2e/docs/app-context.md` and the flat site map. Parent does **not** paste raw DOM snapshots or CLI transcripts into its own context.
+5. Deduplicate pages discovered by multiple subagents (common boundary pages show up twice; keep one entry with merged metadata).
+6. After every subagent has returned and closed its session, the parent runs `npx playwright-cli close-all` as belt-and-suspenders cleanup, then proceeds to Phase 2 with the consolidated site map.
+
+**Concrete dispatch shape:**
+
+For each entry point, the agent dispatches a subagent through whatever subagent-dispatch primitive its environment provides. Example shape:
+
+```
+dispatchSubagent({
+  description: "Discover <subtree>",
+  prompt: `
+    Crawl <entry-point-URL> breadth-first. Capture a snapshot of each page,
+    record URL, purpose, key sections, interactive elements, and outbound links.
+    Return a structured list of discovered pages and interactive elements.
+    Do not paste raw DOM into the return — summarize.
+
+    Browser automation: use @playwright/cli from the Bash tool. Open and close
+    your own session — siblings have their own slugs and sessions are isolated
+    by construction (one browser process per -s= name).
+
+        npx playwright-cli -s=phase1-<entry-slug> open --browser=chromium <entry-point-URL>
+        # ...crawl with snapshot / click / goto...
+        npx playwright-cli -s=phase1-<entry-slug> close
+
+    Snapshot format and command surface:
+    skills/element-interactions/references/playwright-cli-protocol.md §3 + §5.
+    Do NOT call close-all (the parent owns that).
+  `,
+})
+```
+
+Dispatch one subagent per entry point, all in parallel. Each dispatched subagent opens its own browser session via `-s=<slug> open`. The parent does **not** drive its own browser during the parallel phase.
+
+**Parallelism:** dispatch as many subagents in parallel as the independence graph allows — there is no fixed cap and no isolation-driven serialization. In Phase 1, every entry point is an independent root, so dispatch N subagents for N entry points.
+
+### Discovery Scope Rules
+
+- **Follow internal links only.** External links (social media, third-party services) are noted but not followed.
+- **Stop at authentication boundaries.** If a page requires login, document it as gated and move on. Do not guess credentials.
+- **Stop at infinite pagination.** Note that pagination exists and how many pages are accessible, but don't click through 500 pages of results.
+- **Click dropdowns, tabs, and accordions.** These reveal hidden navigation and content that static page views miss.
+- **Check mobile navigation.** Resize to mobile viewport once during discovery to identify mobile-only nav patterns (hamburger menu, bottom tabs).
+
+### Output
+
+An updated `tests/e2e/docs/app-context.md` with every discovered page documented. Plus a **site map** — a flat list of all discovered URLs:
+
+```markdown
+## Site Map
+- / (Homepage)
+- /contact
+- /about-us
+- /services/test-automation
+- /services/performance-testing
+...
+Total: X pages discovered
+Gated: Y pages behind authentication
+```
+
+### Test Infrastructure probe (parallel with crawl)
+
+Phase 1 also captures the application's test-infrastructure surface — auth model, reset endpoint, persistent banners, mutation endpoints, stable seed resources — for downstream consumption by Stage 4a of the test-composition pipeline.
+
+Load `references/test-infrastructure-probe.md` and run the protocol described there. The probe runs in parallel with the breadth-first page crawl: observations from network traffic and DOM snapshots accumulate during the crawl; the deliberate reset-endpoint probe runs once the crawl completes.
+
+**Output:** a `## Test Infrastructure` section appended to `tests/e2e/docs/app-context.md`, in the canonical format documented in `references/test-infrastructure-probe.md`.
+
+**Safety:** the reset-endpoint probe respects the host allowlist defined in the probe protocol. Hosts outside the allowlist short-circuit with `reset-endpoint: skipped`.
+
+---
+
+## Phase 2: Flow Identification
+
+Read the completed app-context.md and trace every path a user can take through the application. A flow is a sequence of pages connected by navigation actions.
+
+### How to Identify Flows
+
+1. **Start from every entry point.** Entry points are: homepage, direct URLs shared in marketing/email, login page, any page indexed by search engines.
+2. **For each entry point, ask: "What does a user want to accomplish?"** Each answer is a potential journey.
+3. **Trace the path.** From entry to goal, what pages does the user visit? What actions do they take on each page?
+4. **Identify branches.** Where can the user go off-path? What happens if they navigate backwards, skip a step, or take an alternative route?
+
+### Flow Categories
+
+| Category | Description | Example |
+|---|---|---|
+| **Conversion flows** | Paths that lead to business outcomes — signups, purchases, contact submissions, bookings | Homepage → Services → Contact → Book meeting |
+| **Content consumption flows** | Paths through informational content — reading articles, case studies, guides | Homepage → Guides → Read article → Related articles |
+| **Navigation flows** | How users move between major sections — top nav, footer, breadcrumbs, CTAs | Nav dropdown → Service page → CTA → Contact |
+| **Account flows** | Authentication, profile management, settings | Login → Dashboard → Settings → Change password |
+| **Error recovery flows** | What happens when things go wrong — 404, expired sessions, invalid input | Submit invalid form → Error state → Correct input → Success |
+| **Return visitor flows** | Users who come back — bookmarks, email links, saved state | Email link → Deep page → Navigate to related content |
+
+### Output
+
+A list of identified flows, each described as a sequence of steps:
+
+```markdown
+### Flow: Visitor to Contact
+**Category:** Conversion
+**Entry:** Homepage (/)
+**Steps:**
+1. User reads hero section
+2. User clicks "Test Automation" pillar link → /test-automation
+3. User reads service description
+4. User clicks "Talk To Our Team" CTA → /contact
+5. User views contact info and calendar
+6. User selects meeting date and time
+**Exit:** Meeting booked (HubSpot confirmation)
+**Branches:**
+- From step 2: user could click any of 3 pillar links
+- From step 3: user could click case study instead of CTA
+- From step 5: user could email or call instead of booking
+```
+
+---
+
+## Phase 3: Journey Prioritization
+
+Assign a priority to each identified flow based on business impact. Priority determines coverage depth.
+
+### Priority Framework
+
+| Priority | Criteria | Coverage expectation |
+|---|---|---|
+| **P0 — Revenue / Core conversion** | Directly leads to business outcomes: purchases, signups, bookings, lead submissions. If this flow breaks, the business loses money or customers. | Full journey test, error states, edge cases, mobile viewport, performance baseline |
+| **P1 — Core experience** | Features most users interact with. Defines what the product is. If broken, users leave. | Full journey test, key error states, data verification |
+| **P2 — Supporting content** | Resources, guides, blog, about pages, informational flows. Enhances experience but not critical path. | Page loads, links work, content present, one journey test |
+| **P3 — Peripheral** | Legal pages, footer links, settings that rarely change, admin tools used internally. | Smoke test: page loads, no broken links |
+
+### Prioritization Questions
+
+For each flow, ask:
+1. **Revenue impact:** Does this flow directly lead to a transaction or conversion? → P0
+2. **User frequency:** Do most users go through this flow? → P1 minimum
+3. **Failure impact:** If this flow breaks, do users notice? Can they work around it? → Raises priority
+4. **Business context:** Is there a deadline, compliance requirement, or recent incident related to this flow? → Raises priority
+
+If the app's business purpose is unclear, ask the user:
+> "What is the primary goal of this application? What action do you most want users to complete?"
+
+### Output
+
+The flow list from Phase 2, now with priorities assigned:
+
+```markdown
+| Priority | Flow | Category | Entry → Exit |
+|----------|------|----------|-------------|
+| P0 | Visitor to Contact | Conversion | / → /contact → booking |
+| P1 | Service browsing | Core experience | / → /services/* → /contact |
+| P2 | Content discovery | Content | / → /guides → /guides/* |
+| P3 | Legal review | Peripheral | footer → /terms-conditions |
+```
+
+---
+
+## Phase 3.5: Redundancy Revision
+
+Before writing the journey map, scan the prioritised journey list for redundancy. Overlap between journeys is expected — real users traverse shared pages — but unmanaged overlap bloats the map and makes downstream parallel test composition harder. Revision rebalances the list.
+
+### Checks
+
+1. **Shared-segment extraction.** Any two journeys that share three or more consecutive steps on the same pages: extract the shared segment as a named sub-journey (`sj-<slug>`) and reference it from both parent journeys.
+2. **Variant collapse.** Any two journeys that differ only in their final step or final page: consider merging as one journey with labelled variant exits.
+3. **Decomposition.** Any single journey that chains multiple distinct user goals (e.g., "browse → purchase → manage account"): split into smaller journeys and record the cross-journey entry points explicitly.
+4. **Explicit overlap annotation.** Where two journeys legitimately pass through the same page for different goals, annotate the page's role per journey on the journey blocks rather than silently.
+
+### Process
+
+1. Build a page × journey matrix from the Phase 2 flow list.
+2. Scan row-by-row and column-by-column for the patterns above.
+3. For each match, propose a revision and apply it to the journey list.
+4. Emit a one-line revision log entry per change (e.g., "extracted sj-login from j-book-demo and j-request-quote").
+
+### Output
+
+A revised journey list where:
+- Shared segments live as reusable sub-journeys (`sj-<slug>`).
+- Each remaining journey has a stable ID (`j-<slug>`).
+- Each journey's `Pages touched:` list is concrete.
+- Every overlap between journeys is either routed through a sub-journey or explicitly annotated.
+
+This revised list feeds Phase 4.
+
+---
+

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -22,6 +22,12 @@ The onboarding skill brings a fresh project from zero to a comprehensive test su
 
 **Design reference:** `docs/superpowers/specs/2026-04-22-onboarding-skill-design.md`.
 
+## Reference index
+
+| Reference file | What's in it |
+|---|---|
+| [`references/phases-walkthrough.md`](references/phases-walkthrough.md) | Phases 1–7 detail: per-phase task list, hard gates, progress-output discipline. |
+
 ---
 
 ## Activation
@@ -197,138 +203,13 @@ Examples:
 
 ## Pipeline
 
-Seven phases. Each phase ends with exactly one commit. Phases are skipped when the cascade level does not require them (Level A runs all phases; Level B skips install; Level C skips install and scaffold).
+The seven-phase pipeline (Phase 1 Scaffold → Phase 2 Groundwork discovery → Phase 3 Happy path → Phase 4 Full journey mapping → Phase 5 Coverage expansion → Phase 6 Bug hunts → Phase 7 Final summary) is specified in [`references/phases-walkthrough.md`](references/phases-walkthrough.md). Read it before authoring or modifying any phase logic.
 
-### Phase 1 — Scaffold (Level A/B only)
+Key invariants kept here:
 
-**Owner:** onboarding (direct).
-
-**Level A install scope:** install **only** missing packages from `@civitas-cerebrum/*` and Playwright:
-
-- `@civitas-cerebrum/element-interactions` if missing from `dependencies`.
-- `@civitas-cerebrum/element-repository` if missing.
-- `@playwright/test` if missing.
-- Run `npx playwright install chromium` (Chromium only; other browsers on request).
-
-Do **not** add, remove, or upgrade any other dependencies. Do **not** modify the user's `package.json` scripts beyond adding a `test:e2e` script if one doesn't already exist.
-
-**Scaffold files** (Level A and B, whichever are missing):
-
-- `playwright.config.ts` — minimal config with `baseURL` from the front-load gate, `testDir: './tests/e2e'`, `reporter: 'html'`, headless true.
-- `tests/fixtures/base.ts` — `baseFixture` export wiring `Steps` and `ContextStore`, with four `HELPER SLOT` comment markers that Stage 4a (test optimization) populates on demand. Exact starting content:
-
-  ```typescript
-  import { test as base, expect } from '@playwright/test';
-  import { baseFixture } from '@civitas-cerebrum/element-interactions';
-
-  const test = baseFixture(base, 'tests/data/page-repository.json', { timeout: 60000 });
-
-  // Stage-4a-managed helpers. Each slot is filled in only when both gates
-  // (UI-covered + API discovered) confirm during Stage 4a; otherwise the slot
-  // stays as a comment.
-  //
-  // HELPER SLOT: resetState — populated when a reset endpoint is discovered
-  //   in app-context.md's Test Infrastructure section.
-  // HELPER SLOT: setAuthCookie — populated when login/signup is UI-covered AND
-  //   POST /api/auth/login is discovered.
-  // HELPER SLOT: seedCart, createListingViaApi, etc. — populated per the
-  //   shortcut list in references/test-optimization.md when both gates apply.
-  // HELPER SLOT: dismissBanners — populated when Phase 1 discovery flagged a
-  //   persistent banner/modal in Test Infrastructure.
-
-  // HELPER SLOT: beforeEach — Stage 4a inserts test.beforeEach hooks here to
-  //   wire fixture-level helpers (dismissBanners, fixture-level resetState if
-  //   the project chooses fixture-level reset, etc.) into the test lifecycle.
-  //   The slot is additive across protocol runs — append, do not overwrite.
-  //   Per-test setup belongs in the spec, not in this slot.
-
-  export { test, expect };
-  ```
-
-  The `HELPER SLOT` comments are a contract: Stage 4a replaces them with code, never editing arbitrary regions of the file. Full helper templates: see `../element-interactions/references/test-optimization.md` §1, §4, §5.
-- `page-repository.json` — `{}` at the repo root (or `tests/e2e/page-repository.json`; follow existing convention if partial scaffold exists).
-- `tests/e2e/` — directory created if missing.
-- `tests/e2e/docs/` — directory created if missing.
-- `screenshots/` — directory created at the repo root if missing. All screenshot artifacts produced during the run (probe evidence, adversarial captures, failure snapshots) must be written here — never to the repo root, never with bare basenames.
-- `.gitignore` — add `screenshots/failures/` so transient Playwright failure captures stay untracked, and `.playwright-cli/` so the CLI's per-run snapshot YAMLs and console buffers stay untracked. Probe-evidence screenshots in `screenshots/` root remain tracked so reviewers can open the ledger and see what the subagent saw.
-
-**Screenshot-path contract for dispatched subagents.** Every subagent brief this skill writes — Phase-3 happy-path agent, Phase-5 `coverage-expansion` subagents, Phase-6 `bug-discovery` subagents — must restate the following rule verbatim:
-
-> All screenshot artifacts write to `screenshots/<descriptive-name>.png`. Never bare basenames. This applies to `playwright-cli screenshot --filename=<path>`, Playwright `page.screenshot({ path: ... })`, and any ledger reference citing a screenshot as evidence. Playwright failure screenshots write to `screenshots/failures/<test-name>-<timestamp>.png` (gitignored).
-
-This is a pure-hygiene rule enforced at the skill-brief level — bare-basename screenshots litter the repo root and break ledger references whose resolution depends on Node's CWD.
-
-**Brief-validation check before dispatch.** Before the orchestrator sends any Phase-3/5/6 subagent brief, it must grep the brief for `screenshots/` and for the bare-basename ban string above. A brief that omits the rule is malformed — the orchestrator regenerates it before dispatching rather than sending a brief that lets the subagent pick its own path convention. This is a one-line self-check, not a new review stage.
-
-**Commit:** `chore: scaffold element-interactions framework`.
-
-### Phase 2 — Groundwork discovery
-
-**Delegate to:** `journey-mapping` with `args: "phase-1-only"`.
-
-The companion writes `tests/e2e/docs/app-context.md` and a sentinel-bearing `tests/e2e/docs/journey-map.md` whose body contains only the site map (Phase-2–4 sections are empty headings).
-
-**Commit:** `docs: initial app-context and site map`.
-
-### Phase 3 — Happy path
-
-**Delegate to:** `element-interactions` with `args: "autonomousMode: true happyPathDescription: '<one-sentence description from the front-load gate>'"`.
-
-The companion runs Stages 1–4 inline with gates suspended, using the description + the site map from Phase 2 to pick the target flow. Any failure routes through `failure-diagnosis` automatically.
-
-**Commit:** `test: happy path — <scenario name>`. The orchestrator returns the scenario name in its summary; use that.
-
-### Phase 4 — Full journey mapping
-
-**Delegate to:** `journey-mapping` with `args: "phases-2-4"`.
-
-The companion reads the existing sentinel-bearing Phase-1 map and fills in Phases 2–4 (flow identification, prioritisation, journey map document). File is overwritten in place; sentinel preserved.
-
-**Commit:** `docs: journey map — <N> journeys prioritized`.
-
-### Phase 5 — Coverage expansion (five passes, depth mode)
-
-**Delegate to:** `coverage-expansion` with `args: "mode: depth"`.
-
-That skill runs five journey-by-journey passes internally (3 compositional via test-composer + 2 adversarial via bug-discovery), each pass split per-journey into Stage A (compose/probe) + Stage B (fresh staff-QA reviewer with its own isolated `playwright-cli` session) running an A↔B retry loop up to 7 cycles per journey per pass. Subagent dispatch is opus-default (cost-blind), parallelised for independent journeys, with map growth reconciled between passes. Onboarding's role here is simply to invoke it and relay `[coverage-expansion]` progress lines upstream — no per-pass or per-cycle orchestration at this layer.
-
-Between and after the five passes, `coverage-expansion` itself refreshes its view of `app-context.md` and `journey-map.md`; onboarding does not need its own refresh step at this phase. When the skill returns, append a "Coverage expansion — new knowledge" section to `onboarding-report.md` summarising total tests added, new journeys discovered, and any sub-journeys promoted.
-
-**The onboarding skill's Phase 5 is not satisfied by Pass 1 alone.** Do not mark Phase 5 complete in the onboarding report, in any task tracker, or in the summary deck until `coverage-expansion` returns from **all five passes + cleanup** (see that skill's §"Per-pass completion criteria"). If the orchestrator is budget-constrained mid-pipeline, it commits what it has, writes resume state per `coverage-expansion`'s state-file contract (`tests/e2e/docs/coverage-expansion-state.json`), and returns to the user with a clear "resume needed" message — it does NOT claim Phase 5 done and silently defer passes 2–5 or the ledger dedup. A Phase 5 report that reads "Pass 1 complete, 2–5 deferred for budget" is honest; a report that reads "Phase 5 complete" when only Pass 1 ran is a bug in the orchestrator's summarisation.
-
-**Commits:** `coverage-expansion` commits once per pass (`test: coverage expansion pass <N>/5 — <summary>`). Onboarding adds no extra commit here.
-
-**No stage may be silently skipped.** Onboarding has seven phases and each phase has its own internal stages (element-interactions has Stages 1–4; coverage-expansion has Passes 1–5 + cleanup; bug-discovery has Phases 1a and 1b). Partial-phase completion is reportable; partial-phase completion disguised as full-phase completion is a contract violation. The onboarding-report and any summary deck MUST state partial status explicitly when applicable — "Phase 5: Pass 1 complete (44/44), Pass 2 partial (3/44), Pass 3–5 pending" — not "Phase 5 complete."
-
-**Dual-stage completion extension.** Phase 5 is complete only when every journey has a terminal `review_status` (`greenlight`, `blocked-cycle-stalled`, `blocked-cycle-exhausted`, or `blocked-dispatch-failure`) for every pass, not only when every journey has returned from Stage A. A pass where every journey's Stage A ran but some journeys have no `review_status` field in the state file is **incomplete**, per the extended no-skip contract. The onboarding-report's Phase-5 section must surface blocked-review-cycle and blocked-dispatch-failure journeys explicitly: `"Phase 5: Pass N/5 complete (44/44), 3 journeys blocked-cycle-stalled with unresolved review findings, 1 journey blocked-dispatch-failure (see state file for details)"`.
-
-### Phase 6 — Bug hunts (two passes)
-
-Two sequential invocations of `bug-discovery`:
-
-| Pass | `args` |
-|---|---|
-| 1 | `phase: 1a-element-probing` |
-| 2 | `phase: 1b-flow-probing` |
-
-Findings go to `tests/e2e/docs/onboarding-report.md` under "App bugs logged". The companion must NOT commit skipped tests for the findings; it logs them and continues.
-
-**Phase 6 is two dedicated bug-discovery passes (element-probing 1a, flow-probing 1b) — not "the bugs we happened to find during coverage."** Organic findings from earlier phases (happy path, coverage-expansion compositional passes, coverage-expansion adversarial passes 4/5) go in the onboarding-report's "App bugs logged" section; Phase 6's two dedicated passes run **in addition to** whatever organic discovery happened in earlier phases. Repackaging organic findings as "the Phase 6 output" is a loophole — the two dedicated passes either ran or they did not. If the orchestrator skips Phase 6's passes (budget, infra halt, explicit user instruction), the onboarding-report and the summary deck MUST say `"Phase 6 deferred — <reason>"` or `"Phase 6 partial — pass 1a only"`, never `"Phase 6 complete"`. Finding count alone is not evidence that Phase 6 ran.
-
-**Commits:** `docs: bug-hunt 1/2 findings` and `docs: bug-hunt 2/2 findings`.
-
-### Phase 7 — Final summary
-
-1. Invoke `work-summary-deck` to produce `qa-summary-deck.html`.
-2. Finalise `tests/e2e/docs/onboarding-report.md` with the sections in the next heading.
-
-**Commit:** `docs: onboarding report and summary deck`.
-
-### Task-tracking granularity
-
-Use pass-level tasks, not phase-level. A single "Phase 5" task that flips to done is a footgun — use `"Pass 1/5 compositional"`, `"Pass 2/5 compositional"`, `"Pass 3/5 compositional"`, `"Pass 4/5 adversarial"`, `"Pass 5/5 adversarial"`, `"Phase 5 cleanup"`, and a `"Phase 5 overall"` parent that only flips done when all child passes do. Same for Phase 6's two sub-passes (`"Phase 6 pass 1a element-probing"`, `"Phase 6 pass 1b flow-probing"`, `"Phase 6 overall"`). Parent tasks never flip done ahead of their children.
-
----
+- **All seven phases run in order, no skipping.** Phase 5 (coverage-expansion) and Phase 6 (bug-discovery) are the lengthy phases — the front-load gate authorises both.
+- **Phase 5 invokes `coverage-expansion` with `mode: depth`** — the full 5-pass + cleanup pipeline. Onboarding does not invoke coverage-expansion in `mode: breadth`.
+- **Hard gates between phases.** A phase that surfaces a malformed prerequisite (missing journey-map sentinel, missing tenant credentials, etc.) stops onboarding with a clear "blocked-on-prerequisite" message rather than silently proceeding.
 
 ## Onboarding report (`tests/e2e/docs/onboarding-report.md`)
 

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -205,11 +205,12 @@ Examples:
 
 The seven-phase pipeline (Phase 1 Scaffold → Phase 2 Groundwork discovery → Phase 3 Happy path → Phase 4 Full journey mapping → Phase 5 Coverage expansion → Phase 6 Bug hunts → Phase 7 Final summary) is specified in [`references/phases-walkthrough.md`](references/phases-walkthrough.md). Read it before authoring or modifying any phase logic.
 
-Key invariants kept here:
+### Hard rules — kernel-resident
 
-- **All seven phases run in order, no skipping.** Phase 5 (coverage-expansion) and Phase 6 (bug-discovery) are the lengthy phases — the front-load gate authorises both.
-- **Phase 5 invokes `coverage-expansion` with `mode: depth`** — the full 5-pass + cleanup pipeline. Onboarding does not invoke coverage-expansion in `mode: breadth`.
-- **Hard gates between phases.** A phase that surfaces a malformed prerequisite (missing journey-map sentinel, missing tenant credentials, etc.) stops onboarding with a clear "blocked-on-prerequisite" message rather than silently proceeding.
+- **All seven phases run in order, no skipping.** Phase 5 (coverage-expansion) and Phase 6 (bug-discovery) are the lengthy phases — the front-load gate authorises both up-front. Skipping either is a contract violation; surface to the user instead.
+- **Phase 5 invokes `coverage-expansion` with `mode: depth`** — the full 5-pass + cleanup pipeline. Onboarding never invokes coverage-expansion in `mode: breadth`.
+- **Hard gates between phases.** A phase that surfaces a malformed prerequisite (missing journey-map sentinel, missing tenant credentials, missing happy-path sentence, etc.) stops onboarding with a clear `blocked-on-prerequisite` message — never silently proceeds.
+- **Front-load gate is the only user prompt.** Once the user authorises the run, onboarding runs autonomously through Phase 7 — no further confirmation prompts. Mid-run scope-reduction without explicit user authorisation is forbidden (mirrors coverage-expansion §"Two valid exits").
 
 ## Onboarding report (`tests/e2e/docs/onboarding-report.md`)
 

--- a/skills/onboarding/references/phases-walkthrough.md
+++ b/skills/onboarding/references/phases-walkthrough.md
@@ -1,0 +1,144 @@
+# Onboarding Pipeline — Phases 1–7
+
+**Status:** authoritative spec for the autonomous onboarding pipeline. Cited from `onboarding/SKILL.md`.
+**Scope:** the full seven-phase pipeline (Phase 1 Scaffold, Phase 2 Groundwork discovery, Phase 3 Happy path, Phase 4 Full journey mapping, Phase 5 Coverage expansion, Phase 6 Bug hunts, Phase 7 Final summary), per-phase task lists, hard gates, and progress-output discipline.
+
+For the front-load gate that authorises the whole pipeline, see `onboarding/SKILL.md` §"Front-load gate".
+For the coverage-expansion sub-skill that Phase 5 invokes, see `../coverage-expansion/SKILL.md`.
+
+---
+
+## Pipeline
+
+Seven phases. Each phase ends with exactly one commit. Phases are skipped when the cascade level does not require them (Level A runs all phases; Level B skips install; Level C skips install and scaffold).
+
+### Phase 1 — Scaffold (Level A/B only)
+
+**Owner:** onboarding (direct).
+
+**Level A install scope:** install **only** missing packages from `@civitas-cerebrum/*` and Playwright:
+
+- `@civitas-cerebrum/element-interactions` if missing from `dependencies`.
+- `@civitas-cerebrum/element-repository` if missing.
+- `@playwright/test` if missing.
+- Run `npx playwright install chromium` (Chromium only; other browsers on request).
+
+Do **not** add, remove, or upgrade any other dependencies. Do **not** modify the user's `package.json` scripts beyond adding a `test:e2e` script if one doesn't already exist.
+
+**Scaffold files** (Level A and B, whichever are missing):
+
+- `playwright.config.ts` — minimal config with `baseURL` from the front-load gate, `testDir: './tests/e2e'`, `reporter: 'html'`, headless true.
+- `tests/fixtures/base.ts` — `baseFixture` export wiring `Steps` and `ContextStore`, with four `HELPER SLOT` comment markers that Stage 4a (test optimization) populates on demand. Exact starting content:
+
+  ```typescript
+  import { test as base, expect } from '@playwright/test';
+  import { baseFixture } from '@civitas-cerebrum/element-interactions';
+
+  const test = baseFixture(base, 'tests/data/page-repository.json', { timeout: 60000 });
+
+  // Stage-4a-managed helpers. Each slot is filled in only when both gates
+  // (UI-covered + API discovered) confirm during Stage 4a; otherwise the slot
+  // stays as a comment.
+  //
+  // HELPER SLOT: resetState — populated when a reset endpoint is discovered
+  //   in app-context.md's Test Infrastructure section.
+  // HELPER SLOT: setAuthCookie — populated when login/signup is UI-covered AND
+  //   POST /api/auth/login is discovered.
+  // HELPER SLOT: seedCart, createListingViaApi, etc. — populated per the
+  //   shortcut list in references/test-optimization.md when both gates apply.
+  // HELPER SLOT: dismissBanners — populated when Phase 1 discovery flagged a
+  //   persistent banner/modal in Test Infrastructure.
+
+  // HELPER SLOT: beforeEach — Stage 4a inserts test.beforeEach hooks here to
+  //   wire fixture-level helpers (dismissBanners, fixture-level resetState if
+  //   the project chooses fixture-level reset, etc.) into the test lifecycle.
+  //   The slot is additive across protocol runs — append, do not overwrite.
+  //   Per-test setup belongs in the spec, not in this slot.
+
+  export { test, expect };
+  ```
+
+  The `HELPER SLOT` comments are a contract: Stage 4a replaces them with code, never editing arbitrary regions of the file. Full helper templates: see `../element-interactions/references/test-optimization.md` §1, §4, §5.
+- `page-repository.json` — `{}` at the repo root (or `tests/e2e/page-repository.json`; follow existing convention if partial scaffold exists).
+- `tests/e2e/` — directory created if missing.
+- `tests/e2e/docs/` — directory created if missing.
+- `screenshots/` — directory created at the repo root if missing. All screenshot artifacts produced during the run (probe evidence, adversarial captures, failure snapshots) must be written here — never to the repo root, never with bare basenames.
+- `.gitignore` — add `screenshots/failures/` so transient Playwright failure captures stay untracked, and `.playwright-cli/` so the CLI's per-run snapshot YAMLs and console buffers stay untracked. Probe-evidence screenshots in `screenshots/` root remain tracked so reviewers can open the ledger and see what the subagent saw.
+
+**Screenshot-path contract for dispatched subagents.** Every subagent brief this skill writes — Phase-3 happy-path agent, Phase-5 `coverage-expansion` subagents, Phase-6 `bug-discovery` subagents — must restate the following rule verbatim:
+
+> All screenshot artifacts write to `screenshots/<descriptive-name>.png`. Never bare basenames. This applies to `playwright-cli screenshot --filename=<path>`, Playwright `page.screenshot({ path: ... })`, and any ledger reference citing a screenshot as evidence. Playwright failure screenshots write to `screenshots/failures/<test-name>-<timestamp>.png` (gitignored).
+
+This is a pure-hygiene rule enforced at the skill-brief level — bare-basename screenshots litter the repo root and break ledger references whose resolution depends on Node's CWD.
+
+**Brief-validation check before dispatch.** Before the orchestrator sends any Phase-3/5/6 subagent brief, it must grep the brief for `screenshots/` and for the bare-basename ban string above. A brief that omits the rule is malformed — the orchestrator regenerates it before dispatching rather than sending a brief that lets the subagent pick its own path convention. This is a one-line self-check, not a new review stage.
+
+**Commit:** `chore: scaffold element-interactions framework`.
+
+### Phase 2 — Groundwork discovery
+
+**Delegate to:** `journey-mapping` with `args: "phase-1-only"`.
+
+The companion writes `tests/e2e/docs/app-context.md` and a sentinel-bearing `tests/e2e/docs/journey-map.md` whose body contains only the site map (Phase-2–4 sections are empty headings).
+
+**Commit:** `docs: initial app-context and site map`.
+
+### Phase 3 — Happy path
+
+**Delegate to:** `element-interactions` with `args: "autonomousMode: true happyPathDescription: '<one-sentence description from the front-load gate>'"`.
+
+The companion runs Stages 1–4 inline with gates suspended, using the description + the site map from Phase 2 to pick the target flow. Any failure routes through `failure-diagnosis` automatically.
+
+**Commit:** `test: happy path — <scenario name>`. The orchestrator returns the scenario name in its summary; use that.
+
+### Phase 4 — Full journey mapping
+
+**Delegate to:** `journey-mapping` with `args: "phases-2-4"`.
+
+The companion reads the existing sentinel-bearing Phase-1 map and fills in Phases 2–4 (flow identification, prioritisation, journey map document). File is overwritten in place; sentinel preserved.
+
+**Commit:** `docs: journey map — <N> journeys prioritized`.
+
+### Phase 5 — Coverage expansion (five passes, depth mode)
+
+**Delegate to:** `coverage-expansion` with `args: "mode: depth"`.
+
+That skill runs five journey-by-journey passes internally (3 compositional via test-composer + 2 adversarial via bug-discovery), each pass split per-journey into Stage A (compose/probe) + Stage B (fresh staff-QA reviewer with its own isolated `playwright-cli` session) running an A↔B retry loop up to 7 cycles per journey per pass. Subagent dispatch is opus-default (cost-blind), parallelised for independent journeys, with map growth reconciled between passes. Onboarding's role here is simply to invoke it and relay `[coverage-expansion]` progress lines upstream — no per-pass or per-cycle orchestration at this layer.
+
+Between and after the five passes, `coverage-expansion` itself refreshes its view of `app-context.md` and `journey-map.md`; onboarding does not need its own refresh step at this phase. When the skill returns, append a "Coverage expansion — new knowledge" section to `onboarding-report.md` summarising total tests added, new journeys discovered, and any sub-journeys promoted.
+
+**The onboarding skill's Phase 5 is not satisfied by Pass 1 alone.** Do not mark Phase 5 complete in the onboarding report, in any task tracker, or in the summary deck until `coverage-expansion` returns from **all five passes + cleanup** (see that skill's §"Per-pass completion criteria"). If the orchestrator is budget-constrained mid-pipeline, it commits what it has, writes resume state per `coverage-expansion`'s state-file contract (`tests/e2e/docs/coverage-expansion-state.json`), and returns to the user with a clear "resume needed" message — it does NOT claim Phase 5 done and silently defer passes 2–5 or the ledger dedup. A Phase 5 report that reads "Pass 1 complete, 2–5 deferred for budget" is honest; a report that reads "Phase 5 complete" when only Pass 1 ran is a bug in the orchestrator's summarisation.
+
+**Commits:** `coverage-expansion` commits once per pass (`test: coverage expansion pass <N>/5 — <summary>`). Onboarding adds no extra commit here.
+
+**No stage may be silently skipped.** Onboarding has seven phases and each phase has its own internal stages (element-interactions has Stages 1–4; coverage-expansion has Passes 1–5 + cleanup; bug-discovery has Phases 1a and 1b). Partial-phase completion is reportable; partial-phase completion disguised as full-phase completion is a contract violation. The onboarding-report and any summary deck MUST state partial status explicitly when applicable — "Phase 5: Pass 1 complete (44/44), Pass 2 partial (3/44), Pass 3–5 pending" — not "Phase 5 complete."
+
+**Dual-stage completion extension.** Phase 5 is complete only when every journey has a terminal `review_status` (`greenlight`, `blocked-cycle-stalled`, `blocked-cycle-exhausted`, or `blocked-dispatch-failure`) for every pass, not only when every journey has returned from Stage A. A pass where every journey's Stage A ran but some journeys have no `review_status` field in the state file is **incomplete**, per the extended no-skip contract. The onboarding-report's Phase-5 section must surface blocked-review-cycle and blocked-dispatch-failure journeys explicitly: `"Phase 5: Pass N/5 complete (44/44), 3 journeys blocked-cycle-stalled with unresolved review findings, 1 journey blocked-dispatch-failure (see state file for details)"`.
+
+### Phase 6 — Bug hunts (two passes)
+
+Two sequential invocations of `bug-discovery`:
+
+| Pass | `args` |
+|---|---|
+| 1 | `phase: 1a-element-probing` |
+| 2 | `phase: 1b-flow-probing` |
+
+Findings go to `tests/e2e/docs/onboarding-report.md` under "App bugs logged". The companion must NOT commit skipped tests for the findings; it logs them and continues.
+
+**Phase 6 is two dedicated bug-discovery passes (element-probing 1a, flow-probing 1b) — not "the bugs we happened to find during coverage."** Organic findings from earlier phases (happy path, coverage-expansion compositional passes, coverage-expansion adversarial passes 4/5) go in the onboarding-report's "App bugs logged" section; Phase 6's two dedicated passes run **in addition to** whatever organic discovery happened in earlier phases. Repackaging organic findings as "the Phase 6 output" is a loophole — the two dedicated passes either ran or they did not. If the orchestrator skips Phase 6's passes (budget, infra halt, explicit user instruction), the onboarding-report and the summary deck MUST say `"Phase 6 deferred — <reason>"` or `"Phase 6 partial — pass 1a only"`, never `"Phase 6 complete"`. Finding count alone is not evidence that Phase 6 ran.
+
+**Commits:** `docs: bug-hunt 1/2 findings` and `docs: bug-hunt 2/2 findings`.
+
+### Phase 7 — Final summary
+
+1. Invoke `work-summary-deck` to produce `qa-summary-deck.html`.
+2. Finalise `tests/e2e/docs/onboarding-report.md` with the sections in the next heading.
+
+**Commit:** `docs: onboarding report and summary deck`.
+
+### Task-tracking granularity
+
+Use pass-level tasks, not phase-level. A single "Phase 5" task that flips to done is a footgun — use `"Pass 1/5 compositional"`, `"Pass 2/5 compositional"`, `"Pass 3/5 compositional"`, `"Pass 4/5 adversarial"`, `"Pass 5/5 adversarial"`, `"Phase 5 cleanup"`, and a `"Phase 5 overall"` parent that only flips done when all child passes do. Same for Phase 6's two sub-passes (`"Phase 6 pass 1a element-probing"`, `"Phase 6 pass 1b flow-probing"`, `"Phase 6 overall"`). Parent tasks never flip done ahead of their children.
+
+---


### PR DESCRIPTION
Stacked on #133 → #125. Re-target to \`main\` after the parents merge.

Closes #128 and #129.

## Summary

Extract heavy reference content from all four SKILL.md files in the suite. Each \`SKILL.md\` becomes a kernel + Reference index + pointers; the heavy spec lives one file away in \`references/\`.

## Per-skill word counts

| File | Before | After | Delta |
|---|---|---|---|
| \`coverage-expansion/SKILL.md\` | 13,343 | **6,053** | −54.6% |
| \`element-interactions/SKILL.md\` | 7,827 | **5,494** | −29.8% |
| \`onboarding/SKILL.md\` | 4,080 | **2,655** | −34.9% |
| \`journey-mapping/SKILL.md\` | 4,015 | **1,932** | −51.9% |
| **Total** | **29,265** | **16,134** | **−44.9%** |

(Issue #128's ≤1,200-word target requires further extraction of §\"No-skip contract\", §\"Mandatory intent declaration\", §\"ABSOLUTE RULES\", §\"Progress output\", §\"Orchestrator context budget\" — left for a follow-up so this PR stays reviewable. The 45% reduction across 4 files is a solid first cut.)

## What's new (\`references/\`)

### coverage-expansion (commit \`b12a9c4\`)

| File | Words | Content |
|---|---|---|
| \`depth-mode-pipeline.md\` | 5,136 | Per-pass pipeline (1–8), pass differences, commit-message conventions, per-pass completion criteria, whole-suite re-run gate, parallelism model, model selection (cost-blind), auto-compaction, re-pass mode 2–3, P3 batched dispatch, ledger dedup. |
| \`dual-stage-retry-loop.md\` | 1,644 | 7-cycle Stage A↔B retry loop pseudocode, termination conditions, fresh-reviewer-every-cycle invariant, dual-stage anti-rationalizations. |
| \`state-file-schema.md\` | 722 | \`coverage-expansion-state.json\` shape, per-journey \`dispatches[]\` fields incl. dual-stage, journey-roster mutability, corrupt-state-refusal. |
| \`subagent-isolation.md\` | 604 | Per-role dispatch contracts: isolation guarantees, brief inputs, \`playwright-cli\` session naming, the never-hold-payload-content rule. |
| **\`anti-rationalizations.md\`** | 2,454 | **(Closes #129.)** 14 failure-mode patterns keyed by category (not surface phrasing). |

### Other three skills (commit \`90a6e21\`)

| File | Words | Content |
|---|---|---|
| \`element-interactions/references/stages-protocol.md\` | 2,700 | Stages 1–4: scenario discovery, element inspection, write automation, post-stabilization review (4a + 4b). |
| \`onboarding/references/phases-walkthrough.md\` | 1,668 | Phases 1–7: scaffold, groundwork, happy path, journey mapping, coverage expansion, bug hunts, final summary. |
| \`journey-mapping/references/phases.md\` | 2,267 | Phases 1–3.5: page discovery, flow identification, prioritization, redundancy revision. (Phase 4–5 stay in SKILL.md because they're tightly coupled to the committed-file's signature-marker rules.) |

## SKILL.md kernel changes

All four SKILL.md files now have:
- A **Reference index** table near the top — every \`references/<file>.md\` listed with a one-line description so the next reader can pick the right file to load.
- Their largest section replaced by a short pointer + key-invariants block (5–12 lines each).

## #129 — Consolidated anti-rationalization registry

\`coverage-expansion/references/anti-rationalizations.md\` consolidates 8+ scattered \"excuse | reality\" tables into 14 patterns, keyed by failure-mode category:

1. Pre-emptive scope reduction (the \"pragmatic Pass 1 only\" failure)
2. Self-authorised batching (Stage A grouping)
3. Self-certifying greenlight
4. Spirit-vs-letter argument
5. Compress findings into summary
6. Stale-budget rationalisation
7. \"MCP tool was in my list, so it must be allowed\"
8. Subagent fan-out anti-pattern
9. Sonnet cost-down rationalisation
10. Trivial-journey-skip / cycle-1 Stage B greenlight self-certification
11. Cycle-7 exhausted → call-it-greenlit
12. Reviewer-disagreement cherry-picking
13. Brief-leak — orchestrator meta-content in subagent brief
14. Auto-compact threshold creep

Each entry: name, symptoms, reality, enforcing hook(s) or \`markdown-only\` tag, origin link. The \`markdown-only\` tag explicitly highlights where mechanical enforcement is missing — a follow-up target list.

## Reviewer checklist

- [ ] Every cross-reference in the moved content still resolves (the extracted files preserve internal links).
- [ ] No information lost — only relocated. Section headings preserved verbatim where they moved.
- [ ] Each \`SKILL.md\` has a \"Reference index\" table covering every \`references/<file>.md\`.
- [ ] \`anti-rationalizations.md\`'s patterns are categorised by failure mode, not surface phrasing — the registry's stated value proposition.

## Out of scope (follow-up)

- Further \`coverage-expansion/SKILL.md\` extraction to hit the ≤1,200-word target (§\"No-skip contract\", §\"Mandatory intent declaration\", §\"Progress output\", §\"Orchestrator context budget\").
- Same for the other three SKILL.md files — each is now ~2-5k words, not yet at ≤500-1,200 target.
- The \`markdown-only\`-tagged anti-rationalization patterns are candidates for new hooks (similar to issues #127 / #132).

## Test plan

- [ ] Pull the branch and read each SKILL.md top-to-bottom — verify the kernel reads cleanly with the Reference index near the top.
- [ ] Open each new \`references/<file>.md\` and verify it's self-contained.
- [ ] Spot-check internal cross-references (\`§\"X\"\` style) still resolve to sections in the same file or the indicated reference file.