### PR TITLE
feat(steps): timing + dispatch/keys/geometry families (complementary-steps RFC phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@
   - `steps.repeat(action, times, { intervalMs? })` — runs `action` `times` times in
     sequence (passing the zero-based index), collects each result, and with
     `intervalMs` paces BETWEEN iterations (never before the first or after the
-    last). The intent-revealing form of "do X rapidly N times". Throws on a
-    non-negative-integer count. Mirrored on `Utils.repeat`.
+    last). The intent-revealing form of "do X rapidly N times". Throws when
+    `times` is not a non-negative integer. Mirrored on `Utils.repeat`.
 - Dispatch / keys / geometry (complementary-steps RFC, phase 3):
   - `steps.dispatchEvent(element, page, type, eventInit?)` — dispatches a synthetic
     DOM event on a named element WITHOUT actionability checks (custom events,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Timing family (complementary-steps RFC, phase 3) — deliberate, intent-revealing
+  timing control without dropping to raw `page.waitForTimeout` / hand-rolled loops:
+  - `steps.pace(ms)` — a deliberate pause, named `pace` (NOT `wait`) to signal
+    intentional timing rather than a missing wait-for-state; prefer `waitForState`
+    / `waitForUrl` / web-first assertions whenever you are actually waiting for a
+    condition. Throws on a negative/non-finite duration. Mirrored on `Utils.pace`.
+  - `steps.repeat(action, times, { intervalMs? })` — runs `action` `times` times in
+    sequence (passing the zero-based index), collects each result, and with
+    `intervalMs` paces BETWEEN iterations (never before the first or after the
+    last). The intent-revealing form of "do X rapidly N times". Throws on a
+    non-negative-integer count. Mirrored on `Utils.repeat`.
+- Dispatch / keys / geometry (complementary-steps RFC, phase 3):
+  - `steps.dispatchEvent(element, page, type, eventInit?)` — dispatches a synthetic
+    DOM event on a named element WITHOUT actionability checks (custom events,
+    firing `input`/`change` on widgets that swallow synthetic typing); prefer
+    `click`/`fill`/`pressKey` for real user input. Mirrored on `Interactions.dispatchEvent`.
+  - `steps.pressKeys(keys)` — presses a multi-key chord, joining the parts with `+`
+    (`['Control', 'A']` → `Control+A`); the intent-revealing companion to
+    `pressKey` for shortcuts. Throws on an empty array. Mirrored on `Interactions.pressKeys`.
+  - `steps.getBoundingBox(element, page)` — returns the element's
+    `{ x, y, width, height }` (CSS pixels, main-frame relative) or `null` when it
+    is not rendered (short-circuits on zero matches rather than blocking on
+    `boundingBox()`'s own auto-wait). Mirrored on `Extractions.getBoundingBox`.
+
 ## 0.3.7 — 2026-06-12
 
 ### Security

--- a/src/interactions/Extraction.ts
+++ b/src/interactions/Extraction.ts
@@ -68,6 +68,23 @@ export class Extractions {
     }
 
     /**
+     * Returns the element's bounding box (`{ x, y, width, height }` in CSS
+     * pixels relative to the main frame), or `null` when the element is not
+     * rendered. Use for layout/geometry assertions the DOM doesn't otherwise
+     * surface: overlap, off-screen positioning, collapsed (`0×0`) regions.
+     */
+    async getBoundingBox(target: WebElement): Promise<{ x: number; y: number; width: number; height: number } | null> {
+        // Soft attach-probe so a present element is measured promptly; if it is
+        // not in the DOM at all, short-circuit to `null` rather than letting
+        // `boundingBox()` block on its own (much longer) auto-wait.
+        await this.softProbe(target);
+        if ((await target.count()) === 0) {
+            return null;
+        }
+        return target.boundingBox();
+    }
+
+    /**
      * Retrieves the raw HTML of an element. Defaults to `innerHTML`; set
      * `{ outer: true }` for `outerHTML` (the element tag plus its subtree).
      *

--- a/src/interactions/Interaction.ts
+++ b/src/interactions/Interaction.ts
@@ -349,6 +349,31 @@ export class Interactions {
         await this.page.keyboard.press(key);
     }
 
+    /**
+     * Presses a key chord by joining the parts with `+` — `['Control', 'A']`
+     * becomes `Control+A`. The multi-key companion to {@link pressKey}; use for
+     * shortcuts (`['Meta', 'K']`) where listing modifiers reads clearer than a
+     * pre-joined string. Throws on an empty array.
+     */
+    async pressKeys(keys: string[]): Promise<void> {
+        if (keys.length === 0) {
+            throw new Error('pressKeys(keys) requires at least one key');
+        }
+        await this.page.keyboard.press(keys.join('+'));
+    }
+
+    /**
+     * Dispatches a synthetic DOM event on the element, optionally with an
+     * `eventInit` payload (e.g. `{ key: 'Enter' }`). Goes through the locator so
+     * it auto-waits for the element; unlike a real click/keypress it does NOT
+     * require actionability — use it to drive handlers directly (custom events,
+     * `input`/`change` on widgets that swallow synthetic typing).
+     */
+    async dispatchEvent(element: WebElement, type: string, eventInit?: Record<string, unknown>): Promise<void> {
+        await this.softProbe(element, 'attached');
+        await element.locator.dispatchEvent(type, eventInit);
+    }
+
     async clearInput(element: WebElement): Promise<void> {
         await this.softProbe(element, 'visible');
         await element.clear({ timeout: this.ELEMENT_TIMEOUT });

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -572,6 +572,11 @@ export class Steps {
      * @param keys - The keys to press together, e.g. `['Meta', 'K']` or `['Control', 'Shift', 'P']`.
      */
     async pressKeys(keys: string[]): Promise<void> {
+        // Enforce the contract before logging so an empty chord never produces a
+        // misleading `Pressing keys: ""` line ahead of the throw.
+        if (keys.length === 0) {
+            throw new Error('pressKeys(keys) requires at least one key');
+        }
         log.interact('Pressing keys: "%s"', keys.join('+'));
         await this.interact.pressKeys(keys);
     }

--- a/src/steps/CommonSteps.ts
+++ b/src/steps/CommonSteps.ts
@@ -566,6 +566,41 @@ export class Steps {
     }
 
     /**
+     * Presses a multi-key chord at the page level. Parts are joined with `+`, so
+     * `['Control', 'A']` presses `Control+A`. The intent-revealing companion to
+     * {@link pressKey} for shortcuts where listing the modifiers reads clearer.
+     * @param keys - The keys to press together, e.g. `['Meta', 'K']` or `['Control', 'Shift', 'P']`.
+     */
+    async pressKeys(keys: string[]): Promise<void> {
+        log.interact('Pressing keys: "%s"', keys.join('+'));
+        await this.interact.pressKeys(keys);
+    }
+
+    /**
+     * Dispatches a synthetic DOM event on a named element, optionally with an
+     * `eventInit` payload. Drives event handlers directly WITHOUT actionability
+     * checks — reach for it only when a real interaction can't express the case
+     * (custom events, firing `input`/`change` on a widget that swallows
+     * synthetic typing). Prefer `click` / `fill` / `pressKey` for real user input.
+     * @param elementName - The element name as defined under the given page.
+     * @param pageName - The page name as defined in `page-repository.json`.
+     * @param type - The DOM event type, e.g. `'click'`, `'input'`, `'focus'`.
+     * @param eventInit - Optional event properties, e.g. `{ key: 'Enter', bubbles: true }`.
+     * @param options - Optional step options for element resolution.
+     */
+    async dispatchEvent(
+        elementName: string,
+        pageName: string,
+        type: string,
+        eventInit?: Record<string, unknown>,
+        options?: StepOptions,
+    ): Promise<void> {
+        log.interact('Dispatching "%s" event on "%s" in "%s"', type, elementName, pageName);
+        const element = await this.getWebElement(elementName, pageName, options);
+        await this.interact.dispatchEvent(element, type, eventInit);
+    }
+
+    /**
      * Types text into an input field one character at a time with a delay between keystrokes.
      * @param elementName - The element name as defined under the given page.
      * @param pageName - The page name as defined in `page-repository.json`.
@@ -680,6 +715,25 @@ export class Steps {
         log.extract('Getting CSS "%s" from "%s" in "%s"', property, elementName, pageName);
         const element = await this.getWebElement(elementName, pageName, options);
         return await this.extract.getCssProperty(element, property);
+    }
+
+    /**
+     * Returns the element's bounding box (`{ x, y, width, height }` in CSS
+     * pixels, relative to the main frame) or `null` when it is not rendered.
+     * Use for geometry the DOM doesn't surface: overlap, off-screen placement,
+     * collapsed (`0×0`) regions.
+     * @param elementName - The element name as defined under the given page.
+     * @param pageName - The page name as defined in `page-repository.json`.
+     * @param options - Optional step options for element resolution.
+     */
+    async getBoundingBox(
+        elementName: string,
+        pageName: string,
+        options?: StepOptions,
+    ): Promise<{ x: number; y: number; width: number; height: number } | null> {
+        log.extract('Getting bounding box of "%s" in "%s"', elementName, pageName);
+        const element = await this.getWebElement(elementName, pageName, options);
+        return await this.extract.getBoundingBox(element);
     }
 
     /**
@@ -1480,6 +1534,44 @@ export class Steps {
     async waitForNetworkIdle(options?: WaitForNetworkIdleOptions): Promise<void> {
         log.wait('Waiting for network idle');
         await this.navigate.waitForNetworkIdle(options);
+    }
+
+    /**
+     * Deliberate pause for `ms` milliseconds. Named `pace` — NOT `wait` — to
+     * signal intentional timing control (settling a debounce, spacing
+     * rapid-fire actions), never a substitute for a wait-for-state. Whenever you
+     * are actually waiting for the app to reach a condition, prefer
+     * {@link waitForState}, {@link waitForUrl}, or a web-first assertion.
+     * @param ms - Pause duration in milliseconds (non-negative).
+     */
+    async pace(ms: number): Promise<void> {
+        log.wait('Pacing for %dms', ms);
+        await this.utils.pace(ms);
+    }
+
+    /**
+     * Runs `action` `times` times in sequence, passing the zero-based index, and
+     * returns each result in order. With `intervalMs`, paces BETWEEN iterations
+     * (never before the first or after the last). The intent-revealing form of a
+     * hand-rolled "do X rapidly N times" loop — repeated swatch clicks,
+     * double-submit probes, hammering a flaky toggle.
+     *
+     * @example
+     * ```ts
+     * await steps.repeat(i => steps.on('swatch', 'PDP').nth(i).click(), 3, { intervalMs: 120 });
+     * ```
+     * @param action - Callback run per iteration; receives the zero-based index.
+     * @param times - Number of iterations (non-negative integer).
+     * @param options - Optional `{ intervalMs }` pacing between iterations.
+     * @returns The array of every iteration's resolved result, in order.
+     */
+    async repeat<T>(
+        action: (index: number) => Promise<T> | T,
+        times: number,
+        options?: { intervalMs?: number },
+    ): Promise<T[]> {
+        log.wait('Repeating action %d time(s)%s', times, options?.intervalMs ? ` (every ${options.intervalMs}ms)` : '');
+        return await this.utils.repeat(action, times, options);
     }
 
     /**

--- a/src/utils/ElementUtilities.ts
+++ b/src/utils/ElementUtilities.ts
@@ -99,7 +99,10 @@ export class Utils {
         const results: T[] = [];
         for (let i = 0; i < times; i++) {
             results.push(await fn(i));
-            if (options?.intervalMs && i < times - 1) {
+            // `!== undefined` (not truthiness) so `intervalMs: 0` is honoured as
+            // an intentional zero-pause and `intervalMs: NaN` reaches `pace` and
+            // throws, rather than both being silently skipped.
+            if (options?.intervalMs !== undefined && i < times - 1) {
                 await this.pace(options.intervalMs);
             }
         }

--- a/src/utils/ElementUtilities.ts
+++ b/src/utils/ElementUtilities.ts
@@ -66,6 +66,47 @@ export class Utils {
     }
 
     /**
+     * Deliberate pause for `ms` milliseconds. Named `pace` — NOT `wait` — to
+     * signal intentional timing control (settling a debounce, spacing
+     * rapid-fire actions) rather than a missing wait-for-state. Whenever you are
+     * actually waiting for the app to reach a condition, prefer `waitForState`
+     * or a web-first assertion; reach here only for genuinely time-based pacing.
+     */
+    async pace(ms: number): Promise<void> {
+        if (!Number.isFinite(ms) || ms < 0) {
+            throw new Error(`pace(ms) requires a non-negative, finite duration, got ${ms}`);
+        }
+        await new Promise<void>(resolve => setTimeout(resolve, ms));
+    }
+
+    /**
+     * Runs `fn` `times` times in sequence — passing the zero-based iteration
+     * index — and collects each result. With `intervalMs`, paces BETWEEN
+     * iterations (never before the first or after the last). The
+     * intent-revealing form of a hand-rolled "do X rapidly N times" loop
+     * (repeated swatch clicks, double-submit probes, retrying a flaky toggle).
+     *
+     * @returns the array of every iteration's resolved result, in order.
+     */
+    async repeat<T>(
+        fn: (index: number) => Promise<T> | T,
+        times: number,
+        options?: { intervalMs?: number },
+    ): Promise<T[]> {
+        if (!Number.isInteger(times) || times < 0) {
+            throw new Error(`repeat(fn, times) requires a non-negative integer count, got ${times}`);
+        }
+        const results: T[] = [];
+        for (let i = 0; i < times; i++) {
+            results.push(await fn(i));
+            if (options?.intervalMs && i < times - 1) {
+                await this.pace(options.intervalMs);
+            }
+        }
+        return results;
+    }
+
+    /**
      * Terminal handling for a timed-out wait: soft (warn + `false`) when the
      * wait was optional, an error carrying the original cause otherwise.
      */

--- a/tests/timing-dispatch-keys-steps.spec.ts
+++ b/tests/timing-dispatch-keys-steps.spec.ts
@@ -43,10 +43,19 @@ test.describe('Timing family — pace / repeat', () => {
     });
 
     test('repeat with intervalMs paces BETWEEN iterations (not after the last)', async ({ steps }) => {
-        const start = Date.now();
-        await steps.repeat(() => undefined, 3, { intervalMs: 100 });
-        // 3 iterations → 2 gaps of ~100ms. Lower-bound the two gaps only.
-        expect(Date.now() - start).toBeGreaterThanOrEqual(180);
+        // Stamp each iteration so we can assert the gaps directly rather than
+        // just lower-bounding the total — which alone could not catch an extra
+        // pace tacked on after the final iteration.
+        const stamps: number[] = [];
+        await steps.repeat(() => { stamps.push(Date.now()); }, 3, { intervalMs: 100 });
+        const end = Date.now();
+        expect(stamps).toHaveLength(3);
+        // Two ~100ms gaps BETWEEN the three iterations (lower-bounded for CI jitter).
+        expect(stamps[1] - stamps[0]).toBeGreaterThanOrEqual(90);
+        expect(stamps[2] - stamps[1]).toBeGreaterThanOrEqual(90);
+        // No trailing pace: repeat returns promptly after the last iteration —
+        // well under one interval, which an extra `pace(100)` would blow past.
+        expect(end - stamps[2]).toBeLessThan(80);
     });
 
     test('repeat drives a real action N times — counter reflects the count', async ({ steps }) => {

--- a/tests/timing-dispatch-keys-steps.spec.ts
+++ b/tests/timing-dispatch-keys-steps.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from './fixture/StepFixture';
+
+/**
+ * Phase-3 coverage for the complementary-steps RFC — the timing + dispatch/keys
+ * surface a consumer suite (Mr Marvis e2e) previously dropped to raw Playwright
+ * `page.*` for:
+ *
+ *   A) Timing family — `steps.pace(ms)` (deliberate, semantic pause) and
+ *      `steps.repeat(fn, times, { intervalMs })` (intent-revealing "do X N times").
+ *   B) Dispatch / keys / geometry — `steps.dispatchEvent`, `steps.pressKeys`,
+ *      `steps.getBoundingBox`.
+ *
+ * Assertions are CONTRACT-level and app-agnostic: counter deltas we drive
+ * ourselves, loose timing lower-bounds (never an upper bound — CI is noisy),
+ * and geometry contracts (a rendered button has positive size; a missing
+ * element has no box).
+ */
+
+test.describe('Timing family — pace / repeat', () => {
+    test('pace resolves after roughly the requested delay', async ({ steps }) => {
+        const start = Date.now();
+        await steps.pace(150);
+        // Loose lower bound only — timers can fire a hair early, CI never early
+        // by much; an upper bound would be flaky.
+        expect(Date.now() - start).toBeGreaterThanOrEqual(120);
+    });
+
+    test('pace(0) resolves immediately; a negative duration throws', async ({ steps }) => {
+        await steps.pace(0); // no throw
+        await expect(steps.pace(-1)).rejects.toThrow(/non-negative/i);
+    });
+
+    test('repeat runs N times, passing the zero-based index, and collects results', async ({ steps }) => {
+        const seen: number[] = [];
+        const results = await steps.repeat((i) => { seen.push(i); return i * 2; }, 3);
+        expect(seen).toEqual([0, 1, 2]);
+        expect(results).toEqual([0, 2, 4]);
+    });
+
+    test('repeat(fn, 0) is a no-op returning []; a non-integer count throws', async ({ steps }) => {
+        expect(await steps.repeat(() => 1, 0)).toEqual([]);
+        await expect(steps.repeat(() => 1, 2.5)).rejects.toThrow(/non-negative integer/i);
+    });
+
+    test('repeat with intervalMs paces BETWEEN iterations (not after the last)', async ({ steps }) => {
+        const start = Date.now();
+        await steps.repeat(() => undefined, 3, { intervalMs: 100 });
+        // 3 iterations → 2 gaps of ~100ms. Lower-bound the two gaps only.
+        expect(Date.now() - start).toBeGreaterThanOrEqual(180);
+    });
+
+    test('repeat drives a real action N times — counter reflects the count', async ({ steps }) => {
+        await steps.navigateTo('/pinia-counter');
+        await steps.verifyText('counterValue', 'PiniaCounterPage', '0');
+        await steps.repeat(() => steps.click('incrementButton', 'PiniaCounterPage'), 3, { intervalMs: 50 });
+        await steps.verifyText('counterValue', 'PiniaCounterPage', '3');
+    });
+});
+
+test.describe('Dispatch / keys / geometry', () => {
+    test('dispatchEvent fires a synthetic click that the handler observes', async ({ steps }) => {
+        await steps.navigateTo('/pinia-counter');
+        await steps.verifyText('counterValue', 'PiniaCounterPage', '0');
+        // A dispatched DOM 'click' drives the handler without actionability checks.
+        await steps.dispatchEvent('incrementButton', 'PiniaCounterPage', 'click');
+        await steps.verifyText('counterValue', 'PiniaCounterPage', '1');
+    });
+
+    test('pressKeys joins a chord and drives the focused field; an empty array throws', async ({ steps }) => {
+        await steps.navigateTo('/text-inputs');
+        await steps.click('textInput', 'TextInputsPage'); // focus the empty input
+        // `Shift+A` is a deterministic, OS-independent chord: holding Shift while
+        // pressing A types a capital 'A'. Proves the parts were joined with `+`
+        // and the chord reached the focused field (unlike Control+A select-all,
+        // whose semantics vary by platform).
+        await steps.pressKeys(['Shift', 'A']);
+        expect(await steps.getInputValue('textInput', 'TextInputsPage')).toBe('A');
+        await expect(steps.pressKeys([])).rejects.toThrow(/at least one key/i);
+    });
+
+    test('getBoundingBox returns positive geometry for a rendered element', async ({ steps }) => {
+        await steps.navigateTo('/buttons');
+        const box = await steps.getBoundingBox('primaryButton', 'ButtonsPage');
+        expect(box).not.toBeNull();
+        expect(box!.width).toBeGreaterThan(0);
+        expect(box!.height).toBeGreaterThan(0);
+        expect(typeof box!.x).toBe('number');
+        expect(typeof box!.y).toBe('number');
+    });
+
+    test('getBoundingBox returns null for an element that is not rendered', async ({ steps }) => {
+        await steps.navigateTo('/');
+        // `missingElement` is defined in the repo but never present in the DOM —
+        // the soft attach-probe passes through and boundingBox() resolves null.
+        const box = await steps.getBoundingBox('missingElement', 'HomePage');
+        expect(box).toBeNull();
+    });
+});


### PR DESCRIPTION
## What

Phase 3 (final) of the complementary-steps RFC. Closes the last slice of the raw-`page.*` residual a real consumer suite (Mr Marvis e2e) had to reach for: deliberate timing, synthetic event dispatch, key chords, and element geometry — all named, typed, logged, and repo-resolved.

### Timing family
- **`steps.pace(ms)`** — a deliberate pause, named `pace` (NOT `wait`) to signal intentional timing control rather than a missing wait-for-state. Throws on a negative/non-finite duration. Mirrored on `Utils.pace`.
- **`steps.repeat(action, times, { intervalMs? })`** — runs `action` `times` times in sequence (passing the zero-based index), collects each result, and with `intervalMs` paces BETWEEN iterations (never before the first or after the last). The intent-revealing form of "do X rapidly N times". Throws on a non-negative-integer count. Mirrored on `Utils.repeat`.

### Dispatch / keys / geometry
- **`steps.dispatchEvent(element, page, type, eventInit?)`** — dispatches a synthetic DOM event on a named element WITHOUT actionability checks (custom events, firing `input`/`change` on widgets that swallow synthetic typing). Prefer `click`/`fill`/`pressKey` for real user input. Mirrored on `Interactions.dispatchEvent`.
- **`steps.pressKeys(keys)`** — presses a multi-key chord, joining the parts with `+` (`['Control', 'A']` → `Control+A`); the intent-revealing companion to `pressKey`. Throws on an empty array. Mirrored on `Interactions.pressKeys`.
- **`steps.getBoundingBox(element, page)`** — returns `{ x, y, width, height }` (CSS pixels, main-frame relative) or `null` when not rendered (short-circuits on zero matches rather than blocking on `boundingBox()`'s own auto-wait). Mirrored on `Extractions.getBoundingBox`.

## Why

Computed-style was already covered by the existing `getCssProperty`; this PR adds the remaining residual shapes. Naming follows the RFC: `pace`/`repeat` express deliberate timing (not waits), `dispatchEvent` is the controlled escape for non-actionable handler drives, and `getBoundingBox` surfaces geometry the DOM doesn't otherwise expose.

## Tests

`tests/timing-dispatch-keys-steps.spec.ts` — 10 tests, all green locally against the docker test site:
- `pace` lower-bound timing, `pace(0)`, negative-throws
- `repeat` index/result collection, no-op `times: 0`, non-integer throws, `intervalMs` between-iteration pacing, and a real counter-driving run
- `dispatchEvent` synthetic click observed by the handler
- `pressKeys` deterministic `Shift+A` chord into a focused field, empty-array throws
- `getBoundingBox` positive geometry for a rendered element, `null` for a not-rendered one

All additions are additive — no existing signatures change.