### PR TITLE
feat(sql)!: adopt sql-client 0.1.2 — driver-free, lazy clients, ping/runScript/timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,8 +841,26 @@ await steps.cleanEmails();
 ## SQL Database Steps
 
 Query a SQL database directly in your tests — the natural oracle for verifying that a UI or API
-mutation actually persisted. Backed by `@civitas-cerebrum/sql-client` (Postgres). All values are
-parametrised; never interpolate values into SQL.
+mutation actually persisted. Backed by `@civitas-cerebrum/sql-client`, which speaks
+Postgres, MySQL/MariaDB, SQLite, SQL Server, and Oracle. All values are parametrised; never
+interpolate values into SQL.
+
+### Install the engine driver
+
+element-interactions does **not** bundle SQL drivers — install the one for the engine you target,
+alongside this package:
+
+```sh
+npm install pg              # Postgres
+npm install mysql2          # MySQL / MariaDB
+npm install better-sqlite3  # SQLite
+npm install mssql           # SQL Server
+npm install oracledb        # Oracle
+```
+
+Drivers load lazily: a `steps.sql*` call against an engine whose driver isn't installed throws a
+clear `UnsupportedEngineException` naming the package to install — at the first DB step, not at
+fixture setup. Tests that never touch SQL need no driver at all.
 
 ### Fixture configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civitas-cerebrum/element-interactions",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "MIT",
       "dependencies": {
         "@civitas-cerebrum/context-store": "^0.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,17 +12,17 @@
         "@civitas-cerebrum/context-store": "^0.0.2",
         "@civitas-cerebrum/element-repository": "^0.3.1",
         "@civitas-cerebrum/email-client": "^0.0.7",
-        "@civitas-cerebrum/sql-client": "^0.1.0",
+        "@civitas-cerebrum/sql-client": "^0.1.2",
         "@civitas-cerebrum/wasapi": "^0.0.3",
         "debug": "^4.4.3",
-        "dotenv": "^17.3.1",
-        "pg": "^8.13.0"
+        "dotenv": "^17.3.1"
       },
       "devDependencies": {
         "@civitas-cerebrum/test-coverage": "^0.1.0",
         "@playwright/test": "^1.61.0",
         "@types/debug": "^4.1.13",
         "@types/node": "^20.0.0",
+        "pg": "^8.13.0",
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
@@ -69,16 +69,16 @@
       }
     },
     "node_modules/@civitas-cerebrum/sql-client": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/sql-client/-/sql-client-0.1.0.tgz",
-      "integrity": "sha512-bjo2MuNVni18ojuGfckNVz6X/U3zM+CikYFH+0zSJ4xZCYsGxK0+9yyHK6SjSuKjjxLBLfaMiNGMBU47gRJCFg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/sql-client/-/sql-client-0.1.2.tgz",
+      "integrity": "sha512-CWOUFSpFMqCrgoAB3Mg8kfcWZknDuivZsvnnJSck3Ooxpwm2duiw+MWL+1JS8Ucy+y9ZgvN6MpMqegAy3DZJDw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
         "better-sqlite3": "*",
@@ -816,6 +816,7 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
       "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -844,6 +845,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
       "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -851,12 +853,14 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
       "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
@@ -866,6 +870,7 @@
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
       "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
@@ -875,12 +880,14 @@
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
       "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "pg-int8": "1.0.1",
@@ -897,6 +904,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
@@ -975,6 +983,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -984,6 +993,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
       "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -993,6 +1003,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1002,6 +1013,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "xtend": "^4.0.0"
@@ -1412,6 +1424,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "A robust, readable interaction and assertion Facade for Playwright. Abstract away boilerplate into semantic, English-like methods, making your test automation framework cleaner, easier to maintain, and accessible to non-developers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -30,6 +30,7 @@
     "@playwright/test": "^1.61.0",
     "@types/debug": "^4.1.13",
     "@types/node": "^20.0.0",
+    "pg": "^8.13.0",
     "typescript": "^5.0.0"
   },
   "keywords": [
@@ -56,11 +57,10 @@
     "@civitas-cerebrum/context-store": "^0.0.2",
     "@civitas-cerebrum/element-repository": "^0.3.1",
     "@civitas-cerebrum/email-client": "^0.0.7",
-    "@civitas-cerebrum/sql-client": "^0.1.1",
+    "@civitas-cerebrum/sql-client": "^0.1.2",
     "@civitas-cerebrum/wasapi": "^0.0.3",
     "debug": "^4.4.3",
-    "dotenv": "^17.3.1",
-    "pg": "^8.13.0"
+    "dotenv": "^17.3.1"
   },
   "overrides": {
     "nodemailer": "^8.0.11"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@civitas-cerebrum/context-store": "^0.0.2",
     "@civitas-cerebrum/element-repository": "^0.2.1",
     "@civitas-cerebrum/email-client": "^0.0.7",
-    "@civitas-cerebrum/sql-client": "^0.1.0",
+    "@civitas-cerebrum/sql-client": "^0.1.1",
     "@civitas-cerebrum/wasapi": "^0.0.3",
     "debug": "^4.4.3",
     "dotenv": "^17.3.1",

--- a/src/fixture/BaseFixture.ts
+++ b/src/fixture/BaseFixture.ts
@@ -86,6 +86,13 @@ export interface BaseFixtureOptions {
      * separate `SqlClient` accessible by name: `steps.sqlQuery('analytics', sql)`.
      */
     dbProviders?: Record<string, string>;
+    /**
+     * Connect-timeout (ms) applied to every SQL client, so an unreachable `dbUrl`
+     * fails fast in CI instead of hanging on the first query.
+     *
+     * @example `dbConnectTimeoutMs: 5000`
+     */
+    dbConnectTimeoutMs?: number;
 }
 
 /**
@@ -124,6 +131,7 @@ export function baseFixture<T extends {}>(
                 apiProviders: options?.apiProviders,
                 dbUrl: options?.dbUrl,
                 dbProviders: options?.dbProviders,
+                dbConnectTimeoutMs: options?.dbConnectTimeoutMs,
             });
             await use(steps);
             await steps.closeDbConnections();

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -4,7 +4,7 @@ import { ElementInteractions } from '../interactions/facade/ElementInteractions'
 import { Utils } from '../utils/ElementUtilities';
 import { EmailClientConfig, EmailSendOptions, EmailReceiveOptions, ReceivedEmail, EmailMarkOptions, EmailMarkAction, EmailFilter } from '@civitas-cerebrum/email-client';
 import { WasapiClient, ApiResponse } from '@civitas-cerebrum/wasapi';
-import { SqlClient, SqlResult, QueryBuilder } from '@civitas-cerebrum/sql-client';
+import { SqlClient, SqlResult, QueryBuilder, UnsupportedEngineException } from '@civitas-cerebrum/sql-client';
 import { StepOptions, DropdownSelectOptions, TextVerifyOptions, CountVerifyOptions, DragAndDropOptions, ListedElementOptions, ListedElementMatch, VerifyListedOptions, GetListedDataOptions, FillFormValue, GetAllOptions, ScreenshotOptions, IsVisibleOptions, StorageVerifyOptions, VisualMatchOptions, VisualMaskTarget } from '../enum/Options';
 import { ExpectNoRequestOptions } from '../interactions/Navigation';
 import { stepLog as log } from '../logger/Logger';
@@ -26,7 +26,11 @@ export class Steps {
     private utils;
     private email;
     private apiClients: Map<string, WasapiClient>;
+    /** Lazily-built SqlClient cache, keyed by provider name (constructed on first DB step). */
     private dbClients: Map<string, SqlClient>;
+    /** Provider name → connection string. Clients are built on first use so a missing driver fails at the first DB step, not at fixture setup. */
+    private dbConfigs: Map<string, string>;
+    private dbConnectTimeoutMs?: number;
     private timeout?: number;
     private interceptionRetry?: boolean;
 
@@ -80,13 +84,18 @@ export class Steps {
             }
         }
         const { dbUrl, dbProviders, dbConnectTimeoutMs } = options ?? {};
+        // Register connection strings only — clients are constructed lazily on the
+        // first DB step so a missing engine driver surfaces a clear, actionable error
+        // at the call site (not at fixture setup, before any SQL is run).
         this.dbClients = new Map();
+        this.dbConfigs = new Map();
+        this.dbConnectTimeoutMs = dbConnectTimeoutMs;
         if (dbUrl) {
-            this.dbClients.set('default', new SqlClient({ connectionString: dbUrl, connectTimeoutMs: dbConnectTimeoutMs }));
+            this.dbConfigs.set('default', dbUrl);
         }
         if (dbProviders) {
             for (const [name, url] of Object.entries(dbProviders)) {
-                this.dbClients.set(name, new SqlClient({ connectionString: url, connectTimeoutMs: dbConnectTimeoutMs }));
+                this.dbConfigs.set(name, url);
             }
         }
     }
@@ -1856,13 +1865,34 @@ export class Steps {
      */
     private getDbClient(name?: string): SqlClient {
         const clientName = name ?? 'default';
-        const client = this.dbClients.get(clientName);
-        if (!client) {
+        const cached = this.dbClients.get(clientName);
+        if (cached) return cached;
+
+        const connectionString = this.dbConfigs.get(clientName);
+        if (!connectionString) {
             if (clientName === 'default') {
                 throw new Error('SQL client is not configured. Pass dbUrl to baseFixture() options when setting up your test fixture.');
             }
-            throw new Error(`SQL provider "${clientName}" is not configured. Pass it in dbProviders to baseFixture() options. Available: ${[...this.dbClients.keys()].join(', ')}`);
+            throw new Error(`SQL provider "${clientName}" is not configured. Pass it in dbProviders to baseFixture() options. Available: ${[...this.dbConfigs.keys()].join(', ')}`);
         }
+
+        // Built lazily on first use. element-interactions does not bundle SQL engine
+        // drivers (pg/mysql2/better-sqlite3/mssql/oracledb) — the agent/project must
+        // install the one for the engine it targets. Surface that as an actionable
+        // error at the first DB step rather than an opaque MODULE_NOT_FOUND.
+        let client: SqlClient;
+        try {
+            client = new SqlClient({ connectionString, connectTimeoutMs: this.dbConnectTimeoutMs });
+        } catch (err) {
+            if (err instanceof UnsupportedEngineException) {
+                throw new UnsupportedEngineException(
+                    `SQL steps need a database driver that is not installed. ${err.message} ` +
+                    `element-interactions does not bundle SQL drivers — install the one for your engine and re-run.`
+                );
+            }
+            throw err;
+        }
+        this.dbClients.set(clientName, client);
         return client;
     }
 

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -50,6 +50,11 @@ export class Steps {
             apiProviders?: Record<string, string>;
             dbUrl?: string;
             dbProviders?: Record<string, string>;
+            /**
+             * Connect-timeout (ms) applied to every SQL client, so a wrong/unreachable
+             * `dbUrl` fails fast in CI instead of hanging on the first query.
+             */
+            dbConnectTimeoutMs?: number;
         }
     ) {
         this.page = repo.driver;
@@ -73,14 +78,14 @@ export class Steps {
                 this.apiClients.set(name, new WasapiClient.Builder().setBaseUrl(url).setLogHeaders(false).buildRaw());
             }
         }
-        const { dbUrl, dbProviders } = options ?? {};
+        const { dbUrl, dbProviders, dbConnectTimeoutMs } = options ?? {};
         this.dbClients = new Map();
         if (dbUrl) {
-            this.dbClients.set('default', new SqlClient({ connectionString: dbUrl }));
+            this.dbClients.set('default', new SqlClient({ connectionString: dbUrl, connectTimeoutMs: dbConnectTimeoutMs }));
         }
         if (dbProviders) {
             for (const [name, url] of Object.entries(dbProviders)) {
-                this.dbClients.set(name, new SqlClient({ connectionString: url }));
+                this.dbClients.set(name, new SqlClient({ connectionString: url, connectTimeoutMs: dbConnectTimeoutMs }));
             }
         }
     }
@@ -1829,6 +1834,33 @@ export class Steps {
         }
         log.sql('TRANSACTION (default)');
         return await this.getDbClient().transaction(fnOrProvider);
+    }
+
+    /**
+     * Connectivity probe against the default (or named) SQL client — runs the
+     * engine-correct `SELECT 1` and throws if the database is unreachable. Use in
+     * a Playwright `globalSetup` so a misconfigured `dbUrl` fails the run up front
+     * with a clear error instead of a hung first query.
+     */
+    async sqlPing(provider?: string): Promise<void> {
+        log.sql('PING (provider=%s)', provider ?? 'default');
+        await this.getDbClient(provider).ping();
+    }
+
+    /**
+     * Execute a multi-statement SQL script (schema/seed file) against the default
+     * or named client. The script is split with the engine's rules (Oracle `/`,
+     * SQL Server `GO`, comment/quote aware) and each statement runs in order.
+     * Provider-overloaded like {@link sqlQuery}:
+     * `steps.sqlScript(readFileSync('seed.sql','utf8'))` or
+     * `steps.sqlScript('analytics', schemaSql)`.
+     */
+    async sqlScript(sqlTextOrProvider: string, maybeSqlText?: string): Promise<void> {
+        const usingProvider = typeof maybeSqlText === 'string';
+        const client = usingProvider ? this.getDbClient(sqlTextOrProvider) : this.getDbClient();
+        const sqlText = usingProvider ? maybeSqlText : sqlTextOrProvider;
+        log.sql('SCRIPT (provider=%s, %d chars)', usingProvider ? sqlTextOrProvider : 'default', sqlText.length);
+        await client.runScript(sqlText);
     }
 
     /** Begin a fluent SELECT builder pre-bound to the default (or named) client. */

--- a/tests/sql-steps.spec.ts
+++ b/tests/sql-steps.spec.ts
@@ -186,6 +186,39 @@ test.describe('TC_SQL_001: SQL Database Steps — bookhive integration', () => {
         await expect(steps.sqlQuery('nope', 'SELECT 1')).rejects.toThrow(/SQL provider "nope" is not configured/);
     });
 
+    test('sqlPing — default and named-provider connectivity probe', async ({ steps }) => {
+        await steps.sqlPing();             // default client — resolves without throwing
+        await steps.sqlPing('analytics');  // named provider
+    });
+
+    test('Negative: sqlPing on unconfigured provider throws helpful error', async ({ steps }) => {
+        await expect(steps.sqlPing('nope')).rejects.toThrow(/SQL provider "nope" is not configured/);
+    });
+
+    test('sqlScript — runs a multi-statement schema/seed script', async ({ steps }) => {
+        await steps.sqlScript(`
+            CREATE TABLE IF NOT EXISTS _sql_script_tmp (id INT PRIMARY KEY, label TEXT);
+            INSERT INTO _sql_script_tmp (id, label) VALUES (1, 'one'), (2, 'two');
+        `);
+        try {
+            const res = await steps.sqlQuery('SELECT label FROM _sql_script_tmp ORDER BY id');
+            await steps.verifySqlColumn(res, 'label', ['one', 'two']);
+        } finally {
+            await steps.sqlExecute('DROP TABLE IF EXISTS _sql_script_tmp');
+        }
+    });
+
+    test('sqlScript — provider-routed (analytics)', async ({ steps }) => {
+        await steps.sqlScript('analytics',
+            'CREATE TABLE IF NOT EXISTS _sql_script_tmp2 (n INT); INSERT INTO _sql_script_tmp2 VALUES (7);');
+        try {
+            const res = await steps.sqlQuery('SELECT n FROM _sql_script_tmp2');
+            await steps.verifySqlValue(res, 0, 'n', 7);
+        } finally {
+            await steps.sqlExecute('DROP TABLE IF EXISTS _sql_script_tmp2');
+        }
+    });
+
     test('closeDbConnections — idempotent pool shutdown', async ({ steps }) => {
         // First call drains the pools; second call must not throw (idempotent).
         await steps.closeDbConnections();


### PR DESCRIPTION
Adopts `@civitas-cerebrum/sql-client` **^0.1.2** and makes element-interactions install **zero SQL drivers**.

### Why
sql-client 0.1.1 shipped drivers as `optionalDependencies`, which install **transitively** — so depending on sql-client forced all five drivers (two native) onto every element-interactions consumer. sql-client 0.1.2 (civitas-cerebrum/sql-client#19) moves them to optional **peer** deps; this PR adopts that and stops EI from re-introducing the fan-out.

### Changes
- **No bundled drivers.** Drop the direct `pg` dependency. (`pg` moves to devDependencies for this package's own Postgres sql-steps integration test.) Installing element-interactions now pulls in no DB drivers.
- **Lazy clients + clear error.** Connection strings are registered at fixture setup; the `SqlClient` is built on the **first `steps.sql*` call**. If the engine's driver isn't installed, that first DB step throws a clear `UnsupportedEngineException` naming the package to install — not an opaque failure at fixture setup. Suites that never touch SQL need no driver.
- **The agent installs the driver.** Documented in the README SQL section; the achilles `database-testing` skill gains a matching Phase-0 install step (civitas-cerebrum/achilles#29).
- Retains the 0.1.x adoption surface: `sqlPing` preflight, `sqlScript` seed helper, `dbConnectTimeoutMs`.
- Bumps to **0.3.8**.

### Merge order
1. Merge + publish sql-client 0.1.2 (#19).
2. `npm install` here to refresh the lockfile against the published 0.1.2 (the lock is intentionally ahead of the registry until then; `npm ci` will go green only after publish).
3. Merge this.
4. Merge achilles#29.