### PR TITLE
ci: weekly dependency audit with auto-opened fix PR

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -81,7 +81,13 @@ jobs:
         if: steps.audit.outputs.vulnerable == 'true' && steps.existing.outputs.count == '0'
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Subscription auth (Claude Pro/Max). Generate the token locally with
+          # `claude setup-token` and store the output as a repository secret
+          # named CLAUDE_CODE_OAUTH_TOKEN. It EXPIRES — when it does this step
+          # fails on auth rather than on a vulnerability, and the job goes red
+          # with the audit report still in the summary. Regenerate and re-add
+          # the secret to restore it.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --allowedTools Bash,Read,Edit,Write,Glob,Grep
             --max-turns 40

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,156 @@
+name: 🔒 Weekly Dependency Audit
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+# Needed by the auto-fix step: it pushes a branch and opens a pull request.
+permissions:
+  contents: write
+  pull-requests: write
+
+# One audit at a time. A scheduled run and a manual one landing together would
+# otherwise race to open the same fix branch.
+concurrency:
+  group: audit-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  FIX_BRANCH: chore/auto-audit-fix
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🗂️ Checkout repository
+        uses: actions/checkout@v4
+
+      - name: ⚙️ Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: 🧩 Install dependencies
+        run: npm ci
+
+      # Full audit including devDependencies — PR CI only audits runtime deps.
+      # `continue-on-error` is deliberate: a finding is the TRIGGER for the
+      # auto-fix below, not the end of the job. The real pass/fail verdict is
+      # decided in the final step.
+      - name: 🔒 Vulnerability audit (all deps)
+        id: audit
+        continue-on-error: true
+        run: |
+          set +e
+          npm audit --audit-level=high > audit.txt 2>&1
+          code=$?
+          set -e
+          cat audit.txt
+          if [ $code -ne 0 ]; then
+            echo "vulnerable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "vulnerable=false" >> "$GITHUB_OUTPUT"
+          fi
+          {
+            echo "### 🔒 Dependency audit"
+            echo
+            echo '```'
+            head -c 8000 audit.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Don't stack a new PR on top of one nobody has merged yet. Without this
+      # the schedule opens a near-identical PR every week until someone acts.
+      - name: 🔎 Check for an existing fix PR
+        id: existing
+        if: steps.audit.outputs.vulnerable == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          open=$(gh pr list --state open --head "$FIX_BRANCH" --json number --jq 'length')
+          echo "count=$open" >> "$GITHUB_OUTPUT"
+          if [ "$open" != "0" ]; then
+            echo "An audit fix PR is already open for $FIX_BRANCH — skipping dispatch." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: 🤖 Dispatch Claude Code to fix and open a PR
+        id: fix
+        if: steps.audit.outputs.vulnerable == 'true' && steps.existing.outputs.count == '0'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --allowedTools Bash,Read,Edit,Write,Glob,Grep
+            --max-turns 40
+          prompt: |
+            `npm audit --audit-level=high` is failing on the default branch of
+            this repository. Fix it and open a pull request.
+
+            The failing report is in ./audit.txt at the repo root — read it first.
+
+            HOW TO FIX, in order of preference:
+              1. A lockfile-only bump (`npm audit fix`) when a patched version
+                 exists inside the ranges already declared.
+              2. If the vulnerable package is pinned by an intermediate
+                 dependency so npm cannot reach the patch, add a narrow
+                 `overrides` entry in package.json. Prefer overriding the
+                 package whose OWN fixed release declares the safe range, so
+                 the resulting tree is a combination its maintainer tested.
+              3. If the vulnerable dependency is never imported or executed by
+                 this repo, prefer removing it over silencing it.
+
+            DO NOT run `npm audit fix --force` and do not accept any fix that
+            downgrades a package to an older major version. If the only
+            available remedy is a breaking change, STOP, open no PR, and
+            explain the situation in your final message instead.
+
+            VERIFY before committing — a fix that breaks the build is worse
+            than the advisory:
+              - `npm run build` (if the script exists) must pass
+              - the repo's test script must pass, except for tests that need
+                network or credentials unavailable in CI
+              - `npm audit --audit-level=high` must now be clean
+
+            THEN:
+              - commit to a branch named exactly `chore/auto-audit-fix`
+              - delete audit.txt before committing; it is a scratch file and
+                must not appear in the diff
+              - open a pull request against the default branch explaining which
+                advisory (quote the GHSA id), which dependency path, why you
+                chose that remedy, and exactly what you verified
+              - if you could not verify something, say so plainly in the PR body
+
+            ATTRIBUTION: do not add `Co-Authored-By`, `Claude-Session`,
+            "Generated with Claude Code", or any similar trailer or footer to
+            the commit message or the PR body. Do not name any AI model
+            anywhere in the commit or PR.
+
+      # The honest verdict. Green means either nothing was found, or something
+      # was found AND there is now an open PR to fix it. Red means a finding is
+      # sitting unactioned and needs a human.
+      - name: 📋 Report status
+        if: always()
+        run: |
+          vulnerable="${{ steps.audit.outputs.vulnerable }}"
+          existing="${{ steps.existing.outputs.count }}"
+          dispatched="${{ steps.fix.outcome }}"
+
+          if [ "$vulnerable" != "true" ]; then
+            echo "✅ No high-severity vulnerabilities."
+            exit 0
+          fi
+          # Non-empty AND non-zero: an empty value means the lookup itself did
+          # not run or failed, which must not be read as "a PR already exists".
+          if [ -n "$existing" ] && [ "$existing" != "0" ]; then
+            echo "⚠️ Vulnerabilities found; a fix PR is already open on $FIX_BRANCH."
+            exit 0
+          fi
+          if [ "$dispatched" = "success" ]; then
+            echo "⚠️ Vulnerabilities found; dispatched Claude Code to open a fix PR."
+            exit 0
+          fi
+          echo "❌ Vulnerabilities found and no fix PR was opened — needs a human."
+          exit 1

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -139,6 +139,22 @@ jobs:
             the commit message or the PR body. Do not name any AI model
             anywhere in the commit or PR.
 
+      # A green dispatch step means the action process exited cleanly — NOT that
+      # a pull request exists. Claude may deliberately open nothing (the prompt
+      # tells it to stop rather than accept a breaking change), or fail to push
+      # while still exiting 0. The first live run did exactly that: dispatch
+      # succeeded, no branch and no PR were created, and the job went green with
+      # the advisory untouched. Verify the artifact, never the exit code.
+      - name: 🔎 Confirm a fix PR actually exists
+        id: confirm
+        if: always() && steps.audit.outputs.vulnerable == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          opened=$(gh pr list --state open --head "$FIX_BRANCH" --json number --jq 'length' 2>/dev/null || echo "")
+          echo "count=${opened}" >> "$GITHUB_OUTPUT"
+          echo "Open PRs on $FIX_BRANCH after dispatch: ${opened:-<lookup failed>}"
+
       # The honest verdict. Green means either nothing was found, or something
       # was found AND there is now an open PR to fix it. Red means a finding is
       # sitting unactioned and needs a human.
@@ -147,21 +163,23 @@ jobs:
         run: |
           vulnerable="${{ steps.audit.outputs.vulnerable }}"
           existing="${{ steps.existing.outputs.count }}"
-          dispatched="${{ steps.fix.outcome }}"
+          confirmed="${{ steps.confirm.outputs.count }}"
 
           if [ "$vulnerable" != "true" ]; then
             echo "✅ No high-severity vulnerabilities."
             exit 0
           fi
-          # Non-empty AND non-zero: an empty value means the lookup itself did
-          # not run or failed, which must not be read as "a PR already exists".
+          # Non-empty AND non-zero. An empty value means the lookup did not run
+          # or failed, which must never be read as "a PR exists".
           if [ -n "$existing" ] && [ "$existing" != "0" ]; then
-            echo "⚠️ Vulnerabilities found; a fix PR is already open on $FIX_BRANCH."
+            echo "⚠️ Vulnerabilities found; a fix PR was already open on $FIX_BRANCH."
             exit 0
           fi
-          if [ "$dispatched" = "success" ]; then
-            echo "⚠️ Vulnerabilities found; dispatched Claude Code to open a fix PR."
+          if [ -n "$confirmed" ] && [ "$confirmed" != "0" ]; then
+            echo "⚠️ Vulnerabilities found; a fix PR is now open on $FIX_BRANCH."
             exit 0
           fi
-          echo "❌ Vulnerabilities found and no fix PR was opened — needs a human."
+          echo "❌ Vulnerabilities found and no fix PR exists — needs a human."
+          echo "   (The fixer may have declined deliberately, e.g. the only"
+          echo "    available remedy was a breaking change. Read its log.)"
           exit 1

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,6 +9,11 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # claude-code-action mints a GitHub App token via OIDC to do its repo
+  # work. That is separate from the Anthropic credential and fails the
+  # whole step without this scope:
+  #   "Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable"
+  id-token: write
 
 # One audit at a time. A scheduled run and a manual one landing together would
 # otherwise race to open the same fix branch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -266,12 +266,22 @@
       }
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.2.tgz",
+      "integrity": "sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==",
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+        }
+      ],
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/dom-serializer": {
@@ -366,6 +376,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -403,13 +414,13 @@
       }
     },
     "node_modules/html-to-text": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-10.0.0.tgz",
-      "integrity": "sha512-2OH59Gtprdczel+7Rxgpz9hGVJREaf8Lt1H4kZwWHpEn70VQKRuMNGsb2eDbwaTzrYzb0hheiOG1P7Dim0B4dQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-10.0.1.tgz",
+      "integrity": "sha512-GiVhRI1BatGARSCmlXWNCjDT0cWrwBWoeduLoV0WSKAgaV/wa+hUWy5LiQLUs4UwiUrE52ZCMfBGiKD87TDPrg==",
       "license": "MIT",
       "dependencies": {
         "@selderee/plugin-htmlparser2": "~0.12.0",
-        "deepmerge-ts": "^7.1.5",
+        "deepmerge-ts": "^8.0.1",
         "dom-serializer": "^2.0.0",
         "htmlparser2": "^10.1.0",
         "selderee": "~0.12.0"
@@ -730,6 +741,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
       "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "nodemailer": "^9.0.1",
     "@civitas-cerebrum/test-coverage": {
       "glob": "^13.0.6"
-    }
+    },
+    "html-to-text": "10.0.1"
   }
 }


### PR DESCRIPTION
Adds a scheduled `npm audit --audit-level=high`, and when it finds a high-severity advisory it dispatches `anthropics/claude-code-action@v1` to fix it and open a pull request against `main`.

Rolled out across every published `@civitas-cerebrum` package. This repo had no periodic audit at all.

### Dependency note

Also carries an `html-to-text: 10.0.1` override for GHSA-ggr8-5vv4-36mx (deepmerge-ts stack exhaustion), which reached the runtime path via `@civitas-cerebrum/email-client → mailparser → html-to-text@10.0.0`.

**This override is now redundant** — `mailparser@3.9.16`/`3.9.17` shipped the same day and moved to `html-to-text@10.0.1` upstream; a clean install of `mailparser@^3.9.13` now resolves fixed with no override anywhere. Being an exact pin it would also block a future `10.0.2`. Happy to strip it before merge; it is inert for consumers either way, since npm ignores `overrides` declared by a dependency.

### Why the job is not simply "red on finding"

The audit step is `continue-on-error` on purpose — a finding is the *trigger* for the fix, not the end of the run. Verdict: **green** when nothing was found, or something was found **and** a fix PR demonstrably exists; **red** only when a finding sits unactioned. A permanently red weekly job teaches people to ignore it — sql-client's sat red for four weeks on the same advisory.

### Verdict is decided on the artifact, not the exit code

An earlier version trusted the dispatch step's exit code. A live run then passed every step and reported green while the advisory was untouched and no PR existed — a clean exit only means the process ended, not that anything was produced. A dedicated step now re-queries for an open PR on `chore/auto-audit-fix` after dispatch, and green requires that PR to exist.

### Guards

- a concurrency group, so a scheduled and a manual run cannot race the same branch
- an open-PR lookup, so an unmerged fix PR is not re-opened every week
- an **empty** lookup result is treated as "no PR", never "a PR exists"

### The prompt constrains the fix

Ordered preference: lockfile-only bump → narrow `overrides` entry → remove a dependency that is never executed. `npm audit fix --force` and major-version downgrades are forbidden.

### Auth

Org-level `CLAUDE_CODE_OAUTH_TOKEN`. `id-token: write` is required — the action mints a GitHub App token via OIDC, separate from the Anthropic credential; its absence failed the first live run in 18 seconds.

### Verification

Build clean, test typecheck clean, `npm audit` reports 0 vulnerabilities. Workflow YAML parsed; verdict truth table checked across six scenarios; auth and dispatch confirmed against a live run on context-store.

---
_Generated by [Claude Code](https://claude.ai/code/session_0152sRirQk7jzSd76CVXUx8t)_