### PR TITLE
fix(postinstall): auto-install jq when missing (closes #165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ npm i @civitas-cerebrum/element-interactions
 
 > **Tip:** Set `reporter: 'html'` in `playwright.config.ts` so failure screenshots are captured and viewable in the HTML report — both the framework's `baseFixture` and the harness's failure-diagnosis flow rely on it.
 
+> **Platform support:** This package targets POSIX environments (Linux, macOS); the harness hooks rely on POSIX shell tooling (e.g. `jq`). Windows users should run via WSL2 or an equivalent POSIX layer.
+
 ---
 
 ## ✨ Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.3.13",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civitas-cerebrum/element-interactions",
-      "version": "0.3.13",
+      "version": "0.3.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.3.6",
+  "version": "0.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civitas-cerebrum/element-interactions",
-      "version": "0.3.6",
+      "version": "0.3.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.3.6",
+  "version": "0.3.13",
   "description": "A robust, readable interaction and assertion Facade for Playwright. Abstract away boilerplate into semantic, English-like methods, making your test automation framework cleaner, easier to maintain, and accessible to non-developers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.3.13",
+  "version": "0.3.6",
   "description": "A robust, readable interaction and assertion Facade for Playwright. Abstract away boilerplate into semantic, English-like methods, making your test automation framework cleaner, easier to maintain, and accessible to non-developers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,10 @@
   },
   "author": "Umut Ay Bora",
   "license": "MIT",
+  "os": [
+    "darwin",
+    "linux"
+  ],
   "dependencies": {
     "@civitas-cerebrum/context-store": "^0.0.2",
     "@civitas-cerebrum/element-repository": "^0.1.9",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -249,13 +249,20 @@ function installCivitasHooks() {
 // jq is a hard runtime dependency of the harness hooks (see issue #165).
 // Most hooks parse the JSON event payload via `jq`, and `jq` missing on the
 // host means every hook crashes with `jq: command not found` — silent
-// non-blocking failures on PostToolUse, accept-all on PreToolUse. Detect
-// and install before registering the hooks so they actually work on first
-// activation.
+// non-blocking failures on PostToolUse, accept-all on PreToolUse.
 //
-// Opt-out: set CIVITAS_SKIP_JQ_INSTALL=1 to skip the auto-install attempt
-// (useful when the user manages jq via a system package manager that this
-// shim doesn't know about, or for offline / sandboxed environments).
+// Detect-only posture (per PR #174 review): the postinstall does NOT attempt
+// to install jq on the consumer's behalf. Auto-installing brings a tangle of
+// risks — sudo prompts in non-TTY contexts, CI/Docker breakage, partial-state
+// failures across package managers, and no clean Windows story — none of
+// which are appropriate for an `npm install` side-effect. Instead, when jq
+// is missing we print a clear, actionable warning naming every install path
+// and set process.exitCode = 1 so npm surfaces the message even under the
+// default foreground-scripts-off behaviour (per #153 mitigation 4).
+//
+// Opt-out: set CIVITAS_SKIP_JQ_INSTALL=1 to silence the check entirely
+// (useful for offline / sandboxed / pre-provisioned environments where jq
+// is known to be present or intentionally absent).
 function ensureJq() {
   if (process.env.CIVITAS_SKIP_JQ_INSTALL === '1') {
     return;
@@ -267,49 +274,22 @@ function ensureJq() {
     return;
   }
 
-  console.log('[@civitas-cerebrum/element-interactions] jq not found — required by harness hooks. Attempting platform-appropriate install…');
-
-  // Try platform-appropriate package manager. Stop at the first that works.
-  // Order: brew (macOS), apt-get (Debian/Ubuntu), apk (Alpine), dnf (RHEL/
-  // Fedora), pacman (Arch). Each attempt is best-effort; failures fall
-  // through to the manual-install warning.
-  const candidates = [
-    { bin: 'brew',     args: ['install', 'jq'],                 sudo: false },
-    { bin: 'apt-get',  args: ['install', '-y', 'jq'],           sudo: true  },
-    { bin: 'apk',      args: ['add', '--no-cache', 'jq'],       sudo: false },
-    { bin: 'dnf',      args: ['install', '-y', 'jq'],           sudo: true  },
-    { bin: 'pacman',   args: ['-S', '--noconfirm', 'jq'],       sudo: true  },
-  ];
-
-  for (const c of candidates) {
-    // `which <bin>` returns 0 if the binary is on PATH. Avoids the shell:true
-    // overhead and the Node deprecation warning about args + shell.
-    if (spawnSync('which', [c.bin], { stdio: 'ignore' }).status !== 0) {
-      continue;
-    }
-    const cmd = c.sudo ? 'sudo' : c.bin;
-    const args = c.sudo ? [c.bin, ...c.args] : c.args;
-    const result = spawnSync(cmd, args, { stdio: 'inherit' });
-    if (result.status === 0) {
-      // Re-probe to confirm.
-      if (spawnSync('jq', ['--version'], { stdio: 'ignore' }).status === 0) {
-        console.log(`[@civitas-cerebrum/element-interactions] ✔ jq installed via ${c.bin}.`);
-        return;
-      }
-    }
-  }
-
-  // No package manager worked — print a clear, actionable warning and exit
-  // non-zero so npm surfaces the message even under the default
-  // foreground-scripts-off behaviour (per #153 mitigation 4).
-  console.warn('[@civitas-cerebrum/element-interactions] WARNING: could not auto-install jq.');
+  // Not present — emit a clear, platform-aware warning and exit non-zero.
+  console.warn('[@civitas-cerebrum/element-interactions] WARNING: jq not found on PATH.');
   console.warn('  Harness hooks require jq to parse hook payloads — without it, hooks crash silently.');
-  console.warn('  Install manually before invoking any skill that depends on the harness:');
-  console.warn('    macOS:           brew install jq');
-  console.warn('    Debian/Ubuntu:   sudo apt-get install jq');
-  console.warn('    Alpine:          apk add --no-cache jq');
-  console.warn('    RHEL/Fedora:     sudo dnf install jq');
-  console.warn('    Arch:            sudo pacman -S jq');
+  console.warn('  Install jq manually before invoking any skill that depends on the harness:');
+  if (process.platform === 'win32') {
+    console.warn('    Windows (winget): winget install jqlang.jq');
+    console.warn('    Windows (choco):  choco install jq');
+    console.warn('    Windows (scoop):  scoop install jq');
+    console.warn('  Note: this package targets POSIX shells (Linux/macOS); on Windows use WSL2.');
+  } else {
+    console.warn('    macOS:           brew install jq');
+    console.warn('    Debian/Ubuntu:   sudo apt-get install jq');
+    console.warn('    Alpine:          apk add --no-cache jq');
+    console.warn('    RHEL/Fedora:     sudo dnf install jq');
+    console.warn('    Arch:            sudo pacman -S jq');
+  }
   console.warn('    Other:           https://jqlang.github.io/jq/download/');
   console.warn('  Skip this check next time: set CIVITAS_SKIP_JQ_INSTALL=1.');
   process.exitCode = 1;
@@ -319,6 +299,7 @@ try {
   ensureJq();
 } catch (err) {
   console.warn(`[civitas-cerebrum] Could not check jq availability: ${err.message}`);
+  process.exitCode = 1;
 }
 
 try {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -2,6 +2,7 @@
 
 const fs   = require('fs');
 const path = require('path');
+const { spawnSync } = require('child_process');
 
 const packageDir  = path.resolve(__dirname, '..');
 const skillsDir   = path.join(packageDir, 'skills');
@@ -245,6 +246,81 @@ function installCivitasHooks() {
   console.log(`[civitas-cerebrum] Harness hooks: ${copiedCount} script${copiedCount === 1 ? '' : 's'} copied, ${registeredCount} registration${registeredCount === 1 ? '' : 's'} added (others already present). Restart Claude Code to pick them up.`);
 }
 
+// jq is a hard runtime dependency of the harness hooks (see issue #165).
+// Most hooks parse the JSON event payload via `jq`, and `jq` missing on the
+// host means every hook crashes with `jq: command not found` — silent
+// non-blocking failures on PostToolUse, accept-all on PreToolUse. Detect
+// and install before registering the hooks so they actually work on first
+// activation.
+//
+// Opt-out: set CIVITAS_SKIP_JQ_INSTALL=1 to skip the auto-install attempt
+// (useful when the user manages jq via a system package manager that this
+// shim doesn't know about, or for offline / sandboxed environments).
+function ensureJq() {
+  if (process.env.CIVITAS_SKIP_JQ_INSTALL === '1') {
+    return;
+  }
+
+  // Already on PATH? Done.
+  const probe = spawnSync('jq', ['--version'], { stdio: 'ignore' });
+  if (probe.status === 0) {
+    return;
+  }
+
+  console.log('[@civitas-cerebrum/element-interactions] jq not found — required by harness hooks. Attempting platform-appropriate install…');
+
+  // Try platform-appropriate package manager. Stop at the first that works.
+  // Order: brew (macOS), apt-get (Debian/Ubuntu), apk (Alpine), dnf (RHEL/
+  // Fedora), pacman (Arch). Each attempt is best-effort; failures fall
+  // through to the manual-install warning.
+  const candidates = [
+    { bin: 'brew',     args: ['install', 'jq'],                 sudo: false },
+    { bin: 'apt-get',  args: ['install', '-y', 'jq'],           sudo: true  },
+    { bin: 'apk',      args: ['add', '--no-cache', 'jq'],       sudo: false },
+    { bin: 'dnf',      args: ['install', '-y', 'jq'],           sudo: true  },
+    { bin: 'pacman',   args: ['-S', '--noconfirm', 'jq'],       sudo: true  },
+  ];
+
+  for (const c of candidates) {
+    // `which <bin>` returns 0 if the binary is on PATH. Avoids the shell:true
+    // overhead and the Node deprecation warning about args + shell.
+    if (spawnSync('which', [c.bin], { stdio: 'ignore' }).status !== 0) {
+      continue;
+    }
+    const cmd = c.sudo ? 'sudo' : c.bin;
+    const args = c.sudo ? [c.bin, ...c.args] : c.args;
+    const result = spawnSync(cmd, args, { stdio: 'inherit' });
+    if (result.status === 0) {
+      // Re-probe to confirm.
+      if (spawnSync('jq', ['--version'], { stdio: 'ignore' }).status === 0) {
+        console.log(`[@civitas-cerebrum/element-interactions] ✔ jq installed via ${c.bin}.`);
+        return;
+      }
+    }
+  }
+
+  // No package manager worked — print a clear, actionable warning and exit
+  // non-zero so npm surfaces the message even under the default
+  // foreground-scripts-off behaviour (per #153 mitigation 4).
+  console.warn('[@civitas-cerebrum/element-interactions] WARNING: could not auto-install jq.');
+  console.warn('  Harness hooks require jq to parse hook payloads — without it, hooks crash silently.');
+  console.warn('  Install manually before invoking any skill that depends on the harness:');
+  console.warn('    macOS:           brew install jq');
+  console.warn('    Debian/Ubuntu:   sudo apt-get install jq');
+  console.warn('    Alpine:          apk add --no-cache jq');
+  console.warn('    RHEL/Fedora:     sudo dnf install jq');
+  console.warn('    Arch:            sudo pacman -S jq');
+  console.warn('    Other:           https://jqlang.github.io/jq/download/');
+  console.warn('  Skip this check next time: set CIVITAS_SKIP_JQ_INSTALL=1.');
+  process.exitCode = 1;
+}
+
+try {
+  ensureJq();
+} catch (err) {
+  console.warn(`[civitas-cerebrum] Could not check jq availability: ${err.message}`);
+}
+
 try {
   installCivitasHooks();
 } catch (err) {
@@ -261,8 +337,6 @@ try {
 // Opt-out: set PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 (the Playwright-standard
 // env var) to skip the browser fetch — useful for offline installs and
 // container builds that mount a pre-warmed browser cache.
-const { spawnSync } = require('child_process');
-
 function probePlaywrightCli() {
   const probe = spawnSync('npx', ['--no-install', 'playwright-cli', '--version'], {
     cwd: projectRoot,


### PR DESCRIPTION
## Summary

Closes #165. **Reported-by:** @Emmdb.

The harness hooks parse JSON event payloads via `jq`. When jq is not on PATH, every hook crashes with `jq: command not found` — silent non-blocking failures on PostToolUse, accept-all on PreToolUse. Discovered in the wild during a farmedvisie project's `suite-gate-ratchet.sh` firing.

## What changed

`scripts/postinstall.js` — new `ensureJq()` runs before `installCivitasHooks()`:

1. `spawnSync('jq', ['--version'])` — silent allow if already on PATH.
2. On miss, attempt platform-appropriate install in order:
   - `brew install jq` (macOS)
   - `sudo apt-get install -y jq` (Debian / Ubuntu)
   - `apk add --no-cache jq` (Alpine)
   - `sudo dnf install -y jq` (RHEL / Fedora)
   - `sudo pacman -S --noconfirm jq` (Arch)

   Each candidate is detected via `which <bin>` (no `shell: true`; avoids the Node deprecation warning about args + shell). First success wins; we re-probe `jq --version` to confirm.
3. On total miss, print a clear actionable warning naming every install path **and** set `process.exitCode = 1` so npm surfaces the warning even under default `foreground-scripts: false` behaviour (same fail-loud pattern as #153 mitigation 4).
4. Opt-out: `CIVITAS_SKIP_JQ_INSTALL=1`.

`spawnSync` `require` lifted to the top of the file (it was previously declared after the playwright-cli probe; `ensureJq()` runs before that).

## Why no hook backstop

The methodology-as-hooks doctrine (PR #158) doesn't apply here — this is an install-time **script** change ensuring the hook layer's prerequisites are met. A hook that detects "jq missing" cannot itself run, because jq is missing. Defense in depth lives in the install-time exit-code-1 + warning, not in a runtime gate.

## Test plan

- [x] `node -c scripts/postinstall.js` → syntax OK.
- [x] which-based detection verified locally (brew detected, apt-get / apk / dnf / pacman / unknown-bin correctly reported absent).
- [x] Full hook suite still green at 276/276 (this branch's baseline; the open #161/#162/#163/#173 PRs add their own tests on their branches).
- [ ] Reviewer confirms the package-manager order is sensible (homebrew first because it's user-level + no-sudo on macOS; apt-get / dnf / pacman use sudo because that's the only path most distros support; apk is no-sudo because it's typically run inside Alpine containers as root anyway).
- [ ] Reviewer confirms `CIVITAS_SKIP_JQ_INSTALL=1` is the right escape-hatch surface — sibling to the existing `CIVITAS_SKIP_HOOK_INSTALL=1` pattern.

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>