### PR TITLE
fix(ci): start SQL fixtures in the publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,11 @@ jobs:
         run: |
           docker compose up --build -d
 
+      - name: 🐘 Start SQL Fixtures
+        run: |
+          docker compose -f docker-compose.sql.yml up -d --wait
+          docker compose -f docker-compose.inventory.yml up -d --wait
+
       - name: 🧪  Run All Tests
         run: npm run test:all
         env:


### PR DESCRIPTION
## Problem

The `0.3.7` publish run **failed** (run 27936449365, 2026-06-22): `tests/inventory/inventory-sql.spec.ts › TC_INV_001` threw `QueryFailedException: Query failed (postgres)` on its `TRUNCATE …` setup — no Postgres to connect to.

**Root cause: pipeline drift.** When the `steps.sql*` surface + its Postgres-backed tests landed, the `🐘 Start SQL Fixtures` step was added to `test.yml` (PR checks — green) but **not** to `publish.yml`. The publish runs `npm run test:all` (which includes the SQL specs), so those tests have no DB and fail, blocking the release.

## Fix

Add the same `🐘 Start SQL Fixtures` step to `publish.yml` (identical to the already-green `test.yml`), before `🧪 Run All Tests`:

```yaml
- name: 🐘 Start SQL Fixtures
  run: |
    docker compose -f docker-compose.sql.yml up -d --wait
    docker compose -f docker-compose.inventory.yml up -d --wait
```

## Validation note

The `publish.yml` change is only exercised by a **tag-triggered publish run** — the PR's own checks run `test.yml`, which already has this step. So this PR's green checks confirm nothing regressed, but the real proof is the next `0.3.7` tag publish (which should now get past `Run All Tests`).

## Heads-up
`test:all` also runs the email-integration tests via the `SENDER_*`/`RECEIVER_*` secrets. If the publish then red-fails on *email* rather than SQL, that's a creds issue, not this.