### PR TITLE
fix(version): 0.3.8 → 0.3.7 (0.3.7 was never published)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.3.8",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civitas-cerebrum/element-interactions",
-      "version": "0.3.8",
+      "version": "0.3.7",
       "license": "MIT",
       "dependencies": {
         "@civitas-cerebrum/context-store": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.3.8",
+  "version": "0.3.7",
   "description": "A robust, readable interaction and assertion Facade for Playwright. Abstract away boilerplate into semantic, English-like methods, making your test automation framework cleaner, easier to maintain, and accessible to non-developers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
PR #208 bumped element-interactions to **0.3.8**, but **0.3.7 was never published** (npm latest is 0.3.6). The driver-free / lazy-client change should ship as **0.3.7** — no version should be skipped.

Corrects `package.json` and `package-lock.json` back to 0.3.7. Pure version fix, no code change.