### PR TITLE
feat(skills): test-infrastructure-probe subagent + inter-phase auto-compact (Q2.1 + Q2.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,11 +13,14 @@ tests/e2e/docs/.in-flight-composers.json
 tests/e2e/docs/.coverage-expansion-cycle-*.json
 tests/e2e/docs/onboarding-phase-ledger.json
 tests/e2e/docs/coverage-expansion-state.json
+tests/e2e/docs/.adversarial-findings.lock
 
 # Subagent spillover bodies (§2.6 of subagent-return-schema.md) — written
 # by reviewer / probe / etc. subagents on return; consumed by the next
 # composer-cycle brief. Per-run state, never source.
 tests/e2e/docs/.subagent-returns/
+tests/e2e/docs/.handover-payloads/
+
 api-coverage-report.txt
 
 .env
@@ -29,12 +32,3 @@ test-coverage-report.md
 /docs
 /skills/*-workspace
 /solution-designs
-
-# Runtime state files written by hooks during testing / live runs.
-tests/e2e/docs/.in-flight-composers.json
-tests/e2e/docs/.handover-payloads/
-tests/e2e/docs/.subagent-returns/
-tests/e2e/docs/.adversarial-findings.lock
-tests/e2e/docs/.coverage-expansion-cycle-*.json
-tests/e2e/docs/coverage-expansion-state.json
-tests/e2e/docs/onboarding-phase-ledger.json

--- a/skills/journey-mapping/references/phases.md
+++ b/skills/journey-mapping/references/phases.md
@@ -112,11 +112,16 @@ Total: X pages discovered
 Gated: Y pages behind authentication
 ```
 
-### Test Infrastructure probe (parallel with crawl)
+### Test Infrastructure probe (split: per-entry observation + post-crawl `phase1-test-infra:` subagent)
 
-Phase 1 also captures the application's test-infrastructure surface — auth model, reset endpoint, persistent banners, mutation endpoints, stable seed resources — for downstream consumption by Stage 4a of the test-composition pipeline.
+Phase 1 captures the application's test-infrastructure surface — auth model, reset endpoint, persistent banners, mutation endpoints, stable seed resources — for downstream consumption by Stage 4a of the test-composition pipeline.
 
-Load `references/test-infrastructure-probe.md` and run the protocol described there. The probe runs in parallel with the breadth-first page crawl: observations from network traffic and DOM snapshots accumulate during the crawl; the deliberate reset-endpoint probe runs once the crawl completes.
+Load `references/test-infrastructure-probe.md` and run the protocol described there. The probe runs in **two coordinated layers**:
+
+1. **In parallel with the crawl** — each per-entry-point `phase1-<entry>:` subagent records observed items (auth-model network shapes, mutation endpoints fired by the browser) in its structured return.
+2. **After the crawl completes** — the orchestrator dispatches a single **`phase1-test-infra:` subagent** that runs the deliberate post-crawl probes (reset-endpoint detection, banner / modal selector resolution, stable-seed enumeration) AND reconciles the per-entry-point observations into a single deduplicated list, then writes the canonical `## Test Infrastructure` section to `tests/e2e/docs/app-context.md`.
+
+**Why a subagent for the post-crawl probe.** The deliberate probe generates several thousand tokens of network output and DOM snapshots. Confining it to a throwaway subagent context keeps the orchestrator at index-level state — the orchestrator only sees the structured return (the `## Test Infrastructure` Markdown block + the audit-tag list). Same context-discipline rule coverage-expansion enforces for composer/probe work, applied here.
 
 **Output:** a `## Test Infrastructure` section appended to `tests/e2e/docs/app-context.md`, in the canonical format documented in `references/test-infrastructure-probe.md`.
 

--- a/skills/journey-mapping/references/test-infrastructure-probe.md
+++ b/skills/journey-mapping/references/test-infrastructure-probe.md
@@ -6,7 +6,17 @@
 
 ## When this protocol runs
 
-In parallel with `journey-mapping`'s Phase 1 breadth-first crawl. The probe collects observations during the crawl and runs a deliberate reset-endpoint probe after the crawl completes.
+The probe runs in two coordinated layers — observation during the crawl + a dedicated post-crawl subagent dispatch:
+
+1. **In parallel with the crawl** (per-entry-point `phase1-<entry>:` subagents already in flight): each crawl subagent records the **observed** items it sees while visiting pages — Category A (auth model: when it visits `/login` / `/signup`, captures the auth shape from network traffic) and Category E (mutation endpoints: every POST/PUT/PATCH/DELETE the browser fires while crawling). These are emitted as part of each crawl subagent's structured return.
+
+2. **After the crawl completes** the orchestrator dispatches a single **`phase1-test-infra:` subagent** that runs the **deliberate post-crawl probes** — Category B (reset/seed endpoint probe — fires the fixed list of `POST /api/reset` etc. against the host), Category C (banner / modal selector resolution — replays one of the homepage hits and resolves dismissal selectors), and Category D (stable seed resource enumeration — visits each catalog-style page once and records first-render IDs). The subagent also reconciles the per-entry-point Categories A + E into a single deduplicated list, then writes the canonical `## Test Infrastructure` section to `tests/e2e/docs/app-context.md`.
+
+**Why this split.** The deliberate probe (B / C / D + the A/E reconciliation) is several thousand tokens of network output, DOM snapshots, and parsing. Running it inline in the orchestrator's context puts that load on every downstream phase. Dispatching it as a subagent confines the load to a single throwaway context — the orchestrator only sees the subagent's structured return (the `## Test Infrastructure` markdown block + a list of constraint tags for the audit). This is the same context-discipline rule coverage-expansion enforces for composer/probe work, applied to journey-mapping Phase 1.
+
+**Dispatch slug:** `phase1-test-infra:` (recognised by the dispatch-guard's `phase1-[a-z0-9-]+` allowed-prefix regex). Single dispatch — not per-entry-point. Runs after the crawl roster reports complete. CLI session slug: `phase1-test-infra` (same prefix, isolated session).
+
+**Subagent return shape:** structured Markdown matching the canonical `## Test Infrastructure` template below + a top-of-return `tags:` array carrying the constraint tags surfaced for the onboarding shared-resource audit (`global-reset:cross-test-race`, `single-tenant-global-state`, `csrf-session-bound`, etc. — see `onboarding/SKILL.md` §"Shared-resource audit").
 
 ## Inputs
 

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -263,6 +263,23 @@ Onboarding dispatches `phase-validator-<N>:` at the **end of every phase**, befo
 
 Full workflow spec — manifest shape, per-phase verification table, response handling, cycle counting across resume — in [`references/phase-validator-workflow.md`](references/phase-validator-workflow.md). Return shape canonical in `../element-interactions/references/subagent-return-schema.md` §2.5. Schema-conformance enforced by `hooks/subagent-return-schema-guard.sh` (validates phase-validator returns at PostToolUse). Mechanical dispatch-required enforcement (deny advance without prior-phase greenlight in the ledger) is the planned v0.3.7 follow-up; until then, the orchestrator self-disciplines per the kernel rules.
 
+#### Inter-phase auto-compact
+
+After each phase greenlights via its `phase-validator-<N>:` and BEFORE the orchestrator begins phase N+1's work, Onboarding runs `/compact` (or emits the safe-compact line for manual compaction on platforms without programmatic compaction). Phase N's accumulated context — per-entry-point summaries, validator returns, in-flight composer bookkeeping — should not persist into Phase N+1. Only the structured state files survive across the compact (the `app-context.md`, `journey-map.md`, `coverage-expansion-state.json`, `onboarding-phase-ledger.json`, `adversarial-findings.md`).
+
+**Why routine, not threshold-only.** Coverage-expansion's `references/depth-mode-pipeline.md` §"Auto-compaction between passes" already runs auto-compact when context crosses a 70%-threshold. That handles the within-phase case (e.g. when Pass 5's adversarial-totals counter approaches budget mid-run). The inter-phase auto-compact is independent: even at 30% utilisation, flushing Phase N's context before Phase N+1 keeps the orchestrator at index-level state across phase boundaries — which is what the per-phase completion contract assumes.
+
+**Sequence:**
+
+1. Phase N's sub-skill returns. Orchestrator dispatches `phase-validator-<N>:` per the kernel rule above.
+2. Validator returns greenlight. Onboarding records the entry in `onboarding-phase-ledger.json` (handled by `hooks/phase-validator-dispatch-required.sh`).
+3. **Onboarding runs `/compact`** (or emits the safe-compact line). The orchestrator's first action on the post-compact turn is to re-read the ledger + relevant state files; it picks up from the ledger's recorded greenlight and proceeds to phase N+1.
+4. Phase N+1 begins.
+
+A skipped inter-phase compact is not a hard error — it just leaves Phase N's load on the orchestrator. Routine compact is the cheap, deliberate alternative to the >70%-threshold panic case.
+
+**Phase 7 exception.** No compact after Phase 7 — the run is done; the report and deck are the deliverables.
+
 #### Other invariants
 
 - **All seven phases run in order.** No reordering, no skipping. The front-load gate authorises Phases 1–7 up-front; the user does not get re-prompted between phases.


### PR DESCRIPTION
Q2 of the context-offloading design conversation. Q1 in flight as #144 (in-flight composer registry). Q2.2 (per-subagent summary spillover) tracked as #145. Q3 (pollution-signaled compact) explicitly out of scope.

## Q2.1 — test-infrastructure-probe subagent

\`journey-mapping/references/test-infrastructure-probe.md\` split into two coordinated layers:

| Layer | Runs in | Captures |
|---|---|---|
| 1 — Inline during crawl | per-entry-point \`phase1-<entry>:\` subagents | Category A (auth model from network shapes) + Category E (mutation endpoints) |
| 2 — Post-crawl deliberate probe | new \`phase1-test-infra:\` subagent | Category B (reset/seed endpoint detection) + Category C (banner / modal selector resolution) + Category D (stable-seed enumeration) + per-entry reconciliation |

Layer 2 is the heavy work — several thousand tokens of network output, DOM snapshots, and parsing. Confining it to a throwaway subagent context keeps the orchestrator at index-level state (it only sees the structured \`## Test Infrastructure\` Markdown block + the audit-tag list).

The new dispatch slug \`phase1-test-infra:\` matches the existing \`phase1-[a-z0-9-]+\` allowed-prefix regex — no dispatch-guard change needed.

\`journey-mapping/references/phases.md\` §\"Test Infrastructure probe\" updated to reflect the split.

## Q2.3 — Inter-phase auto-compact

\`onboarding/SKILL.md\` §\"Hard rules — kernel-resident\" gains a new subsection:

> After each phase greenlights via phase-validator-<N>: AND BEFORE Onboarding begins phase N+1, the orchestrator runs \`/compact\` (or emits the safe-compact line). Phase N's accumulated context — per-entry-point summaries, validator returns, in-flight composer bookkeeping — should not persist into Phase N+1. Only the structured state files survive across the compact.

Distinct from coverage-expansion's \`references/depth-mode-pipeline.md\` §\"Auto-compaction between passes\" which fires at >70% context threshold within a phase. Inter-phase compact is **routine** — fires at every phase boundary regardless of utilisation. Phase 7 exempt (run is done).

The 4-step sequence is documented in the skill: phase-N sub-skill returns → phase-validator-N greenlight → ledger record → \`/compact\` → orchestrator's first post-compact action is re-reading the ledger + state files → phase N+1 begins.

## .gitignore

Runtime-state-file entries forward-ported from PR #144 (general-purpose, safe to land independently):
- \`tests/e2e/docs/.in-flight-composers.json\`
- \`tests/e2e/docs/.coverage-expansion-cycle-*.json\`
- \`tests/e2e/docs/onboarding-phase-ledger.json\`
- \`tests/e2e/docs/coverage-expansion-state.json\`

## Why Q2.2 is deferred

Per-subagent summary spillover to disk (where bulk-content Markdown returns are written to \`.subagent-returns/\` files and the orchestrator holds only pointers) is a bigger architectural change — return-shape contract update across composer / reviewer / probe / process-validator / phase-validator. Tracked as #145.

Until #145 ships, structured Markdown returns continue to live in subagent reply bodies. Q2.1's post-crawl probe subagent already practises the spirit of #145 (the deliberate probe stays in throwaway context) — extending the pattern suite-wide is #145's job.

## Why Q3 is out of scope

Pollution-signaled compact (phase-validator return triggers \`/compact\` on improvements-needed) skipped because:

- **#144 (Q1)** prevents pollution at write time — orchestrator-direct composition is denied unless the slug is in-flight.
- **This PR (Q2.1 + Q2.3)** lightens orchestrator load (test-infra probe offloaded) AND flushes context routinely (inter-phase compact).
- Existing 70%-threshold auto-compact handles residual within-phase pressure.
- Adding pollution-signaled compact would solve a problem this PR + #144 prevent.

## Reviewer checklist

- [ ] \`bash hooks/tests/run.sh\` reports 200/200 (this PR adds no new tests — Q2 is markdown-only design).
- [ ] \`phase1-test-infra:\` dispatch slug is recognised by the existing \`phase1-[a-z0-9-]+\` allowed-prefix regex (no dispatch-guard change needed).
- [ ] Inter-phase auto-compact wording is consistent with coverage-expansion's existing within-phase auto-compact (different trigger, same mechanism).
- [ ] Phase 7 exemption named explicitly.
- [ ] \`.gitignore\` entries match #144's set (no divergence at merge time).

## Coordination with #144

PR #144 (in-flight composer registry) lands the runtime state file convention. This PR forward-ports the .gitignore entries so they're available independent of #144's merge order.

If #144 merges first: this PR's .gitignore additions are a no-op (already present). Clean rebase.

If this PR merges first: #144 will see the .gitignore entries already in place when rebased; its own .gitignore changes deduplicate to no-op. Clean rebase.

Either order works.