### PR TITLE
chore(release): 0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.3.8 — 2026-07-28
 
 ### Added
 
@@ -106,6 +106,14 @@
     `{ x, y, width, height }` (CSS pixels, main-frame relative) or `null` when it
     is not rendered (short-circuits on zero matches rather than blocking on
     `boundingBox()`'s own auto-wait). Mirrored on `Extractions.getBoundingBox`.
+
+### Security
+
+- Clear the high-severity `npm audit` findings published since 0.3.7: in-range
+  lockfile bump for `linkify-it` (GHSA-v245-v573-v5vm, via `mailparser`), and a
+  scoped override lifting `@civitas-cerebrum/test-coverage`'s `glob` to `^13`,
+  clearing `brace-expansion` GHSA-mh99-v99m-4gvg (which has no in-range fix —
+  every `brace-expansion` ≤ 5.0.7 is affected).
 
 ## 0.3.7 — 2026-06-12
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civitas-cerebrum/element-interactions",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "MIT",
       "dependencies": {
         "@civitas-cerebrum/context-store": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitas-cerebrum/element-interactions",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "A robust, readable interaction and assertion Facade for Playwright. Abstract away boilerplate into semantic, English-like methods, making your test automation framework cleaner, easier to maintain, and accessible to non-developers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Patch release bump to **0.3.8**: `npm version patch` (package.json + lockfile) and the CHANGELOG `## Unreleased` section rolled into `## 0.3.8 — 2026-07-28` — covering the #214 residual-gap additions, all three complementary-steps RFC phases (#215/#216/#217), and a Security note for the audit-hygiene dependency fixes.

After merge, the `0.3.8` tag (repo convention: no `v` prefix) on the release commit triggers the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQtzzhzwM45w14vAExG6T7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQtzzhzwM45w14vAExG6T7)_