### PR TITLE
test(fluent-api): pin byAttribute to the filtered non-first element (regression)

### DIFF
--- a/tests/data/page-repository.json
+++ b/tests/data/page-repository.json
@@ -574,6 +574,12 @@
       "name": "ButtonsPage",
       "elements": [
         {
+          "elementName": "variantButtons",
+          "selector": {
+            "css": "button.btn"
+          }
+        },
+        {
           "elementName": "primaryButton",
           "selector": {
             "css": "[data-testid='btn-primary']"

--- a/tests/fluent-api.spec.ts
+++ b/tests/fluent-api.spec.ts
@@ -45,6 +45,27 @@ test.describe('Fluent API — steps.on()', () => {
       const attr = await steps.on('disabledButton', 'ButtonsPage').byAttribute('disabled', '').getAttribute('disabled');
       expect(attr).toBe('');
     });
+
+    // Regression: the ATTRIBUTE strategy used to fall through the resolver's
+    // strategy switch to the un-filtered `.first()` path, so `byAttribute`
+    // silently resolved the FIRST matching base element and ignored the
+    // filter. These tests use a multi-match base ('variantButtons' matches
+    // every variant button) with a target that is deliberately NOT the first
+    // match — a silent first-match fallback fails both.
+
+    test('.byAttribute() resolves the matching non-first element from a multi-match base', async ({ steps }) => {
+      await steps.navigateTo('/');
+      await steps.click( 'buttonsLink','SidebarNav');
+      const text = await steps.on('variantButtons', 'ButtonsPage').byAttribute('data-testid', 'btn-danger').getText();
+      expect(text).toBe('Danger');
+    });
+
+    test('.byAttribute() click acts on the filtered element, not the first match', async ({ steps }) => {
+      await steps.navigateTo('/');
+      await steps.click( 'buttonsLink','SidebarNav');
+      await steps.on('variantButtons', 'ButtonsPage').byAttribute('data-testid', 'btn-danger').click();
+      await steps.verifyTextContains( 'resultText','ButtonsPage', 'Danger');
+    });
   });
 
   test.describe('Terminal — interactions', () => {


### PR DESCRIPTION
## Summary

Companion to civitas-cerebrum/element-repository#54 (ATTRIBUTE strategy implemented; unhandled strategies now throw).

The existing `byAttribute` tests were **tautological with respect to the filter**: they used single-match bases (`disabledButton`) or filtered for an attribute the first element already carried (`byAttribute('data-testid','btn-primary')` on `primaryButton`). They passed whether or not the filter was applied — which is exactly why the resolver's missing ATTRIBUTE case (silent un-filtered `.first()` on the strategy path) went undetected while a consumer suite depended on it.

## Changes

- **Fixture** (`tests/data/page-repository.json`): adds `variantButtons` to ButtonsPage — a multi-match base (`css: button.btn`) matching every variant button. Called out per the selectors-ship-in-the-PR convention.
- **Tests** (`tests/fluent-api.spec.ts`, strategy-selectors block): two regression tests pinning `byAttribute` to a deliberately **non-first** target (`btn-danger`):
  1. resolved element's text is `Danger` (not the first match `Primary`);
  2. `.click()` acts on the filtered element — asserted through the page's feedback element (`resultText`), causally meaningful per the meaningful-verification rule.

## Verification

- With the fixed element-repository linked locally (`npm i --no-save ../element-repository`, branch of #54): `fluent-api`, `expect-combinatorial`, `core-api`, `steps-api`, `listed-elements`, `enhanced-selectors` — **202 passed**.
- **Negative control** against published element-repository **0.3.2**: both new tests **fail** with `Expected "Danger" / Received "Primary"` — they pin the defect precisely.
- `npm run build` and `npm run typecheck:tests` — clean.
- Local validation note: the docker registry was unreachable on the dev machine, so the run above used a temporary (uncommitted) baseURL override pointing at the hosted copy of the same vue-test-app; CI uses the standard docker-compose environment.

## Dependency

This PR stays red until element-repository#54 merges and releases; the existing `^0.3.1` range then satisfies it on a lockfile refresh — no manifest change needed and no version bump in this PR (release-time versioning).

## Preflight

- Searched existing issues/PRs (open + closed) for "attribute" / "strategy" in both repos — no duplicate.
- Local vs. origin/main: in sync at `6b146a2`.
- `.contribution-handover.json`: not populated — the template and schema were removed from this repo in the 0.3.6 cleanup; guardrail claims are reproduced in this description instead.