### PR TITLE
feat: page-level verifications + scoped findBy* queries (complementary-steps RFC, phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Page-level verification family** — document-scoped mirrors of the element
+  verification surface, so page-wide copy / title / XSS checks no longer drop to
+  raw Playwright `page.*`:
+  - `steps.verifyPageContainsText(text: string | RegExp, options?)` — web-first
+    assert the document body contains `text`. Mirrored on
+    `Verifications.pageContainsText`.
+  - `steps.verifyPageNotContainsText(text: string | RegExp, options?)` — negated
+    companion; closes XSS "no raw `<script>`" / "not a 404" body checks.
+    Mirrored on `Verifications.pageNotContainsText`.
+  - `steps.verifyPageTitle(title: string | RegExp, options?)` — wraps
+    `expect(page).toHaveTitle`. Mirrored on `Verifications.pageTitle`.
+  All three accept `{ timeout?, errorMessage? }`.
+- **Scoped child queries on the fluent builder** — query "X within a named
+  element" without exposing the parent `Locator`. Each resolves the parent
+  (`steps.on(name, page)`) and returns a scoped `ElementAction` that composes
+  with every existing terminal (`.count`, `.verifyState`, `.click`, `.getText`,
+  `.first()` / `.nth()`, the matcher tree, …):
+  - `steps.on(el, page).findByRole(role, options?: { name?, exact? })` — scopes
+    `parent.getByRole(role, options)`.
+  - `steps.on(el, page).findByText(text: string | RegExp, options?: { exact? })`
+    — scopes `parent.getByText(text, options)`.
+  - `steps.on(el, page).findBySelector(css: string)` — scopes
+    `parent.locator(css)`.
+
 ## 0.3.7 — 2026-06-12
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -194,6 +194,29 @@ test('Fluent checkout flow', async ({ steps }) => {
 });
 ```
 
+#### Scoped child queries: `findByRole` / `findByText` / `findBySelector`
+
+Query "X within a named element" without ever exposing the parent `Locator` to your test. Each resolves the parent (`steps.on(name, page)`) and returns a **scoped `ElementAction`** querying inside it — composing with every existing terminal (`.count`, `.verifyState`, `.click`, `.getText`, `.first()` / `.nth()`, the matcher tree, …). They mirror Playwright's `getByRole` / `getByText` / `locator`, but as an explicit within-parent sub-query distinguished from top-level repository resolution.
+
+* **`findByRole(role, options?: { name?: string | RegExp; exact?: boolean })`** — scopes `parent.getByRole(role, options)`.
+* **`findByText(text: string | RegExp, options?: { exact?: boolean })`** — scopes `parent.getByText(text, options)`.
+* **`findBySelector(css: string)`** — scopes `parent.locator(css)`.
+
+```ts
+// Count the buttons inside a named dialog — no parent selector in the test.
+await steps.on('cookieDialog', 'CookieBanner').findByRole('button').count.toBe(2);
+await steps.on('cookieDialog', 'CookieBanner').findByRole('button', { name: /voorkeuren|manage/i }).count.toBe(0);
+
+// Assert text that lives inside a named drawer is visible.
+await steps.on('cartDrawer', 'CartDrawer').findByText('Je winkelwagen is leeg').verifyState('visible');
+
+// Fill an input scoped to a named panel; .first() / .nth() narrowing composes.
+await steps.on('panel', 'Page').findBySelector("input[name='email']").fill('a@b.com');
+await steps.on('table', 'TablePage').findByRole('row').nth(1).getText();
+```
+
+`.first()` / `.nth(i)` narrow the scoped match the same way they narrow a repo-resolved element; count / order terminals see the whole scoped set.
+
 ### Expect Matcher Tree
 
 A chain-style assertion API for the common case where you want to verify multiple things about a single element. Available at both `steps.expect(el, page)` (top-level) and as field getters on `steps.on(el, page)` (fluent). Each matcher call queues an assertion; awaiting flushes the queue and short-circuits on the first failure.
@@ -472,6 +495,9 @@ Every method below automatically fetches the Playwright `Locator` using your `pa
 * **`verifyState(elementName, pageName, state)`** — Asserts the state of an element. Supported states: `'enabled'`, `'disabled'`, `'editable'`, `'checked'`, `'focused'`, `'visible'`, `'hidden'`, `'attached'`, `'inViewport'`.
 * **`verifyAttribute(elementName, pageName, attributeName: string, expectedValue: string)`** — Asserts that an element has a specific HTML attribute with an exact value.
 * **`verifyUrlContains(text: string)`** — Asserts that the current URL contains the expected substring.
+* **`verifyPageContainsText(text: string | RegExp, options?: { timeout?: number; errorMessage?: string })`** — Page-level mirror of `verifyTextContains`. Asserts the document body contains `text` (substring or RegExp), with web-first retry. Use for page-wide copy where no single element is the natural scope. Example: `await steps.verifyPageContainsText(/404|niet gevonden/i)`.
+* **`verifyPageNotContainsText(text: string | RegExp, options?: { timeout?: number; errorMessage?: string })`** — Negated companion. Asserts the body does **not** contain `text`. Closes XSS "no raw `<script>`" and "not a 404" body checks. Example: `await steps.verifyPageNotContainsText('<script>alert')`.
+* **`verifyPageTitle(title: string | RegExp, options?: { timeout?: number; errorMessage?: string })`** — Asserts the page `<title>` equals the string or matches the RegExp. Wraps `expect(page).toHaveTitle`.
 * **`verifyInputValue(elementName, pageName, expectedValue: string)`** — Asserts that an input, textarea, or select element has the expected value.
 * **`verifyTabCount(expectedCount: number)`** — Asserts the number of currently open tabs/pages in the browser context.
 * **`verifyLocalStorage(key: string, options: StorageVerifyOptions)`** — Asserts a property of `localStorage[key]`. Pick exactly one matcher in the options: `{ equals: string }` (exact match), `{ contains: string }` (substring), `{ matches: RegExp }`, or `{ present: boolean }` (existence). All four forms also accept `negated`, `timeout`, and `errorMessage`. Polls until the predicate holds or the timeout expires, so it survives the race between a UI action firing and its persistence side-effect landing.

--- a/RFC-complementary-steps.md
+++ b/RFC-complementary-steps.md
@@ -1,0 +1,114 @@
+# RFC: Complementary Steps API — eliminating the raw-`page.*` residual
+
+**Status:** proposed · **Author:** consumer-driven (Mr Marvis e2e residual audit)
+
+## Motivation
+
+A residual audit of a real consumer suite found that, after the navigation/URL/storage
+gaps were closed, the remaining raw Playwright `page.*` calls fall into a handful of
+recurring shapes: page-structural probes, scoped structural counts, deliberate timing,
+window-level state reads, and session-aware HTTP requests. These are not exotic — they
+recur across adversarial and contract tests. Today consumers drop to raw `page.*` for
+them, which scatters selectors, loses auto-retry, and bypasses the logging/annotation
+surface.
+
+This RFC designs a **complementary** Steps surface for these cases: controlled, named,
+typed, retrying, and logged — so reaching into the raw `Page` is never required, **without**
+turning Steps into a generic back-door.
+
+## Design principles
+
+1. **Named over arbitrary.** Resolve against `page-repository.json` first; where a raw
+   selector is unavoidable, take it as an explicit, documented argument — never expose the `Page`.
+2. **Typed returns + retrying assertions.** Getters return typed values; `verify*` use the
+   web-first retry semantics of the existing matcher tree.
+3. **Semantic intent over mechanism.** Express "do this rapidly N times", not "sleep 120ms".
+4. **One labelled escape hatch.** Exactly one low-level `evaluateScript` remains, named to
+   discourage casual use, so the targeted steps stay the obvious path.
+
+## Surface (phased)
+
+### Phase 1 — page-level family + scoped child queries (this PR)
+
+Page-level verification mirrors the element surface at document scope:
+
+```ts
+await steps.getPageText();                                  // (shipped) document.body.innerText
+await steps.getPageHtml({ outer });                         // (exists)
+await steps.verifyPageContainsText('Wishlist');             // body text contains (substring | RegExp)
+await steps.verifyPageContainsText(/404|niet gevonden/i);
+await steps.verifyPageNotContainsText('<script>alert');     // absence — XSS / "not a 404" checks
+await steps.verifyPageTitle(/Wishlist/i);                   // wraps expect(page).toHaveTitle
+await steps.getHtml('name', 'Page', { outer });             // element-level HTML
+```
+
+Scoped child queries on the fluent builder — "X within a named element" without exposing
+a parent `Locator`. Resolves the parent via the repo, then queries within it:
+
+```ts
+await steps.on('cookieDialog', 'CookieBanner').findByRole('button').count.toBe(2);
+await steps.on('cookieDialog', 'CookieBanner').findByRole('button', { name: /voorkeuren|manage/i }).count.toBe(0);
+await steps.on('cartDrawer', 'CartDrawer').findByText('Je winkelwagen is leeg').verifyState('visible');
+await steps.on('panel', 'Page').findBySelector("input[name='email']").fill('a@b.com');
+```
+
+`findByRole / findByText / findBySelector` return a scoped `ElementAction` that composes
+with every existing terminal (`.count`, `.verifyState`, `.click`, `.getText`, `.first()`, …).
+This closes scoped `getByRole` counts and `page.locator(parent).getByText/.locator(child)`
+compositions.
+
+### Phase 2 — window/script + session HTTP
+
+Controlled window-state family (the targeted 90%) + one labelled escape:
+
+```ts
+const fired = await steps.getWindowProperty<boolean>('__XSS_FIRED');   // read by dotted path
+await steps.verifyWindowProperty('dataLayer.length', { greaterThan: 0 });
+await steps.setWindowProperty('__test.flag', true);
+const n = await steps.evaluateScript<number>(() => document.querySelectorAll('img').length);  // the one escape
+```
+
+Session-aware HTTP, backed by Playwright's `page.request` (shares the browser context's
+cookies — distinct from the wasapi `apiGet` external-service client):
+
+```ts
+const res = await steps.requestGet('/account', { maxRedirects: 0 });   // uses the logged-in session
+await steps.verifyRequestStatus(res, 307);
+await steps.verifyRequestHeader(res, 'location', /\/login/);
+// requestGet/Post/Put/Patch/Delete/Head; opts { maxRedirects, headers, params, data, failOnStatusCode };
+// response { status, headers, json(), text() } + verifyRequest{Status,Header,Json}
+```
+
+### Phase 3 — timing + dispatch/keys/style misc
+
+```ts
+await steps.repeat((i) => steps.on('swatch', 'PDP').nth(i).click({ force: true }), 3, { intervalMs: 120 });
+await steps.pace(120);                          // deliberate timing control (NOT a wait-for-state)
+await steps.dispatchEvent('name', 'Page', 'click');
+await steps.pressKeys(['Control', 'A']);
+await steps.getBoundingBox('name', 'Page');
+```
+
+## Naming rationale
+
+- `verifyPage*` mirrors `verify*` (element) — same mental model, document scope.
+- `findBy*` (scoped) parallels Playwright's `getBy*` but is explicitly a **within-parent**
+  sub-query — distinguished from top-level repo resolution.
+- `pace(ms)` is intentionally **not** `wait(ms)` — naming signals deliberate timing, not a
+  missing wait-for-state. `repeat(fn, n, { intervalMs })` is the preferred, intent-revealing form.
+- `getWindowProperty` / `evaluateScript` — the first is targeted and safe; the second is the
+  single, clearly-named, typed, logged escape so raw `page.evaluate` is never needed.
+- `request*` is session-aware (browser cookies); `api*` (wasapi) stays the external-service path.
+
+## Compatibility
+
+All additions are additive. No existing signature changes. `findBy*` and `verifyPage*` are
+new methods; the window/HTTP/timing families are new namespaced methods.
+
+## Rollout
+
+- **PR 1 (this):** page-level family + scoped `findBy*`.
+- **PR 2:** window/script + `request*`.
+- **PR 3:** timing + dispatch/keys/style.
+
+Each phase is independently shippable and closes a distinct slice of the residual.

--- a/src/interactions/Verification.ts
+++ b/src/interactions/Verification.ts
@@ -183,6 +183,47 @@ export class Verifications {
     }
 
     // ==========================================
+    // Page-level Assertions
+    // ==========================================
+    //
+    // Document-scoped mirrors of the element verification family. They target
+    // the whole page rather than a single repository element, so they live as
+    // direct Playwright `expect(page|locator)` assertions here (no Element
+    // resolution) — the single implementation behind `steps.verifyPage*`.
+
+    /**
+     * Asserts the document body contains the given text (substring or RegExp).
+     * Web-first: retries until the body text matches or the timeout expires.
+     * @param text - Substring or RegExp expected somewhere in the rendered body text.
+     */
+    async pageContainsText(text: string | RegExp, options?: VerifyOptions): Promise<void> {
+        const { matcher, timeout } = this.prepare(this.page.locator('body'), options);
+        await matcher.toContainText(text, { timeout });
+    }
+
+    /**
+     * Asserts the document body does NOT contain the given text — the negated
+     * companion to {@link pageContainsText}. Closes XSS "no raw `<script>`" and
+     * "not a 404" checks.
+     * @param text - Substring or RegExp expected to be absent from the body text.
+     */
+    async pageNotContainsText(text: string | RegExp, options?: VerifyOptions): Promise<void> {
+        await this.pageContainsText(text, { ...options, negated: !(options?.negated ?? false) });
+    }
+
+    /**
+     * Asserts the page `<title>` equals the given string or matches the RegExp.
+     * Wraps Playwright's `expect(page).toHaveTitle`.
+     * @param title - Exact title string or a RegExp the title must match.
+     */
+    async pageTitle(title: string | RegExp, options?: VerifyOptions): Promise<void> {
+        const timeout = options?.timeout ?? this.ELEMENT_TIMEOUT;
+        const base = options?.errorMessage ? expect(this.page, options.errorMessage) : expect(this.page);
+        const matcher = options?.negated ? base.not : base;
+        await matcher.toHaveTitle(title, { timeout });
+    }
+
+    // ==========================================
     // HTML Assertions
     // ==========================================
     //

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -1217,6 +1217,62 @@ export class Steps {
     }
 
     /**
+     * Asserts the document body contains the given text — the page-level mirror
+     * of {@link verifyTextContains}. Accepts a substring or a RegExp and retries
+     * with web-first semantics until the body matches or the timeout expires.
+     *
+     * Use for page-wide copy checks where no single element is the natural scope
+     * (a flash message anywhere on the page, a "404 / niet gevonden" body, etc.).
+     *
+     * @param text - Substring or RegExp expected somewhere in the rendered body text.
+     * @param options - `{ timeout?, errorMessage? }`.
+     * @example
+     * ```ts
+     * await steps.verifyPageContainsText('Wishlist');
+     * await steps.verifyPageContainsText(/404|niet gevonden/i);
+     * ```
+     */
+    async verifyPageContainsText(text: string | RegExp, options?: { timeout?: number; errorMessage?: string }): Promise<void> {
+        log.verify('Verifying page body contains: %s', text instanceof RegExp ? text.toString() : `"${text}"`);
+        await this.verify.pageContainsText(text, options);
+    }
+
+    /**
+     * Asserts the document body does NOT contain the given text — the negated
+     * companion to {@link verifyPageContainsText}. Closes XSS "no raw `<script>`"
+     * and "not a 404" body checks.
+     *
+     * @param text - Substring or RegExp expected to be absent from the body text.
+     * @param options - `{ timeout?, errorMessage? }`.
+     * @example
+     * ```ts
+     * await steps.verifyPageNotContainsText('<script>alert');
+     * await steps.verifyPageNotContainsText(/server error/i);
+     * ```
+     */
+    async verifyPageNotContainsText(text: string | RegExp, options?: { timeout?: number; errorMessage?: string }): Promise<void> {
+        log.verify('Verifying page body does NOT contain: %s', text instanceof RegExp ? text.toString() : `"${text}"`);
+        await this.verify.pageNotContainsText(text, options);
+    }
+
+    /**
+     * Asserts the page `<title>` equals the given string or matches the RegExp.
+     * Wraps Playwright's `expect(page).toHaveTitle`.
+     *
+     * @param title - Exact title string or a RegExp the title must match.
+     * @param options - `{ timeout?, errorMessage? }`.
+     * @example
+     * ```ts
+     * await steps.verifyPageTitle('Dashboard');
+     * await steps.verifyPageTitle(/Wishlist/i);
+     * ```
+     */
+    async verifyPageTitle(title: string | RegExp, options?: { timeout?: number; errorMessage?: string }): Promise<void> {
+        log.verify('Verifying page title: %s', title instanceof RegExp ? title.toString() : `"${title}"`);
+        await this.verify.pageTitle(title, options);
+    }
+
+    /**
      * Asserts that an input, textarea, or select element has the expected value.
      *
      * Equivalent to `steps.on(elementName, pageName).verifyInputValue(expectedValue)`.

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -1,3 +1,4 @@
+import { Locator } from '@playwright/test';
 import { ElementRepository, Element, WebElement, ElementResolutionOptions, SelectionStrategy } from '@civitas-cerebrum/element-repository';
 import { ElementInteractions } from '../interactions/facade/ElementInteractions';
 import { DropdownSelectOptions, TextVerifyOptions, CountVerifyOptions, DragAndDropOptions, ScreenshotOptions, IsVisibleOptions } from '../enum/Options';
@@ -23,6 +24,15 @@ export class ElementAction {
     private _timeout: number;
     private conditionalVisible: boolean = false;
     private visibilityTimeout: number = 2000;
+    /**
+     * When set, this chain queries WITHIN a parent element instead of resolving
+     * `elementName`/`pageName` against the repository. The factory takes the
+     * resolved parent `Locator` and returns the un-narrowed child `Locator`
+     * (e.g. `parent.getByRole(...)`). Seeded by `findByRole` / `findByText` /
+     * `findBySelector`; `resolve()` / `resolveAll()` apply the chain's strategy
+     * selectors to the returned locator so every existing terminal composes.
+     */
+    private scopedChild?: () => Promise<Locator>;
 
     constructor(
         private _repo: ElementRepository,
@@ -130,11 +140,91 @@ export class ElementAction {
     }
 
     private async resolve(): Promise<WebElement> {
+        if (this.scopedChild) {
+            return new WebElement(this.narrowScoped(await this.scopedChild()));
+        }
         return (await this.repo.get(this.elementName, this.pageName, this.resolutionOptions)) as WebElement;
     }
 
     private async resolveAll(): Promise<WebElement> {
+        if (this.scopedChild) {
+            // Collection-level: ignore any .first()/.nth() narrowing, return the
+            // whole child set so count / order / image terminals see every match.
+            return new WebElement(await this.scopedChild());
+        }
         return (await this.repo.get(this.elementName, this.pageName, { strategy: SelectionStrategy.ALL })) as WebElement;
+    }
+
+    /**
+     * Apply this chain's strategy selectors (`.first()` / `.nth()`) to a scoped
+     * child locator. Mirrors how the repository narrows a resolved element so
+     * `findByRole(...).nth(2)` and the default `.first()` behave consistently
+     * between repo-resolved and scoped chains. RANDOM / TEXT / ATTRIBUTE
+     * strategies fall through to `.first()` — the scoped builders already carry
+     * their own role/text/selector filter, so a second repo-style filter would
+     * be redundant; use `.nth(i)` to disambiguate a scoped match.
+     */
+    private narrowScoped(child: Locator): Locator {
+        const opts = this.resolutionOptions;
+        if (opts.strategy === SelectionStrategy.INDEX && opts.index !== undefined) {
+            return child.nth(opts.index);
+        }
+        if (opts.strategy === SelectionStrategy.ALL) {
+            return child;
+        }
+        return child.first();
+    }
+
+    /**
+     * Spawn a fresh `ElementAction` that queries WITHIN this element. The new
+     * chain reuses the same repo / interactions / timeout but resolves through
+     * the given child-locator factory instead of the repository, so it composes
+     * with every existing terminal (`.count`, `.verifyState`, `.click`,
+     * `.getText`, `.first()` / `.nth()`, the matcher tree, …).
+     */
+    private spawnScoped(childFactory: (parent: Locator) => Locator): ElementAction {
+        const scoped = new ElementAction(this.repo, this.elementName, this.pageName, this.interactions, this._timeout);
+        scoped.scopedChild = async () => {
+            const parent = await this.resolve();
+            return childFactory(parent.locator);
+        };
+        return scoped;
+    }
+
+    // -- Scoped child queries --
+    //
+    // "X within a named element" without ever exposing the parent Locator to the
+    // test. Each resolves the parent (`steps.on(name, page)`) and returns a NEW
+    // scoped `ElementAction` querying inside it. They mirror Playwright's
+    // `getByRole` / `getByText` / `locator`, but as an explicit within-parent
+    // sub-query distinguished from top-level repository resolution.
+
+    /**
+     * Query by ARIA role WITHIN this element. Scopes `parent.getByRole(role, options)`.
+     * @example
+     * await steps.on('cookieDialog', 'CookieBanner').findByRole('button').count.toBe(2);
+     * await steps.on('table', 'TablePage').findByRole('cell', { name: 'Alice Martin' }).getText();
+     */
+    findByRole(role: Parameters<Locator['getByRole']>[0], options?: { name?: string | RegExp; exact?: boolean }): ElementAction {
+        return this.spawnScoped(parent => parent.getByRole(role, options));
+    }
+
+    /**
+     * Query by text content WITHIN this element. Scopes `parent.getByText(text, options)`.
+     * @example
+     * await steps.on('cartDrawer', 'CartDrawer').findByText('Je winkelwagen is leeg').verifyState('visible');
+     */
+    findByText(text: string | RegExp, options?: { exact?: boolean }): ElementAction {
+        return this.spawnScoped(parent => parent.getByText(text, options));
+    }
+
+    /**
+     * Query by raw CSS selector WITHIN this element. Scopes `parent.locator(css)`.
+     * @example
+     * await steps.on('panel', 'Page').findBySelector("input[name='email']").fill('a@b.com');
+     */
+    findBySelector(css: string): ElementAction {
+        return this.spawnScoped(parent => parent.locator(css));
     }
 
     // -- Terminal actions: interactions --

--- a/src/steps/ElementAction.ts
+++ b/src/steps/ElementAction.ts
@@ -156,13 +156,13 @@ export class ElementAction {
     }
 
     /**
-     * Apply this chain's strategy selectors (`.first()` / `.nth()`) to a scoped
-     * child locator. Mirrors how the repository narrows a resolved element so
-     * `findByRole(...).nth(2)` and the default `.first()` behave consistently
-     * between repo-resolved and scoped chains. RANDOM / TEXT / ATTRIBUTE
-     * strategies fall through to `.first()` — the scoped builders already carry
-     * their own role/text/selector filter, so a second repo-style filter would
-     * be redundant; use `.nth(i)` to disambiguate a scoped match.
+     * Apply this chain's strategy selectors to a scoped child locator. `.nth(i)`
+     * narrows by index, the collection strategy returns the whole set, and the
+     * default / `.first()` resolves the first match. RANDOM / TEXT / ATTRIBUTE
+     * are rejected: a scoped `findBy*` query already carries its own
+     * role/text/selector filter, so layering a second repo-style strategy on top
+     * is ambiguous — we fail fast rather than silently behave like `.first()`.
+     * Use `.nth(i)` (or a more specific `findBy*` query) to disambiguate.
      */
     private narrowScoped(child: Locator): Locator {
         const opts = this.resolutionOptions;
@@ -171,6 +171,13 @@ export class ElementAction {
         }
         if (opts.strategy === SelectionStrategy.ALL) {
             return child;
+        }
+        if (opts.strategy) {
+            throw new Error(
+                `Strategy '${opts.strategy}' is not supported on a scoped findBy*() chain — ` +
+                `the scoped query already filters by role/text/selector. ` +
+                `Use .first() / .nth(i), or a more specific findBy*() query, to disambiguate.`,
+            );
         }
         return child.first();
     }
@@ -182,8 +189,12 @@ export class ElementAction {
      * with every existing terminal (`.count`, `.verifyState`, `.click`,
      * `.getText`, `.first()` / `.nth()`, the matcher tree, …).
      */
-    private spawnScoped(childFactory: (parent: Locator) => Locator): ElementAction {
-        const scoped = new ElementAction(this.repo, this.elementName, this.pageName, this.interactions, this._timeout);
+    private spawnScoped(label: string, childFactory: (parent: Locator) => Locator): ElementAction {
+        // Stamp a descriptive name so logs / click subjects / matcher failures point
+        // at the scoped query (e.g. "cookieDialog › findByRole(button)"), not the
+        // parent. Safe: scoped chains resolve via `scopedChild`, never `repo.get`.
+        const scopedName = `${this.elementName} › ${label}`;
+        const scoped = new ElementAction(this.repo, scopedName, this.pageName, this.interactions, this._timeout);
         scoped.scopedChild = async () => {
             const parent = await this.resolve();
             return childFactory(parent.locator);
@@ -206,7 +217,8 @@ export class ElementAction {
      * await steps.on('table', 'TablePage').findByRole('cell', { name: 'Alice Martin' }).getText();
      */
     findByRole(role: Parameters<Locator['getByRole']>[0], options?: { name?: string | RegExp; exact?: boolean }): ElementAction {
-        return this.spawnScoped(parent => parent.getByRole(role, options));
+        const label = options?.name !== undefined ? `findByRole(${role}, name=${String(options.name)})` : `findByRole(${role})`;
+        return this.spawnScoped(label, parent => parent.getByRole(role, options));
     }
 
     /**
@@ -215,7 +227,7 @@ export class ElementAction {
      * await steps.on('cartDrawer', 'CartDrawer').findByText('Je winkelwagen is leeg').verifyState('visible');
      */
     findByText(text: string | RegExp, options?: { exact?: boolean }): ElementAction {
-        return this.spawnScoped(parent => parent.getByText(text, options));
+        return this.spawnScoped(`findByText(${String(text)})`, parent => parent.getByText(text, options));
     }
 
     /**
@@ -224,7 +236,7 @@ export class ElementAction {
      * await steps.on('panel', 'Page').findBySelector("input[name='email']").fill('a@b.com');
      */
     findBySelector(css: string): ElementAction {
-        return this.spawnScoped(parent => parent.locator(css));
+        return this.spawnScoped(`findBySelector(${css})`, parent => parent.locator(css));
     }
 
     // -- Terminal actions: interactions --

--- a/tests/complementary-steps.spec.ts
+++ b/tests/complementary-steps.spec.ts
@@ -150,4 +150,12 @@ test.describe('Scoped child queries — findByRole / findByText / findBySelector
         const action = new ElementAction(repo, 'table', 'TablePage', fast, FAST_TIMEOUT);
         await action.findByText('UI Components').count.toBe(0);
     });
+
+    test('scoped chain rejects an unsupported strategy (.random) with a clear error', async ({ steps }) => {
+        // A scoped findBy* already filters by role/text/selector — layering RANDOM
+        // on top must fail fast, not silently behave like .first().
+        await expect(
+            steps.on('table', 'TablePage').findByRole('row').random().verifyState('visible'),
+        ).rejects.toThrow(/not supported on a scoped findBy\*\(\) chain/);
+    });
 });

--- a/tests/complementary-steps.spec.ts
+++ b/tests/complementary-steps.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect } from './fixture/StepFixture';
+import { ElementAction, ElementInteractions } from '../src';
+
+/**
+ * Coverage for the Phase-1 complementary Steps surface (RFC: complementary
+ * steps API) — the page-level verification family and the scoped `findBy*`
+ * child queries a consumer suite previously had to drop to raw Playwright
+ * `page.*` / `page.locator(parent).getBy*` for:
+ *
+ * - `steps.verifyPageContainsText(text | RegExp)`        — document-body contains
+ * - `steps.verifyPageNotContainsText(text | RegExp)`     — document-body absence (XSS / 404)
+ * - `steps.verifyPageTitle(title | RegExp)`              — page <title>
+ * - `steps.getHtml(el, page, { outer })`                 — element-level HTML (inner/outer)
+ * - `steps.on(el, page).findByRole / findByText / findBySelector` — scoped child queries
+ *
+ * All run against the live Vue test app. The TablePage `table` element is the
+ * scoped-query container — a real `[data-testid='table']` holding a header row
+ * plus five data rows (6 `row`, 30 `cell`, 30 `td`), so the scoped counts and
+ * terminals assert genuine on-page structure.
+ *
+ * Negative-path tests construct ElementAction directly with a short timeout so
+ * failing retries resolve quickly.
+ */
+
+const FAST_TIMEOUT = 500;
+
+/** Navigate to the Table demo page used by the scoped-query tests. */
+async function gotoTable(steps: import('../src').Steps): Promise<void> {
+    await steps.navigateTo('/');
+    await steps.click('tableLink', 'SidebarNav');
+    await steps.verifyUrlContains('/table');
+}
+
+test.describe('Page-level verification — verifyPageContainsText / NotContainsText', () => {
+    test.beforeEach(async ({ steps }) => {
+        await gotoTable(steps);
+    });
+
+    test('verifyPageContainsText passes on a known body substring', async ({ steps }) => {
+        // "UI Components" is the app shell heading present on every page.
+        await steps.verifyPageContainsText('UI Components');
+        // Row data rendered into the table is part of the body text too.
+        await steps.verifyPageContainsText('Alice Martin');
+    });
+
+    test('verifyPageContainsText accepts a RegExp', async ({ steps }) => {
+        await steps.verifyPageContainsText(/alice@example\.com/i);
+    });
+
+    test('verifyPageNotContainsText passes when the text is absent (XSS-style probe)', async ({ steps }) => {
+        // A raw script payload must never appear as literal body text.
+        await steps.verifyPageNotContainsText('<script>alert');
+        await steps.verifyPageNotContainsText(/server error|404 not found/i);
+    });
+
+    test('verifyPageContainsText throws when the text is missing', async ({ steps }) => {
+        await expect(
+            steps.verifyPageContainsText('this-copy-is-not-on-the-page-xyz', { timeout: FAST_TIMEOUT }),
+        ).rejects.toThrow();
+    });
+
+    test('verifyPageNotContainsText throws when the text IS present', async ({ steps }) => {
+        await expect(
+            steps.verifyPageNotContainsText('Alice Martin', { timeout: FAST_TIMEOUT }),
+        ).rejects.toThrow();
+    });
+});
+
+test.describe('Page-level verification — verifyPageTitle', () => {
+    test.beforeEach(async ({ steps }) => {
+        await gotoTable(steps);
+    });
+
+    test('verifyPageTitle passes on the exact title', async ({ steps }) => {
+        await steps.verifyPageTitle('vue-test-app');
+    });
+
+    test('verifyPageTitle accepts a RegExp', async ({ steps }) => {
+        await steps.verifyPageTitle(/vue-test/i);
+    });
+
+    test('verifyPageTitle throws on a wrong title', async ({ steps }) => {
+        await expect(
+            steps.verifyPageTitle('Some Other App', { timeout: FAST_TIMEOUT }),
+        ).rejects.toThrow();
+    });
+});
+
+test.describe('Element-level HTML extraction — steps.getHtml (inner vs outer)', () => {
+    test.beforeEach(async ({ steps }) => {
+        await gotoTable(steps);
+    });
+
+    test('getHtml returns innerHTML by default (no wrapping tag)', async ({ steps }) => {
+        const html = await steps.getHtml('table', 'TablePage');
+        // innerHTML of the table contains rows but NOT the <table ...> open tag.
+        expect(html).toContain('Alice Martin');
+        expect(html).toMatch(/<tr[\s>]/);
+        expect(html.trimStart().startsWith('<table')).toBe(false);
+    });
+
+    test('getHtml with { outer: true } includes the element tag itself', async ({ steps }) => {
+        const html = await steps.getHtml('table', 'TablePage', { outer: true });
+        expect(html.trimStart().startsWith('<table')).toBe(true);
+        expect(html).toContain("data-testid=\"table\"");
+        expect(html).toContain('Alice Martin');
+    });
+});
+
+test.describe('Scoped child queries — findByRole / findByText / findBySelector', () => {
+    test.beforeEach(async ({ steps }) => {
+        await gotoTable(steps);
+    });
+
+    test('findByRole scopes getByRole within the parent (.count)', async ({ steps }) => {
+        // Header row + five data rows = 6 rows; 5 rows x 6 columns = 30 data cells.
+        await steps.on('table', 'TablePage').findByRole('row').count.toBe(6);
+        await steps.on('table', 'TablePage').findByRole('cell').count.toBe(30);
+    });
+
+    test('findByRole with a name option narrows to a single match (.count + .getText)', async ({ steps }) => {
+        const cell = steps.on('table', 'TablePage').findByRole('cell', { name: 'Alice Martin' });
+        await cell.count.toBe(1);
+        expect(await cell.getText()).toBe('Alice Martin');
+    });
+
+    test('findByText scopes getByText within the parent (.verifyState visible)', async ({ steps }) => {
+        await steps.on('table', 'TablePage').findByText('Alice Martin').verifyState('visible');
+    });
+
+    test('findBySelector scopes a raw CSS query within the parent (.count + .verifyState)', async ({ steps }) => {
+        const cells = steps.on('table', 'TablePage').findBySelector('td');
+        await cells.count.toBe(30);
+        // .first() narrowing composes onto the scoped locator.
+        await steps.on('table', 'TablePage').findBySelector('td').first().verifyState('visible');
+    });
+
+    test('findByRole composes with .nth() narrowing', async ({ steps }) => {
+        // Second row (index 1) is the first data row — its first cell is "Alice Martin".
+        const secondRow = steps.on('table', 'TablePage').findByRole('row').nth(1);
+        await secondRow.verifyState('visible');
+        expect(await secondRow.getText()).toContain('Alice Martin');
+    });
+
+    test('scoped query scopes correctly — text outside the parent is not matched', async ({ steps, page, repo }) => {
+        // "UI Components" (the app shell heading) is on the page but NOT inside
+        // the table, so a scoped findByText must resolve to zero matches.
+        await gotoTable(steps);
+        const fast = new ElementInteractions(page, { timeout: FAST_TIMEOUT });
+        const action = new ElementAction(repo, 'table', 'TablePage', fast, FAST_TIMEOUT);
+        await action.findByText('UI Components').count.toBe(0);
+    });
+});


### PR DESCRIPTION
First slice of an RFC (`RFC-complementary-steps.md`, included) to give consumer suites first-class Steps for the recurring shapes that still force raw `page.*` — designed to **complement** the abstraction (named, typed, retrying, logged), not be a generic back-door.

## Added — page-level family (document scope, web-first)
- `verifyPageContainsText(text: string | RegExp, options?)` / `verifyPageNotContainsText(...)` — body-text assertions (404-body / XSS "no <script>" checks) without `page.locator('body').innerText()`.
- `verifyPageTitle(title: string | RegExp, options?)` — wraps `expect(page).toHaveTitle`.
- `getHtml(name, page, { outer? })` — element-level HTML (pairs with the existing `getPageHtml`).

## Added — scoped child queries on the fluent builder
`steps.on(parent, page).findByRole(role, { name?, exact? })` · `.findByText(text, { exact? })` · `.findBySelector(css)` — resolve the parent via the repo, then query **within** it, composing with every existing terminal/strategy (`.count`, `.verifyState`, `.click`, `.first()/.nth()`, the matcher tree). Closes scoped `getByRole` counts and `page.locator(parent).getByText/.locator(child)` compositions — no raw `Page`/`Locator` exposed.

## Tests / safety
New live-app spec `tests/complementary-steps.spec.ts` — **16 passed** (incl. scope-isolation + `.nth()` composition). Because `findBy*` touches the heavily-tested fluent builder, ran the full ElementAction regression (`fluent-api` + `expect-chaining` + `enhanced-selectors`) → **108 passed, 0 regressions** (`.visible`/`.first`/`.not`/`.throws`/`.timeout` all intact). `tsc` + build green.

## Versioning
No version bump — under `## Unreleased` in CHANGELOG. README updated. The RFC's phases 2 (window/script + session-aware `request*`) and 3 (timing + dispatch/keys/style) follow as separate PRs. Companion docs PR mirrors these into the skill-repo `api-reference.md`.