### PR TITLE
chore: bump version to 0.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civitas-cerebrum/element-interactions",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A robust, readable interaction and assertion Facade for Playwright. Abstract away boilerplate into semantic, English-like methods, making your test automation framework cleaner, easier to maintain, and accessible to non-developers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bundles the 30 commits merged across PRs #125, #133, #134, #135, #136 into a v0.3.4 release.

## Highlights

- **#125** — 9-hook harness gate suite + manifest-driven installer + 14 edge-case fixes
- **#126/#127/#130/#132** (PR #133) — inter-agent communication format: role-explicit prefixes (composer-/reviewer-/probe-/process-validator-), PostToolUse:Agent return-schema validator hook, process-validator workflow spec, brief-cleanup WARN→BLOCK promotion
- **#131** (PR #134) — suite-gate windowed ratchet: last-N runs (default 3), env override `CIVITAS_SUITE_GATE_WINDOW`, legacy single-object format auto-migration
- **#128/#129** (PR #135) — skill-file consolidation: 4 SKILL.md kernels shrunk from 29,265 → 16,134 words (-44.9%), 8 new `references/` files, 14-pattern category-level anti-rationalization registry
- **PR #136** — hook documentation/helper unification (consistent header: Hook / Mode / State / Env / Rule / Why / Reference / Failure → action), skill consistency (uniform `### Hard rules — kernel-resident` blocks across all 4 SKILL.mds), 141-case edge-case regression test harness at `hooks/tests/run.sh`

## Issues closed

#126, #127, #128, #129, #130, #131, #132 (7 issues).

## Test plan

- [ ] `bash hooks/tests/run.sh` reports 141/141 green
- [ ] CI: `test` + `coverage` pass