### PR TITLE
chore(deps): bump @civitas-cerebrum/email-client → ^0.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@civitas-cerebrum/context-store": "^0.0.2",
         "@civitas-cerebrum/element-repository": "^0.3.1",
-        "@civitas-cerebrum/email-client": "^0.0.7",
+        "@civitas-cerebrum/email-client": "^0.0.8",
         "@civitas-cerebrum/sql-client": "^0.1.2",
         "@civitas-cerebrum/wasapi": "^0.0.3",
         "debug": "^4.4.3",
@@ -57,15 +57,15 @@
       }
     },
     "node_modules/@civitas-cerebrum/email-client": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/email-client/-/email-client-0.0.7.tgz",
-      "integrity": "sha512-iKG41mLngqCehrQkME1iXDyVZiL8GP3e0H6bJEaIPAP3RdXpUiSdixXBxrtayy3E8cF9D/rVeFjjeLcySLF/mQ==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/email-client/-/email-client-0.0.8.tgz",
+      "integrity": "sha512-opKTTOURpLN56zDcCwm97borkbgmA2qaH1kQWw97dlglEdBzcm5n56iLihmokjmlcxjpQDeZ1gOJzuo91z15xQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
         "imapflow": "^1.3.1",
         "mailparser": "^3.9.8",
-        "nodemailer": "^8.0.5"
+        "nodemailer": "^9.0.1"
       }
     },
     "node_modules/@civitas-cerebrum/sql-client": {
@@ -181,6 +181,7 @@
       "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.61.0"
       },
@@ -471,6 +472,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -816,6 +818,7 @@
       "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.13.0",
         "pg-pool": "^3.14.0",
@@ -842,6 +845,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
       "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -1078,6 +1082,7 @@
       "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.12.0.tgz",
       "integrity": "sha512-b1YMh3+DHZp59DLna3qVwQ5iOla/nrI6mLBNW02XxU77M3046Df6VLkoaJyFz20VsGIG5kkp+FK0kg4K4HnUFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parseley": "~0.13.1"
       },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@civitas-cerebrum/context-store": "^0.0.2",
     "@civitas-cerebrum/element-repository": "^0.3.1",
-    "@civitas-cerebrum/email-client": "^0.0.7",
+    "@civitas-cerebrum/email-client": "^0.0.8",
     "@civitas-cerebrum/sql-client": "^0.1.2",
     "@civitas-cerebrum/wasapi": "^0.0.3",
     "debug": "^4.4.3",


### PR DESCRIPTION
## Summary

Update the email-client dependency to the latest published version.

- `@civitas-cerebrum/email-client`: `^0.0.7` → `^0.0.8`
- `package-lock.json` resolved to `0.0.8`

The old `^0.0.7` caret pinned to *only* 0.0.7 (caret on a `0.0.x` range), so the spec change was required to move at all.

## Verification
- [x] `npm run typecheck:tests` → exit 0 against email-client 0.0.8
- [x] API surface compatible — every consumed type (`EmailClientConfig`, `EmailSendOptions`, `EmailReceiveOptions`, `ReceivedEmail`, `EmailMarkOptions`, `EmailFilter`, `EmailClient`, `EmailFilterType`, `EmailMarkAction`) still resolves; not a breaking bump
- [ ] Full Playwright unit suite + email-integration tests not run locally (need the test server / live IMAP+SMTP creds) — defer to CI