### PR TITLE
chore: bump element-repository to ^0.1.9 (cap resolver attach probe at 2s)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@civitas-cerebrum/context-store": "^0.0.2",
-        "@civitas-cerebrum/element-repository": "^0.1.8",
+        "@civitas-cerebrum/element-repository": "^0.1.9",
         "@civitas-cerebrum/email-client": "^0.0.7",
         "@civitas-cerebrum/wasapi": "^0.0.3",
         "@playwright/cli": "0.1.10",
@@ -36,9 +36,9 @@
       "license": "MIT"
     },
     "node_modules/@civitas-cerebrum/element-repository": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/element-repository/-/element-repository-0.1.8.tgz",
-      "integrity": "sha512-mWNjvjBJ6wEyLsViH2h4sdwooiE5zqOyv7MVjE4hjYBxQRP2l40XY92orCHPdSjOAdR+dT54mtbn91tGf5z+Zg==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/element-repository/-/element-repository-0.1.9.tgz",
+      "integrity": "sha512-jcmFJUUbCFMb9faAKcFKE2bATe75/pNhBtX95jvbwVxKJBqGuwq1ULFy38qMXHk99P7SlpCYC+9xmZcLCKJcIw==",
       "license": "MIT",
       "dependencies": {
         "@civitas-cerebrum/test-coverage": "^0.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civitas-cerebrum/element-interactions",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "A robust, readable interaction and assertion Facade for Playwright. Abstract away boilerplate into semantic, English-like methods, making your test automation framework cleaner, easier to maintain, and accessible to non-developers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "license": "MIT",
   "dependencies": {
     "@civitas-cerebrum/context-store": "^0.0.2",
-    "@civitas-cerebrum/element-repository": "^0.1.8",
+    "@civitas-cerebrum/element-repository": "^0.1.9",
     "@civitas-cerebrum/email-client": "^0.0.7",
     "@civitas-cerebrum/wasapi": "^0.0.3",
     "@playwright/cli": "0.1.10",


### PR DESCRIPTION
## Summary

Bumps `@civitas-cerebrum/element-repository` from `^0.1.8` to `^0.1.9` and bumps `@civitas-cerebrum/element-interactions` from `0.3.5` to `0.3.6`.

The upstream change ([element-repository#46](https://github.com/civitas-cerebrum/element-repository/pull/46), released as 0.1.9) caps the no-strategy `StrategyResolver.fromSelector` attach probe at 2s. Previously the resolver burned the full configured `timeout` (15s by default) on a swallowed pre-action `waitFor({ state: 'attached' })`, so any negative assertion in the consumer matcher tree on a missing element paid that full cost — for example:

```ts
await steps.expect('absent', 'page').visible.toBeFalse();   // burned 15s
await steps.expect('absent', 'page').count.toBe(0);         // burned 15s
```

Downstream actions and assertions still get the full configured timeout via their own waits, so behaviour for genuinely-present elements is unchanged.

## Verified impact

Re-ran a real consumer suite (`bookhive-e2e`, `j-search-books`) with the patched build linked into `node_modules`:

- Before: 7/8 tests took 15–16s each (resolver burn on `noBooks visible.toBeFalse` after a real-match query)
- After: same 7 tests take 2–2.6s each
- File runtime: ~1m45s → ~17s

## Test plan

- [x] `npm install` — lockfile refreshed to 0.1.9
- [x] `npm run build` — passes
- [x] `npm test` — 501 unit tests pass; one pre-existing failure (`tests/api-steps.spec.ts` `beforeAll` requires a live BookHive backend that isn't running in this environment) — unrelated to the dep bump
- [ ] Reviewer: confirm 0.3.6 is the right version bump (patch — no consumer-visible API change)